### PR TITLE
Dark state

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,6 +1,6 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
-version: 6.5.1
+version: 6.6.0
 instance_dir: tmp/solr-development
 collection:
   persist: true

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -14,6 +14,16 @@ class Etd < ActiveFedora::Base
     self.degree_granting_institution = "http://id.loc.gov/vocabulary/organizations/geu"
   end
 
+  def hidden?
+    return false unless hidden
+    true
+  end
+
+  # Boolean
+  property :hidden, predicate: "http://emory.edu/local/hidden", multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   property :degree, predicate: "http://vivoweb.org/ontology/core#AcademicDegree" do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/services/hyrax/workflow/hidden_notification.rb
+++ b/app/services/hyrax/workflow/hidden_notification.rb
@@ -1,0 +1,19 @@
+module Hyrax
+  module Workflow
+    class HiddenNotification < AbstractNotification
+      private
+
+        def subject
+          'Deposit has been hidden'
+        end
+
+        def message
+          "#{title} (#{link_to work_id, document_path}) was hidden by #{user.user_key}  #{comment}"
+        end
+
+        def users_to_notify
+          super << user
+        end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/hide_object.rb
+++ b/app/services/hyrax/workflow/hide_object.rb
@@ -1,0 +1,14 @@
+module Hyrax
+  module Workflow
+    ##
+    # Mark an object hidden. It will never be displayed to the public, only
+    # visible to superusers and school approvers.
+    #
+    # @param target [#state] an instance of a model
+    module HideObject
+      def self.call(target:, **)
+        target.hidden = true
+      end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/unhidden_notification.rb
+++ b/app/services/hyrax/workflow/unhidden_notification.rb
@@ -1,0 +1,19 @@
+module Hyrax
+  module Workflow
+    class UnhiddenNotification < AbstractNotification
+      private
+
+        def subject
+          'Deposit has been unhidden'
+        end
+
+        def message
+          "#{title} (#{link_to work_id, document_path}) was unhidden by #{user.user_key}  #{comment}"
+        end
+
+        def users_to_notify
+          super << user
+        end
+    end
+  end
+end

--- a/app/services/hyrax/workflow/unhide_object.rb
+++ b/app/services/hyrax/workflow/unhide_object.rb
@@ -1,0 +1,13 @@
+module Hyrax
+  module Workflow
+    ##
+    # Remove the hidden flag for an object
+    #
+    # @param target [#state] an instance of a model
+    module UnhideObject
+      def self.call(target:, **)
+        target.hidden = false
+      end
+    end
+  end
+end

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,5 @@
 #config/solr_wrapper_test.yml
-version: 6.5.1
+version: 6.6.0
 port: 8985
 instance_dir: tmp/solr-test
 collection:

--- a/config/workflows/laney_graduate_school.json
+++ b/config/workflows/laney_graduate_school.json
@@ -99,6 +99,36 @@
                             "to": ["approving"]
                         }
                     ]
+                }, {
+                    "name": "hide",
+                    "from_states": [
+                        { "names": ["pending_review", "pending_approval", "approved", "changes_required"], "roles": ["reviewing", "approving"] }
+                    ],
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::HiddenNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                      "Hyrax::Workflow::HideObject"
+                    ]
+                }, {
+                    "name": "unhide",
+                    "from_states": [
+                        { "names": ["pending_review", "pending_approval", "approved", "changes_required"], "roles": ["reviewing", "approving"] }
+                    ],
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::UnhiddenNotification",
+                            "to": ["approving"]
+                        }
+                    ],
+                    "methods": [
+                      "Hyrax::Workflow::UnhideObject"
+                    ]
                 }
             ]
         }

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -122,5 +122,4 @@ RSpec.describe Etd do
       its(:degree_granting_institution) { is_expected.to eq "http://id.loc.gov/vocabulary/organizations/geu" }
     end
   end
-
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -3,6 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe Etd do
+  context "#hidden?" do
+    let(:etd) { FactoryGirl.create(:etd) }
+    context "with a new ETD" do
+      it "is not hidden when it is first created" do
+        expect(etd.hidden?).to eq false
+      end
+      it "can be set to true" do
+        etd.hidden = true
+        expect(etd.hidden?).to eq true
+      end
+    end
+  end
+
   describe "#degree" do
     subject { described_class.new }
     let(:degree) { "Bachelor of Arts with Honors" }
@@ -109,4 +122,5 @@ RSpec.describe Etd do
       its(:degree_granting_institution) { is_expected.to eq "http://id.loc.gov/vocabulary/organizations/geu" }
     end
   end
+
 end


### PR DESCRIPTION
Addresses #291 
I changed my mind on terminology and changed "dark" to "hidden". "Inactive" still feels wrong to me, but I'm happy to hear arguments otherwise. The workflow part of this is working. Next we need to wire up the UI to respect the `hidden?` flag on an object.