### PR TITLE
Add graduation_year field

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -55,6 +55,10 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :graduation_year, predicate: "http://purl.org/dc/terms/issued", multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   property :keyword, predicate: "http://schema.org/keywords" do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -49,6 +49,10 @@ class SolrDocument
     self[Solrizer.solr_name('department')]
   end
 
+  def graduation_year
+    self[Solrizer.solr_name('graduation_year')]
+  end
+
   def school
     self[Solrizer.solr_name('school')]
   end

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -4,6 +4,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
            :committee_members_names,
            :degree,
            :department,
+           :graduation_year,
            :school,
            :subfield,
            :partnering_agency,

--- a/app/views/hyrax/base/_work_title.erb
+++ b/app/views/hyrax/base/_work_title.erb
@@ -6,5 +6,9 @@
     <% end %>
 <% end %>
 <% presenter.creator.each_with_index do |creator, index| %>
-  <h2><%= creator %></h2>
+  <h2><%= creator %>
+    <% if presenter.graduation_year %>
+    (<%= presenter.graduation_year.first %>)
+    <% end %>
+  </h2>
 <% end %>

--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -25,6 +25,7 @@ FactoryGirl.define do
       subfield []
       degree ['MA']
       language ['English']
+      graduation_year "2016"
       abstract { [] << FFaker::Lorem.paragraph }
       table_of_contents { [] << FFaker::Lorem.paragraph }
       committee_chair [
@@ -40,8 +41,6 @@ FactoryGirl.define do
       post_graduation_email ['redacted@example.com']
       # permanent_address ['123 Sesame St, Atlanta, GA 30306, UNITED STATES']
       # pdf ["#{fixture_path}/joey/joey_thesis.pdf"]
-      # abstract ['']
-      # table_of_contents ['']
     end
   end
 end

--- a/spec/features/show_migrated_etd_spec.rb
+++ b/spec/features/show_migrated_etd_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Display an ETD built from migrated content' do
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content etd.title.first
       expect(page).to have_content etd.creator.first
+      expect(page).to have_content etd.graduation_year
       expect(page).to have_content "About this #{etd.submitting_type.first}"
       expect(page).to have_content etd.school.first
       expect(page).to have_content etd.department.first

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe Etd do
     end
   end
 
+  context "graduation_year" do
+    let(:etd) { FactoryGirl.build(:etd) }
+    it "has graduation_year" do
+      etd.graduation_year = "2007"
+      expect(etd.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/issued/)
+      expect(etd.graduation_year).to eq "2007"
+    end
+  end
+
   context "committee_chair" do
     let(:etd) { FactoryGirl.create(:ateer_etd) }
     it "has a committee_chair which is a CommitteeMember object" do


### PR DESCRIPTION
In addition to graduation_date, we need a simple year that can be used by legacy data for display on the show page and used for year based search and facet.

Addresses #166 and #306 