### PR TITLE
Integrate with shibboleth in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'jquery-rails'
 # mail pinned to specific version to address "SMTP INJECTION VIA TO/FROM ADDRESSES" vulnerability
 # See https://gemnasium.com/gems/mail
 gem 'mail', '2.6.6.rc1'
+gem 'omniauth-shibboleth', '~> 1.2', '>= 1.2.1'
 gem 'pg'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashie (3.5.5)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     httmultiparty (0.3.16)
@@ -487,6 +488,11 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-shibboleth (1.2.1)
+      omniauth (>= 1.0.0)
     openseadragon (0.3.3)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
@@ -789,6 +795,7 @@ DEPENDENCIES
   launchy
   listen (~> 3.0.5)
   mail (= 2.6.6.rc1)
+  omniauth-shibboleth (~> 1.2, >= 1.2.1)
   pg
   rails (~> 5.0.2)
   resque-pool!

--- a/app/controllers/omniauth_callback_controller.rb
+++ b/app/controllers/omniauth_callback_controller.rb
@@ -1,0 +1,9 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def shibboleth
+    Rails.logger.debug "OmniauthCallbacksController#shibboleth: request.env['omniauth.auth']: #{request.env['omniauth.auth']}"
+    # had to create the `from_omniauth(auth_hash)` class method on our User model
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+    set_flash_message :notice, :success, kind: "Emory NetID"
+    sign_in_and_redirect @user
+  end
+end

--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -1,0 +1,10 @@
+class SessionsController < Devise::SessionsController
+  def new
+    # Rails.logger.debug "SessionsController#new: request.referer = #{request.referer}"
+    if Rails.env.production?
+      redirect_to user_omniauth_authorize_path(:shibboleth)
+    else
+      super
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,20 @@ class User < ApplicationRecord
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+  # changed from :database_authenticatable, removed :validatable to integrate with Shibboleth
+  devise :database_authenticatable, :omniauthable, :rememberable, :trackable, omniauth_providers: [:shibboleth]
+
+  # When a user authenticates via shibboleth, find their User object or make
+  # a new one. Populate it with data we get from shibboleth.
+  # @param [OmniAuth::AuthHash] auth
+  def self.from_omniauth(auth)
+    Rails.logger.debug "auth = #{auth.inspect}"
+    # Uncomment the debugger above to capture what a shib auth object looks like for testing
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.display_name = auth.info.name
+    end
+  end
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,25 +251,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-
-  # ==> Warden configuration
-  # If you want to use other strategies, that are not supported by Devise, or
-  # change the failure app, you can configure them inside the config.warden block.
-  #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
-
-  # ==> Mountable engine configurations
-  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
-  # is mountable, there are some extra configurations to be taken into account.
-  # The following options are available, assuming the engine is mounted as:
-  #
-  #     mount MyEngine, at: '/my_engine'
-  #
-  # The router that invoked `devise_for`, in the example above, would be:
-  # config.router_name = :my_engine
+  config.omniauth :shibboleth,
+                  uid_field: 'uid',
+                  info_fields: { email: 'mail' },
+                  callback_url: '/users/auth/shibboleth/callback'
   #
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,16 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }
+  # These routes are provided by Devise's database_authenticatable. If we remove
+  # database_authenticatable (as we will need to, eventually) we need to put these back
+  # so omniauth and shibboleth have them.
+  # devise_scope :user do
+  #   get 'sign_in', to: 'devise/sessions#new', as: :new_user_session
+  #   post 'sign_in', to: 'devise/session#create', as: :session
+  #   get 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
+  # end
+
   mount BrowseEverything::Engine => '/browse'
   mount ResqueWeb::Engine => '/resque'
   mount Hydra::RoleManagement::Engine => '/'

--- a/db/migrate/20170613154600_add_omniauth_to_users.rb
+++ b/db/migrate/20170613154600_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170501141542) do
+ActiveRecord::Schema.define(version: 20170613154600) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -483,6 +483,8 @@ ActiveRecord::Schema.define(version: 20170501141542) do
     t.string   "arkivo_subscription"
     t.binary   "zotero_token"
     t.string   "zotero_userid"
+    t.string   "provider"
+    t.string   "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
-    password "12345678"
-    password_confirmation "12345678"
 
     transient do
       # Allow for custom groups when a user is instantiated.

--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe WorkflowSetup do
       # Newly created users should be able to deposit, but nothing else
       depositor = User.new
       depositor.email = "fake#{rand(0..10_000)}@email.com"
-      depositor.password = "123456"
+      # depositor.password = "123456"
       depositor.save
       roles = Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: depositor, workflow: workflow).pluck(:role_id)
       depositor_role_names = roles.map { |r| Sipity::Role.where(id: r).first.name }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,34 @@
 require 'rails_helper'
 
+auth_hash = OmniAuth::AuthHash.new(
+  provider: 'shibboleth',
+  uid: 'brian',
+  info: {
+    email: "brian@beachboys.com",
+    name: "Brian Wilson"
+  }
+)
+
 RSpec.describe User do
-  let(:user) { FactoryGirl.create(:user) }
-  it "gives you the user's email when you print the user to the screen" do
-    expect(user.to_s).to match(/@example.com/)
+  context "shibboleth" do
+    let(:user) { described_class.from_omniauth(auth_hash) }
+    it "has a uid" do
+      expect(user.uid).to eq auth_hash.uid
+    end
+    it "has a shibboleth provided name" do
+      expect(user.display_name).to eq auth_hash.info.name
+    end
+    it "has a shibboleth provided email" do
+      expect(user.email).to eq auth_hash.info.email
+    end
+  end
+  context "signing in twice" do
+    it "finds the original account instead of trying to make a new one" do
+      expect(described_class.count).to eq 0
+      described_class.from_omniauth(auth_hash)
+      expect(described_class.count).to eq 1
+      described_class.from_omniauth(auth_hash)
+      expect(described_class.count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
but keep database authentication for now, while we're still in development.
Create new User objects for anyone who authenticates via Shibboleth and doesn't yet exist in the app.

Closes #332, #333 and #347 