### PR TITLE
adding tabbed UI from wireframes

### DIFF
--- a/app/views/hyrax/base/_form_about_me.html.erb
+++ b/app/views/hyrax/base/_form_about_me.html.erb
@@ -1,0 +1,22 @@
+
+        <div class="form-instructions">
+          <p>The more descriptive information you provide the better we can serve your needs.</p>
+        </div>
+        <div class="base-terms">
+          <% f.object.primary_terms.each do |term| %>
+            <%#= render_edit_field_partial(term, f: f) %>
+          <% end %>
+        </div>
+        <%#= link_to t('hyrax.works.form.additional_fields'),
+                    '#extended-terms',
+                    class: 'btn btn-default additional-fields',
+                    data: { toggle: 'collapse' },
+                    role: "button",
+                    'aria-expanded'=> "false",
+                    'aria-controls'=> "extended-terms" %>
+        <div id="extended-terms" class='collapse'>
+          <%#= render 'form_media', f: f %>
+          <% f.object.secondary_terms.each do |term| %>
+            <%#= render_edit_field_partial(term, f: f) %>
+          <% end %>
+        </div>

--- a/app/views/hyrax/base/_form_about_my_etd.html.erb
+++ b/app/views/hyrax/base/_form_about_my_etd.html.erb
@@ -1,0 +1,21 @@
+<div class="form-instructions">
+  <p>About My Thesis or Dissertation</p>
+</div>
+<div class="base-terms">
+  <% f.object.primary_terms.each do |term| %>
+    <%= render_edit_field_partial(term, f: f) %>
+  <% end %>
+</div>
+<%= link_to t('hyrax.works.form.additional_fields'),
+            '#extended-terms',
+            class: 'btn btn-default additional-fields',
+            data: { toggle: 'collapse' },
+            role: "button",
+            'aria-expanded'=> "false",
+            'aria-controls'=> "extended-terms" %>
+  <div id="extended-terms" class='collapse'>
+    <%= render 'form_media', f: f %>
+    <% f.object.secondary_terms.each do |term| %>
+      <%= render_edit_field_partial(term, f: f) %>
+    <% end %>
+</div>

--- a/app/views/hyrax/base/_form_embargoes.html.erb
+++ b/app/views/hyrax/base/_form_embargoes.html.erb
@@ -1,0 +1,4 @@
+
+        <div class="form-instructions">
+          <p>My Embargoes</p>
+        </div>

--- a/app/views/hyrax/base/_form_my_pdf.html.erb
+++ b/app/views/hyrax/base/_form_my_pdf.html.erb
@@ -1,0 +1,55 @@
+<div class="form-instructions">
+  <p>My Primary PDF</p>
+</div>
+
+<div id="fileupload">
+   <!-- Redirect browsers with JavaScript disabled to the origin page -->
+   <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
+   <!-- The table listing the files available for upload/download -->
+   <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
+
+   <h2><%= t('hyrax.base.form_files.local_upload') %></h2>
+   <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+   <div class="row fileupload-buttonbar">
+       <div class="col-xs-7">
+           <!-- The fileinput-button span is used to style the file input field as button -->
+           <span class="btn btn-success fileinput-button">
+               <span class="glyphicon glyphicon-plus"></span>
+               <span>Add files...</span>
+               <input type="file" name="files[]" multiple>
+           </span>
+           <% if browser_supports_directory_upload? %>
+           <!-- The fileinput-button span is used to style the file input field as button -->
+           <span class="btn btn-success fileinput-button">
+               <span class="glyphicon glyphicon-plus"></span>
+               <span>Add folder...</span>
+               <input type="file" name="files[]" multiple directory webkitdirectory>
+           </span>
+           <% end %>
+           <button type="reset" class="btn btn-warning cancel hidden">
+               <span class="glyphicon glyphicon-ban-circle"></span>
+               <span>Cancel upload</span>
+           </button>
+           <!-- The global file processing state -->
+           <span class="fileupload-process"></span>
+       </div>
+       <!-- The global progress state -->
+       <div class="col-xs-5 fileupload-progress fade">
+           <!-- The global progress bar -->
+           <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+               <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+           </div>
+           <!-- The extended global progress state -->
+           <div class="progress-extended">&nbsp;</div>
+       </div>
+   </div>
+   <div class="dropzone">
+     <%= t('hyrax.base.form_files.dropzone') %>
+   </div>
+</div>
+
+<%= render 'hyrax/uploads/js_templates' %>
+<% if Hyrax.config.browse_everything? %>
+<h2><%= t('hyrax.base.form_files.external_upload') %></h2>
+<%= render 'browse_everything', f: f %>
+<% end %>

