### PR TITLE
make title and creator single valued in edit form

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -2,10 +2,12 @@
 #  `rails generate hyrax:work Etd`
 module Hyrax
   class EtdForm < Hyrax::Forms::WorkForm
+    include SingleValuedForm
     self.model_class = ::Etd
     self.terms += [:resource_type]
     self.terms += [:department]
     self.terms += [:school]
     self.terms += [:degree]
+    self.single_valued_fields = [:title, :creator]
   end
 end

--- a/app/forms/single_valued_form.rb
+++ b/app/forms/single_valued_form.rb
@@ -1,0 +1,45 @@
+module SingleValuedForm
+  extend ActiveSupport::Concern
+  included do
+    class_attribute :single_valued_fields
+    self.single_valued_fields = []
+
+    def multiple?(field)
+      if single_valued_fields.include?(field.to_sym)
+        false
+      else
+        super
+      end
+    end
+
+    def [](key)
+      return Array(super).first if single_valued_fields.include?(key.to_sym)
+      super
+    end
+
+    def initialize_field(key)
+      return if single_valued_fields.include?(key.to_sym)
+      super
+    end
+  end
+
+  class_methods do
+    def multiple?(field)
+      if single_valued_fields.include?(field.to_sym)
+        false
+      else
+        super
+      end
+    end
+
+    def model_attributes(form_params)
+      super.tap do |params|
+        single_valued_fields.each do |field|
+          if params.key?(field) || params.key?(field.to_s)
+            params[field.to_s] = Array.wrap(params[field.to_s])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -14,6 +14,10 @@ RSpec.feature 'Create a Etd' do
       visit(root_url)
       click_link("Share Your Work")
       expect(current_url).to start_with new_hyrax_etd_url
+      expect(page).to have_css('input#etd_title.required')
+      expect(page).not_to have_css('input#etd_title.multi_value')
+      expect(page).to have_css('input#etd_creator.required')
+      expect(page).not_to have_css('input#etd_creator.multi_value')
       fill_in 'Title', with: 'China and its Minority Population'
       fill_in 'Creator', with: 'Eun, Dongwon'
       fill_in 'Keyword', with: 'China'


### PR DESCRIPTION
Use single_valued_form solution from escowles to make title and creator single valued in ETD edit form. This will likely be incorporated into Hyrax 2.x.

Closes #160 