### PR TITLE
Improved workflow setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ or cherokee rose is the <a href="https://georgia.gov/georgia-facts-and-symbols">
 1. Run the test suite  
     `bin/rails ci`
 
+## User and workflow setup
+
+Each Emory school has its own AdminSet, which determines the approval process for that
+school, and who can approve deposited ETDs. Running `bin/setup` will create an AdminSet for each school in the schools.yml file, load the appropriate workflow, and set permissions such that any registered user can deposit.
+
+A "superuser" can manage all admin_sets, edit all ETDs, and approve submissions
+everywhere. To create a new superuser, add the user's email address to the `config/emory/superusers.yml` file. Then run `bin/setup` to reload the config. Until we get real authentication running, the password for all superusers is `123456`
+
 # README
 
 This README would normally document whatever steps are necessary to get the

--- a/config/emory/emory_college.yml
+++ b/config/emory/emory_college.yml
@@ -1,0 +1,2 @@
+approvers:
+  ecadmin@emory.edu

--- a/config/emory/superusers.yml
+++ b/config/emory/superusers.yml
@@ -1,0 +1,4 @@
+superusers:
+ - bnash@emory.edu # Bethany Nash
+ - fpici@emory.edu
+ - bess@emory.edu

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,4 @@ require 'workflow_setup'
 # re-create all AdminSets too
 AdminSet.destroy_all
 w = WorkflowSetup.new
-w.schools.each do |school|
-  w.make_mediated_deposit_admin_set(school)
-end
+w.setup

--- a/spec/fixtures/config/emory/superusers.yml
+++ b/spec/fixtures/config/emory/superusers.yml
@@ -1,0 +1,3 @@
+superusers:
+ - bnash@emory.edu # Bethany Nash
+ - fpici@emory.edu

--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 require 'workflow_setup'
+require 'active_fedora/cleaner'
 
 RSpec.describe WorkflowSetup do
   let(:w) { described_class.new }
-  let(:uberadmin_email) { "uberadmin@example.com" }
+  let(:superuser_email) { "superuser@emory.edu" }
   let(:admin_set_title) { "School of Hard Knocks" }
   it "can instantiate" do
     expect(w).to be_instance_of(described_class)
@@ -13,26 +14,35 @@ RSpec.describe WorkflowSetup do
     expect(admin).to be_instance_of(Role)
     expect(Role.where(name: "admin").count).to eq 1
   end
-  it "makes an uberadmin user" do
-    w.make_uberadmin(uberadmin_email)
-    expect(User.where(email: uberadmin_email).count).to eq 1
-    expect((w.admin_role.users.map(&:email).include? uberadmin_email)).to eq true
+  it "makes a superuser" do
+    w.make_superuser(superuser_email)
+    expect(User.where(email: superuser_email).count).to eq 1
+    expect((w.admin_role.users.map(&:email).include? superuser_email)).to eq true
   end
-  it "returns the uberadmin user" do
-    w.make_uberadmin(uberadmin_email)
-    expect(w.uberadmin.email).to eq uberadmin_email
+  it "returns all the superusers" do
+    s = %w[admin1@example.com admin2@example.com admin3@example.com]
+    s.each do |t|
+      w.make_superuser(t)
+    end
+    expect(w.superusers.count).to eq 3
+    expect(w.superusers.pluck(:email).include?(s.first)).to be true
   end
-  it "throws an error if uberadmin doesn't exist" do
-    expect { w.uberadmin }.to raise_error(RuntimeError)
+  it "throws an error if there are no superusers" do
+    expect { w.superusers }.to raise_error(RuntimeError)
+  end
+  it "loads all the superusers from a file" do
+    w.superusers_config = "#{fixture_path}/config/emory/superusers.yml"
+    w.load_superusers
+    expect((w.admin_role.users.map(&:email).include? "bnash@emory.edu")).to eq true
   end
   it "makes an AdminSet" do
-    w.make_uberadmin(uberadmin_email)
+    w.make_superuser(superuser_email)
     expect(w.make_admin_set(admin_set_title)).to be_instance_of AdminSet
     expect(AdminSet.where(title: admin_set_title).count).to eq 1
   end
   it "won't make a second admin set with the same title" do
     AdminSet.where(title: admin_set_title).each(&:destroy)
