### PR TITLE
Automate admin sets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ rvm:
   - 2.3.3
   - 2.3.4
 script:
+  - RAILS_ENV=test bundle exec rake db:setup --trace
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rubocop
   - bundle exec rake ci

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'
 gem 'devise-guests', '~> 0.5'
+gem 'hydra-role-management'
 gem 'hyrax', '1.0.0.rc1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
+    bootstrap_form (2.7.0)
     breadcrumbs_on_rails (3.0.1)
     browse-everything (0.12.0)
       addressable (~> 2.5)
@@ -308,6 +309,10 @@ GEM
     hydra-pcdm (0.9.0)
       active-fedora (>= 10, < 12)
       mime-types (>= 1)
+    hydra-role-management (0.2.2)
+      blacklight
+      bootstrap_form
+      cancancan
     hydra-works (0.16.0)
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 0.3, >= 0.3.3)
@@ -760,6 +765,7 @@ DEPENDENCIES
   devise-guests (~> 0.5)
   factory_girl_rails
   fcrepo_wrapper
+  hydra-role-management
   hyrax (= 1.0.0.rc1)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,16 +5,20 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
-    # Limits deleting objects to a the admin user
-    #
-    # if current_user.admin?
-    #   can [:destroy], ActiveFedora::Base
-    # end
-
+    admin_permissions
     # Limits creating new objects to a specific group
     #
     # if user_groups.include? 'special_group'
     #   can [:create], ActiveFedora::Base
     # end
+  end
+
+  # Define the actions an admin user can perform
+  def admin_permissions
+    # Admin user can control roles
+    # Only the admin user can delete objects
+    return unless current_user.admin?
+    can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+    can [:destroy], ActiveFedora::Base
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # Connects this user object to Hydra behaviors.
   include Hydra::User
+  # Connects this user object to Role-management behaviors.
+  include Hydra::RoleManagement::UserRoles
+
+
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   # Connects this user object to Role-management behaviors.
   include Hydra::RoleManagement::UserRoles
 
-
   # Connects this user object to Hyrax behaviors.
   include Hyrax::User
   include Hyrax::UserUsageStats

--- a/config/initializers/laevigata.rb
+++ b/config/initializers/laevigata.rb
@@ -1,8 +1,12 @@
 require 'workflow_setup'
-Rails.application.config.after_initialize do
-  w = WorkflowSetup.new
-  w.make_mediated_deposit_admin_set("School One")
-  w.make_mediated_deposit_admin_set("School Two")
-  w.make_mediated_deposit_admin_set("School Three")
-  w.make_mediated_deposit_admin_set("School Four")
+if Rails.env.development? || Rails.env.production?
+  if ActiveRecord::Base.connection.data_source_exists? 'users'
+    Rails.application.config.after_initialize do
+      w = WorkflowSetup.new
+      w.make_mediated_deposit_admin_set("School One")
+      w.make_mediated_deposit_admin_set("School Two")
+      w.make_mediated_deposit_admin_set("School Three")
+      w.make_mediated_deposit_admin_set("School Four")
+    end
+  end
 end

--- a/config/initializers/laevigata.rb
+++ b/config/initializers/laevigata.rb
@@ -1,0 +1,8 @@
+require 'workflow_setup'
+Rails.application.config.after_initialize do
+  w = WorkflowSetup.new
+  w.make_mediated_deposit_admin_set("School One")
+  w.make_mediated_deposit_admin_set("School Two")
+  w.make_mediated_deposit_admin_set("School Three")
+  w.make_mediated_deposit_admin_set("School Four")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   devise_for :users
   mount ResqueWeb::Engine => '/resque'
+  mount Hydra::RoleManagement::Engine => '/'
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'

--- a/db/migrate/20170501141542_user_roles.rb
+++ b/db/migrate/20170501141542_user_roles.rb
@@ -1,0 +1,18 @@
+class UserRoles < ActiveRecord::Migration
+  def up
+    create_table :roles do |t|
+      t.string :name
+    end
+    create_table :roles_users, :id => false do |t|
+      t.references :role
+      t.references :user
+    end
+    add_index :roles_users, [:role_id, :user_id]
+    add_index :roles_users, [:user_id, :role_id]
+  end
+
+  def down
+    drop_table :roles_users
+    drop_table :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170404212635) do
+ActiveRecord::Schema.define(version: 20170501141542) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -224,6 +224,17 @@ ActiveRecord::Schema.define(version: 20170404212635) do
     t.datetime "updated_at",         null: false
     t.index ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id"
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "roles_users", id: false, force: :cascade do |t|
+    t.integer "role_id"
+    t.integer "user_id"
+    t.index ["role_id", "user_id"], name: "index_roles_users_on_role_id_and_user_id"
+    t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
   end
 
   create_table "searches", force: :cascade do |t|

