### PR TITLE
replacing removed fields (including partnering) from about me form

### DIFF
--- a/app/views/hyrax/base/_form_about_me.html.erb
+++ b/app/views/hyrax/base/_form_about_me.html.erb
@@ -4,10 +4,10 @@
         </div>
         <div class="base-terms">
           <% f.object.primary_terms.each do |term| %>
-            <%#= render_edit_field_partial(term, f: f) %>
+            <%= render_edit_field_partial(term, f: f) %>
           <% end %>
         </div>
-        <%#= link_to t('hyrax.works.form.additional_fields'),
+        <%= link_to t('hyrax.works.form.additional_fields'),
                     '#extended-terms',
                     class: 'btn btn-default additional-fields',
                     data: { toggle: 'collapse' },
@@ -15,8 +15,8 @@
                     'aria-expanded'=> "false",
                     'aria-controls'=> "extended-terms" %>
         <div id="extended-terms" class='collapse'>
-          <%#= render 'form_media', f: f %>
+          <%= render 'form_media', f: f %>
           <% f.object.secondary_terms.each do |term| %>
-            <%#= render_edit_field_partial(term, f: f) %>
+            <%= render_edit_field_partial(term, f: f) %>
           <% end %>
         </div>

--- a/app/views/hyrax/base/_form_about_my_etd.html.erb
+++ b/app/views/hyrax/base/_form_about_my_etd.html.erb
@@ -1,21 +1,3 @@
 <div class="form-instructions">
   <p>About My Thesis or Dissertation</p>
 </div>
-<div class="base-terms">
-  <% f.object.primary_terms.each do |term| %>
-    <%= render_edit_field_partial(term, f: f) %>
-  <% end %>
-</div>
-<%= link_to t('hyrax.works.form.additional_fields'),
-            '#extended-terms',
-            class: 'btn btn-default additional-fields',
-            data: { toggle: 'collapse' },
-            role: "button",
-            'aria-expanded'=> "false",
-            'aria-controls'=> "extended-terms" %>
-  <div id="extended-terms" class='collapse'>
-    <%= render 'form_media', f: f %>
-    <% f.object.secondary_terms.each do |term| %>
-      <%= render_edit_field_partial(term, f: f) %>
-    <% end %>
-</div>


### PR DESCRIPTION
I'm adding form partials to our local project, which will overwrite their originals in the hyrax gem if they exist. This PR fixes the accidental removal of some fields in the about_me partial, and removes content from the about_my_etd partial for the time being.