### PR TITLE
Adding degree_granting_institution to ETD metadata

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -7,13 +7,24 @@ class Etd < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
   self.human_readable_type = 'Etd'
-  property :school, predicate: "http://vivoweb.org/ontology/core#School" do |index|
+
+  after_initialize :set_defaults, unless: :persisted?
+
+  def set_defaults
+    self.degree_granting_institution = "http://id.loc.gov/vocabulary/organizations/geu"
+  end
+
+  property :degree, predicate: "http://vivoweb.org/ontology/core#AcademicDegree" do |index|
     index.as :stored_searchable, :facetable
   end
+
+  # should always be Emory University (http://id.loc.gov/vocabulary/organizations/geu)
+  property :degree_granting_institution, predicate: "http://id.loc.gov/vocabulary/relators/dgg", multiple: false
+
   property :department, predicate: "http://vivoweb.org/ontology/core#AcademicDepartment" do |index|
     index.as :stored_searchable, :facetable
   end
-  property :degree, predicate: "http://vivoweb.org/ontology/core#AcademicDegree" do |index|
+  property :school, predicate: "http://vivoweb.org/ontology/core#School" do |index|
     index.as :stored_searchable, :facetable
   end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -51,4 +51,12 @@ RSpec.describe Etd do
       its(:school) { is_expected.to eq([school]) }
     end
   end
+
+  # An ETD should always have a hidden metadata field saying that the degree_granting_institution is Emory
+  describe "#degree_granting_institution" do
+    subject { described_class.new }
+    context "with a new ETD" do
+      its(:degree_granting_institution) { is_expected.to eq "http://id.loc.gov/vocabulary/organizations/geu" }
+    end
+  end
 end


### PR DESCRIPTION
ETDs should always have a degree_granting_institution field and it should always be set to Emory University. This isn't displayed in a UI, just recorded on the object. When a new ETD object is initialized, set this as a default value. 

Also, put the fields in etd.rb in alphabetical order so they will be easier to read as we get more of them.