### PR TITLE
enable tab saves with etd submits

### DIFF
--- a/app/assets/javascripts/etd_save_work_control.es6
+++ b/app/assets/javascripts/etd_save_work_control.es6
@@ -72,6 +72,12 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
       new VisibilityComponent(this.element.find('.visibility'), this.adminSetWidget)
       this.preventSubmit()
       this.formChanged()
+      this.removePartialDataParamUponSubmit()
+    }
+
+    removePartialDataParamUponSubmit(){
+      this.form.on('submit', (evt) =>
+        $('#partial_data').remove())
     }
 
     preventSubmit() {

--- a/app/views/hyrax/base/_form_about_my_etd.html.erb
+++ b/app/views/hyrax/base/_form_about_my_etd.html.erb
@@ -1,5 +1,5 @@
 <h1><%= t("hyrax.works.form.tab.about_my_etd", type: curation_concern.human_readable_type) %></h1>
-
+<div class="about-my-etd">
   <%= f.input :title, required: false, label: "Title", hint: "",
       input_html: { class: 'form-control' } %>
 
@@ -25,7 +25,7 @@
       3) Does your thesis or dissertation disclose or describe any inventions or discoveries that could potentially have commercial application and therefore may be patented? If so, please contact the Office of Technology Transfer (OTT) at Phone: (404) 727-2211.
       <%= f.input :copyright_question_three, as: :radio_buttons, label: "" %>
     </div>
-
-<input name="about_my_etd_data" value="Save My Etd" class="btn btn-primary" id="about_my_etd_data" type="submit" />
+  </div>
+<input name="about_my_etd_data" value="Save My ETD" class="btn btn-primary" id="about_my_etd_data" type="submit" />
 
 <div id="my-etd-success"></div>

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -21,6 +21,18 @@ RSpec.feature 'Create an Etd' do
       expect(page).to have_selector("[data-toggle='tab']", text: "My Embargoes")
       expect(page).to have_selector("[data-toggle='tab']", text: "Review")
     end
+
+    scenario "Submit an ETD after saving data in the tabs", js: true do
+      click_on('Save About Me')
+      click_on('About My ETD')
+      fill_in 'Title', with: 'A great thesis'
+      click_on('Save My ETD')
+      check('agreement')
+
+      click_on('Save')
+
+      expect(page).to have_content("Your files are being processed by ETD in the background. The metadata and access controls you specified are being applied.")
+    end
   end
 
   context 'a logged out user' do

--- a/spec/features/validate_new_etd_about_spec.rb
+++ b/spec/features/validate_new_etd_about_spec.rb
@@ -48,61 +48,6 @@ RSpec.feature 'Validate an Etd: About Me' do
       expect(all('select.committee-member-select').count).to eq(1)
     end
 
-    scenario "'about me' validates dynamically added committee member names", js: true do
-      fill_in 'Student Name', with: 'Eun, Dongwon'
-      select("Spring 2018", from: "Graduation date")
-      fill_in "Post graduation email", with: "graduate@done.com"
-      select("Emory College", from: "School")
-      select("Art History and Visual Arts", from: "Department")
-      select('MS', from: "Degree")
-      select("Honors Thesis", from: "I am submitting my")
-      fill_in "Committee Chair/Thesis Advisor", with: "Diane Arbus"
-      fill_in "Committee Member", with: "Joan Didion"
-      click_on("Add Another Committee Member")
-      wait_for_ajax
-
-      expect(page).to have_css('li#required-about-me.incomplete')
-      expect(page).not_to have_css('li#required-about-me.complete')
-
-      within('.committee-member.row.second') do
-        fill_in("Committee Member", with: "Amelia Earhart")
-      end
-      # clicking outside of input after filling it with text tells js to fire validate event
-      find('div.about-me.chairs').click
-
-      wait_for_ajax
-      expect(page).to have_css('li#required-about-me.complete')
-      expect(page).not_to have_css('li#required-about-me.incomplete')
-    end
-
-    scenario "'about me' validates dynamically added committee chair names", js: true do
-      fill_in 'Student Name', with: 'Eun, Dongwon'
-      select("Spring 2018", from: "Graduation date")
-      fill_in "Post graduation email", with: "graduate@done.com"
-      select("Emory College", from: "School")
-      select("Art History and Visual Arts", from: "Department")
-      select('MS', from: "Degree")
-      select("Honors Thesis", from: "I am submitting my")
-      fill_in "Committee Chair/Thesis Advisor", with: "Diane Arbus"
-      fill_in "Committee Member", with: "Joan Didion"
-      click_on("Add Another Committee Chair/Thesis Advisor")
-      wait_for_ajax
-
-      expect(page).to have_css('li#required-about-me.incomplete')
-      expect(page).not_to have_css('li#required-about-me.complete')
-
-      within('.committee-chair.row.second') do
-        fill_in("Committee Chair/Thesis Advisor", with: "Amelia Earhart")
-      end
-      # clicking outside of input after filling it with text tells js to fire validate event
-      find('div.about-me.chairs').click
-
-      wait_for_ajax
-
-      expect(page).to have_css('li#required-about-me.complete')
-      expect(page).not_to have_css('li#required-about-me.incomplete')
-    end
-
     scenario "'about me' validates absence of dynamically added committee member affiliations", js: true do
       fill_in 'Student Name', with: 'Eun, Dongwon'
       select("Spring 2018", from: "Graduation date")


### PR DESCRIPTION
Fixes a bug @acozine ran into while testing shibboleth, where you couldn't submit and persist an ETD if you'd clicked one of the tab saves. Note: An ETD requires a title, now found on the About My ETD form.