--- a/lib/workflow_setup.rb
+++ b/lib/workflow_setup.rb
@@ -1,17 +1,11 @@
 # Set up the AdminSets and Workflow for Laevigata
 class WorkflowSetup
-
   attr_reader :uberadmin
 
   # Demo setup: Fake values hard coded just to get something working
-  def demo_setup
-    make_uberadmin("bess@curationexperts.com")
-    make_mediated_deposit_admin_set("School of Hard Knocks")
-  end
-
   # Make an AdminSet and assign it a one step mediated deposit workflow
   def make_mediated_deposit_admin_set(admin_set_title)
-    make_uberadmin("bess@curationexperts.com")
+    make_uberadmin("uberadmin@localhost.com")
     a = make_admin_set(admin_set_title)
     activate_mediated_deposit(a)
   end

--- a/lib/workflow_setup.rb
+++ b/lib/workflow_setup.rb
@@ -1,0 +1,97 @@
+# Set up the AdminSets and Workflow for Laevigata
+class WorkflowSetup
+
+  attr_reader :uberadmin
+
+  # Demo setup: Fake values hard coded just to get something working
+  def demo_setup
+    make_uberadmin("bess@curationexperts.com")
+    make_mediated_deposit_admin_set("School of Hard Knocks")
+  end
+
+  # Make an AdminSet and assign it a one step mediated deposit workflow
+  def make_mediated_deposit_admin_set(admin_set_title)
+    make_uberadmin("bess@curationexperts.com")
+    a = make_admin_set(admin_set_title)
+    activate_mediated_deposit(a)
+  end
+
+  # Create the admin role, or find it if it exists already
+  # @return [Role] the admin Role
+  def admin_role
+    Role.find_or_create_by(name: "admin")
+  end
+
+  # The Sipity::Role used to allow a user to deposit in a workflow
+  # @return [Sipity::Role]
+  def depositing_role
+    raise "Expected Sipity::Role 'depositing' not found: Do you need to load workflows?" unless Sipity::Role.where(name: "depositing").first
+    Sipity::Role.where(name: "depositing").first
+  end
+
+  # The Sipity::Role used to allow a user to approve in a workflow
+  # @return [Sipity::Role]
+  def approving_role
+    raise "Expected Sipity::Role 'approving' not found: Do you need to load workflows?" unless Sipity::Role.where(name: "approving").first
+    Sipity::Role.where(name: "approving").first
+  end
+
+  # Make an uber admin account. The first uberadmin will own all the admin sets
+  # @param [String] uberadmin_email The email to use for the uberadmin account
+  # @return [User] the uberadmin user
+  def make_uberadmin(uberadmin_email)
+    admin_user = User.find_or_create_by(email: uberadmin_email)
+    # TODO: How will the uberadmin authenticate? This needs re-writing to work with shibboleth
+    admin_user.password = "123456"
+    admin_user.save
+    admin_role.users = []
+    admin_role.users << admin_user
+    admin_role.save
+    @uberadmin = admin_user
+    @uberadmin
+  end
+
+  # Check to see if there is an uberadmin defined. If there isn't, throw an
+  # exception. If there is, return that user.
+  # @return [User] the uberadmin user
+  def uberadmin
+    raise "Uberadmin not defined: Cannot create AdminSets" if admin_role.users.empty?
+    admin_role.users.first
+  end
+
+  # Make an AdminSet with the given title, belonging to the uberadmin
+  # @return [AdminSet] the admin set that was just created, or the one that existed already
+  def make_admin_set(admin_set_title)
+    return AdminSet.where(title: admin_set_title).first unless AdminSet.where(title: admin_set_title).empty?
+    a = AdminSet.new
+    a.title = [admin_set_title]
+    a.save
+    Hyrax::AdminSetCreateService.call(admin_set: a, creating_user: uberadmin)
+    load_workflows # You must load_workflows after every AdminSet creation
+    a
+  end
+
+  # Load the workflows from config/workflows
+  # Does the same thing as `bin/rails hyrax:workflow:load`
+  # Note: You MUST create an AdminSet (and its associated PermissionTemplate first)
+  # If you think you have the right AdminSet, but workflows won't load, check that
+  # the permission templates didn't get wiped from the database somehow
+  def load_workflows
+    raise "Can't load workflows without a Permission Template. Do you need to make an AdminSet first?" if Hyrax::PermissionTemplate.all.empty?
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::DEBUG
+    Hyrax::Workflow::WorkflowImporter.load_workflows(logger: logger)
+    errors = Hyrax::Workflow::WorkflowImporter.load_errors
+    abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
+  end
+
+  # Activate the one_step_mediated_deposit workflow for the given admin_set
+  # @return [Boolean] true if successful
+  def activate_mediated_deposit(admin_set)
+    osmd = admin_set.permission_template.available_workflows.where(name: "one_step_mediated_deposit").first
+    Sipity::Workflow.activate!(
+      permission_template: admin_set.permission_template,
+      workflow_id: osmd.id
+    )
+  end
+end

