### PR TITLE
mounts browse-everything route, adds sample config

### DIFF
--- a/config/browse_everything_providers.yml.sample
+++ b/config/browse_everything_providers.yml.sample
@@ -1,0 +1,28 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+---
+# file_system:
+#   :home: /<location for server file drop>
+# 
+## dropbox:
+## as of May 2017 browse-everything does not work with the DropBox API
+##   :app_key: YOUR_DROPBOX_APP_KEY
+##   :app_secret: YOUR_DROPBOX_APP_SECRET
+# box:
+#   :client_id: YOUR_BOX_CLIENT_ID
+#   :client_secret: YOUR_BOX_CLIENT_SECRET
+# google_drive:
+#   :client_id: YOUR_GOOGLE_API_CLIENT_ID
+#   :client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
+# s3:
+#   :bucket: YOUR_AWS_S3_BUCKET
+#   :response_type: :signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
+#   :app_key: YOUR_AWS_S3_KEY       # :app_key, :app_secret, and :region can be specified
+#   :app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured
+#   :region: YOUR_AWS_S3_REGION     # defaults.
+#   See https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
+# sky_drive:
+#   :client_id: YOUR_MS_LIVE_CONNECT_CLIENT_ID
+#   :client_secret: YOUR_MS_LIVE_CONNECT_CLIENT_SECRET

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :users
+  mount BrowseEverything::Engine => '/browse'
   mount ResqueWeb::Engine => '/resque'
   mount Hydra::RoleManagement::Engine => '/'
   mount Qa::Engine => '/authorities'


### PR DESCRIPTION
This will get the master branch working with browse-everything. The shared production config is set up already on both sandbox machines. This work should have been included with the shared files change - mea culpa.