### PR TITLE
Update capfile to match current version of capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 after 'deploy:published', 'laevigata:workflow_setup'
 # config valid only for current version of Capistrano
-lock "3.8.1"
+lock "3.8.2"
 
 set :application, "laevigata"
 set :repo_url, "https://github.com/curationexperts/laevigata.git"


### PR DESCRIPTION
Currently we can't deploy latest code to aws because we get the error "Capfile locked at 3.8.1, but 3.8.2 is loaded." This PR should fix that.