### PR TITLE
Superusers need to be in the approving role

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_gem:
   bixby: bixby_default.yml
 
+Metrics/AbcSize:
+  Enabled: false
+
 Metrics/BlockLength:
   Enabled: false
 

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Create an Etd' do
       fill_in 'Title', with: "A Good Title"
       fill_in "School", with: "Emory College of Arts and Sciences"
       fill_in "Department", with: "Department of Russian and East Asian Languages and Cultures"
-      select('Alternative Medicine', from: 'Research Field')
+      select('Medicine', from: 'Research Field')
       # select('All rights reserved', from: 'Rights')
       # fill_in 'Keyword', with: 'Surrealism'
       fill_in "Degree", with: "Bachelor of Arts with Honors"

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -72,22 +72,13 @@ RSpec.feature 'Create a Laney ETD' do
       expect(available_workflow_actions.include?("request_changes")).to eq true
       expect(available_workflow_actions.include?("comment_only")).to eq true
 
-      # TODO: second superuser should have all workflow options available. (first superuser gets these by virtue of owning the admin sets)
-      # workflow = AdminSet.where(title: ["Laney Graduate School"]).first.permission_template.available_workflows.where(active: true).first
-      # User.all.each do |user|
-      #   puts "-----"
-      #   puts user.email
-      #   roles = Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: user, workflow: workflow).pluck(:role_id)
-      #   puts roles.map { |r| Sipity::Role.where(id: r).first.name }
-      # end
-      # Check workflow permissions for superuser
-      # available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: w.superusers.last, entity: etd.to_sipity_entity).pluck(:name)
-      # puts w.superusers.last
-      # puts available_workflow_actions.inspect
-      # expect(available_workflow_actions.include?("mark_as_reviewed")).to eq true
-      # expect(available_workflow_actions.include?("approve")).to eq false # it can't be approved until after it has been marked as reviewed
-      # expect(available_workflow_actions.include?("request_changes")).to eq true
-      # expect(available_workflow_actions.include?("comment_only")).to eq true
+      # Last superuser should have all workflow options available. (First superuser gets these by virtue of owning the admin sets.)
+      expect(w.superusers.count).to be > 1 # This test is meaningless if there is only one superuser
+      available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: w.superusers.last, entity: etd.to_sipity_entity).pluck(:name)
+      expect(available_workflow_actions.include?("mark_as_reviewed")).to eq true
+      expect(available_workflow_actions.include?("approve")).to eq false # it can't be approved until after it has been marked as reviewed
+      expect(available_workflow_actions.include?("request_changes")).to eq true
+      expect(available_workflow_actions.include?("comment_only")).to eq true
 
       # The approving user marks the etd as reviewed
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)

--- a/spec/fixtures/config/emory/laney_graduate_school.yml
+++ b/spec/fixtures/config/emory/laney_graduate_school.yml
@@ -3,4 +3,3 @@ workflow:
 approving:
  - laneyadmin@emory.edu
  - laneyadmin2@emory.edu
- 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  let(:user) { FactoryGirl.create(:user) }
+  it "gives you the user's email when you print the user to the screen" do
+    expect(user.to_s).to match(/@example.com/)
+  end
+end


### PR DESCRIPTION
Superusers need to be in the approving role in order to participate in the approval workflow