--- a/app/views/hyrax/base/_form_review.html.erb
+++ b/app/views/hyrax/base/_form_review.html.erb
@@ -1,0 +1,4 @@
+
+        <div class="form-instructions">
+          <p>Review</p>
+        </div>

--- a/app/views/hyrax/base/_form_supplemental_files.html.erb
+++ b/app/views/hyrax/base/_form_supplemental_files.html.erb
@@ -1,0 +1,4 @@
+
+        <div class="form-instructions">
+          <p>My Supplemental Files</p>
+        </div>

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,0 +1,53 @@
+<% # we will yield to content_for for each tab, e.g. :files_tab %>
+<% tabs ||= %w[about_me about_my_etd my_pdf supplemental_files embargoes review] # default tab order %>
+<div class="row">
+  <div class="col-xs-12 col-sm-8" role="main">
+
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" role="tablist">
+      <% tabs.each_with_index do | tab, i | %>
+        <% if i == 0 %>
+          <li role="presentation" class="active">
+        <% else %>
+          <li role="presentation">
+        <% end %>
+            <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+              <i class="fa icon-<%= tab %>"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
+            </a>
+          </li>
+      <% end %>
+
+      <li role="presentation" id="tab-share" class="hidden">
+        <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
+          <i class="fa icon-share"></i> <%= t("hyrax.works.form.tab.share") %>
+        </a>
+      </li>
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <% (tabs - ['share']).each_with_index do | tab, i | %>
+        <% if i == 0 %>
+          <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
+        <% else %>
+          <div role="tabpanel" class="tab-pane" id="<%= tab %>">
+        <% end %>
+          <div class="form-tab-content">
+            <%= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
+            <%= render "form_#{tab}", f: f %>
+          </div>
+        </div>
+      <% end %>
+
+      <div role="tabpanel" class="tab-pane" id="share" data-param-key="<%= f.object.model_name.param_key %>">
+          <div class="form-tab-content">
+            <%= render "form_share", f: f %>
+          </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+    <%= render 'form_progress', f: f %>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -10,3 +10,12 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Emory University</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="https://emory.edu/" class="navbar-link" target="_blank">Emory University</a>.
+    works:
+      form:
+        tab:
+          about_me:      "About Me"
+          about_my_etd:  "About My ETD"
+          my_pdf:        "My PDF"
+          supplemental_files: "My Supplemental Files"
+          embargoes: "My Embargoes"
+          review:         "Review"

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -10,6 +10,18 @@ RSpec.feature 'Create a Etd' do
       login_as user
     end
 
+    scenario "View Etd Tabs" do
+      visit(root_url)
+      click_link("Share Your Work")
+
+      expect(page).to have_selector("[data-toggle='tab']", text: "About Me")
+      expect(page).to have_selector("[data-toggle='tab']", text: "About My ETD")
+      expect(page).to have_selector("[data-toggle='tab']", text: "My PDF")
+      expect(page).to have_selector("[data-toggle='tab']", text: "My Supplemental Files")
+      expect(page).to have_selector("[data-toggle='tab']", text: "My Embargoes")
+      expect(page).to have_selector("[data-toggle='tab']", text: "Review")
+    end
+
     scenario "Submit a basic MS Word Thesis" do
       visit(root_url)
       click_link("Share Your Work")
@@ -18,6 +30,7 @@ RSpec.feature 'Create a Etd' do
       expect(page).not_to have_css('input#etd_title.multi_value')
       expect(page).to have_css('input#etd_creator.required')
       expect(page).not_to have_css('input#etd_creator.multi_value')
+      click_link("About My ETD")
       fill_in 'Title', with: 'China and its Minority Population'
       fill_in 'Creator', with: 'Eun, Dongwon'
       fill_in 'Keyword', with: 'China'
@@ -29,7 +42,7 @@ RSpec.feature 'Create a Etd' do
       select('All rights reserved', from: 'Rights')
       choose('open')
       check('agreement')
-      click_on('Files')
+      click_on('My PDF')
       attach_file('files[]', "#{fixture_path}/emory_7tjfb-FILE")
       click_on('Save')
       expect(page).to have_content 'Your files are being processed'


### PR DESCRIPTION
Adding in the locale file tab settings, and the form partials required to override the default Hyrax form. Added one new create etd feature scenario to confirm the presence of the tabs and altered the existing submission scenario only enough to reflect the new names/link texts. 