-    w.make_uberadmin(uberadmin_email)
+    w.make_superuser(superuser_email)
     w.make_admin_set(admin_set_title)
     expect(AdminSet.where(title: admin_set_title).count).to eq 1
     w.make_admin_set(admin_set_title)
@@ -43,7 +53,7 @@ RSpec.describe WorkflowSetup do
   end
   it "loads and activates the workflows" do
     AdminSet.where(title: admin_set_title).each(&:destroy)
-    w.make_uberadmin(uberadmin_email)
+    w.make_superuser(superuser_email)
     a = w.make_admin_set(admin_set_title)
     expect(AdminSet.where(title: admin_set_title).count).to eq 1
     expect(a.permission_template.available_workflows.where(name: "one_step_mediated_deposit").count).to eq 1
@@ -52,6 +62,7 @@ RSpec.describe WorkflowSetup do
   end
   it "makes a mediated deposit admin set" do
     new_title = "A Different Title"
+    w.make_superuser(superuser_email)
     w.make_mediated_deposit_admin_set(new_title)
     expect(AdminSet.where(title: new_title).count).to eq 1
     a = AdminSet.where(title: new_title).first
@@ -70,5 +81,37 @@ RSpec.describe WorkflowSetup do
   it "has an array of all the schools" do
     expect(w.schools.include?("Laney Graduate School")).to eq true
     expect(w.schools.count).to eq 4
+  end
+  it "gives superusers superpowers" do
+    ActiveFedora::Cleaner.clean!
+    w.load_superusers
+    expect(w.superusers.count).to be > 1 # This test won't be meaningful if there is only one superuser
+    admin_set = w.make_mediated_deposit_admin_set("River School")
+    workflow = admin_set.permission_template.available_workflows.where(active: true).first
+    expect(workflow).to be_instance_of Sipity::Workflow
+    approving_role = Sipity::Role.where(name: "approving").first
+    wf_role = Sipity::WorkflowRole.find_by(workflow: workflow, role_id: approving_role)
+    approving_agents = wf_role.workflow_responsibilities.pluck(:agent_id)
+    expect(approving_agents.count).to eq 1 # The only approving user should be the one who created the admin set
+    w.give_superusers_superpowers
+    approving_agents = wf_role.workflow_responsibilities.pluck(:agent_id)
+    expect(approving_agents.count).to eq w.superusers.count # Now all superusers have the approving role
+  end
+  it "allows any registered user to deposit anywhere" do
+    ActiveFedora::Cleaner.clean!
+    w.load_superusers
+    admin_set = w.make_mediated_deposit_admin_set("Frog and Toad")
+    workflow = admin_set.permission_template.available_workflows.where(active: true).first
+    expect(workflow).to be_instance_of Sipity::Workflow
+    depositing_role = Sipity::Role.where(name: "depositing").first
+    wf_role = Sipity::WorkflowRole.find_by(workflow: workflow, role_id: depositing_role)
+    depositing_agents = wf_role.workflow_responsibilities.pluck(:agent_id)
+    expect(depositing_agents.count).to eq 1 # The only depositing user should be the one who created the admin set
+    w.everyone_can_deposit_everywhere
+    depositing_agents = wf_role.workflow_responsibilities.pluck(:agent_id)
+    expect(depositing_agents.count).to eq 2 # Now there are 2 depositing_agents...
+    # and the second depositing agent is a Group consisting of all registered users
+    expect(Sipity::Agent.where(id: depositing_agents.last).first.proxy_for_id).to eq "registered"
+    expect(Sipity::Agent.where(id: depositing_agents.last).first.proxy_for_type).to eq "Hyrax::Group"
   end
 end


### PR DESCRIPTION
 * Load superusers from a config file
 * Call them "superusers" instead of "uberadmin"
 * Give superusers all roles in all workflows
 * Allow any registered user to deposit into any AdminSet

Obviously in real life we won't hard code passwords or check our production config file into a public repo. This is just to give an idea of what the config file might look like and start a conversation about how that might be managed.

Fixes #236 and #237 