### PR TITLE
Remove logic from _abstract metadata view

### DIFF
--- a/app/views/hyrax/base/_abstract.erb
+++ b/app/views/hyrax/base/_abstract.erb
@@ -1,6 +1,2 @@
 <h2>Abstract</h2>
-<% if presenter.abstract %>
-  <p><%= presenter.abstract_with_embargo_check %></p>
-<% else %>
-  <p>No abstract available</p>
-<% end %>
+<p><%= presenter.abstract_with_embargo_check %></p>


### PR DESCRIPTION
This logic now lives in the presenter, where it can be tested.