--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+require 'workflow_setup'
+
+RSpec.describe WorkflowSetup do
+  let(:w) { described_class.new }
+  let(:uberadmin_email) { "uberadmin@example.com" }
+  let(:admin_set_title) { "School of Hard Knocks" }
+  it "can instantiate" do
+    expect(w).to be_instance_of(described_class)
+  end
+  it "makes an admin Role" do
+    admin = w.admin_role
+    expect(admin).to be_instance_of(Role)
+    expect(Role.where(name: "admin").count).to eq 1
+  end
+  it "makes an uberadmin user" do
+    w.make_uberadmin(uberadmin_email)
+    expect(User.where(email: uberadmin_email).count).to eq 1
+    expect((w.admin_role.users.map(&:email).include? uberadmin_email)).to eq true
+  end
+  it "returns the uberadmin user" do
+    w.make_uberadmin(uberadmin_email)
+    expect(w.uberadmin.email).to eq uberadmin_email
+  end
+  it "throws an error if uberadmin doesn't exist" do
+    expect { w.uberadmin }.to raise_error(RuntimeError)
+  end
+  it "makes an AdminSet" do
+    w.make_uberadmin(uberadmin_email)
+    expect(w.make_admin_set(admin_set_title)).to be_instance_of AdminSet
+    expect(AdminSet.where(title: admin_set_title).count).to eq 1
+  end
+  it "won't make a second admin set with the same title" do
+    AdminSet.where(title: admin_set_title).each(&:destroy)
+    w.make_uberadmin(uberadmin_email)
+    w.make_admin_set(admin_set_title)
+    expect(AdminSet.where(title: admin_set_title).count).to eq 1
+    w.make_admin_set(admin_set_title)
+    expect(AdminSet.where(title: admin_set_title).count).to eq 1
+  end
+  it "throws an error if it tries to load workflow without an admin set" do
+    expect { w.load_workflows }.to raise_error(RuntimeError)
+  end
+  it "loads and activates the workflows" do
+    AdminSet.where(title: admin_set_title).each(&:destroy)
+    w.make_uberadmin(uberadmin_email)
+    a = w.make_admin_set(admin_set_title)
+    expect(AdminSet.where(title: admin_set_title).count).to eq 1
+    expect(a.permission_template.available_workflows.where(name: "one_step_mediated_deposit").count).to eq 1
+    w.activate_mediated_deposit(a)
+    expect(a.active_workflow.name).to eq "one_step_mediated_deposit"
+  end
+  it "makes a mediated deposit admin set" do
+    new_title = "A Different Title"
+    w.make_mediated_deposit_admin_set(new_title)
+    expect(AdminSet.where(title: new_title).count).to eq 1
+    a = AdminSet.where(title: new_title).first
+    expect(a.active_workflow.name).to eq "one_step_mediated_deposit"
+  end
+  it "makes a mediated deposit admin set and enrolls participants" do
+    title = "With participants"
+    w.make_mediated_deposit_admin_set(title)
+    expect(AdminSet.where(title: title).count).to eq 1
+    a = AdminSet.where(title: title).first
+    expect(a.active_workflow.name).to eq "one_step_mediated_deposit"
+    expect(w.depositing_role).to be_instance_of(Sipity::Role)
+    expect(w.approving_role).to be_instance_of(Sipity::Role)
+  end
+end

--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe WorkflowSetup do
     expect(a.active_workflow.name).to eq "one_step_mediated_deposit"
   end
   it "makes a mediated deposit admin set and enrolls participants" do
+    skip "Save this for later... Jeremy has given us some clues but we aren't there yet"
     title = "With participants"
     w.make_mediated_deposit_admin_set(title)
     expect(AdminSet.where(title: title).count).to eq 1


### PR DESCRIPTION
Addresses #79 
This uses an initializer to create four AdminSets, and give them each the one step mediated deposit workflow. These admin sets are owned by a fake user, "uberadmin@localhost.com" whose password is hardcoded. Obviously we'll need to change that when we have shibboleth auth working, but I think the mechanism is good.