### PR TITLE
mark shib accounts

### DIFF
--- a/config/emory/superusers.yml
+++ b/config/emory/superusers.yml
@@ -1,3 +1,6 @@
 superusers:
- - bess
- - alicia
+  database:
+   - bess
+   - alicia
+  shibboleth:
+   - P1529006 # tezprox

--- a/spec/fixtures/config/emory/superusers.yml
+++ b/spec/fixtures/config/emory/superusers.yml
@@ -1,3 +1,6 @@
 superusers:
- - superman001
- - wonderwoman001
+  database:
+   - superman001
+   - wonderwoman001
+  shibboleth:
+   - P1529006 # tezprox

--- a/spec/services/hyrax/workflow/approved_notification_spec.rb
+++ b/spec/services/hyrax/workflow/approved_notification_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Hyrax::Workflow::ApprovedNotification do
   end
   it "can find approvers" do
     expect(notification.approvers).to be_instance_of(Array)
-    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2")
+    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", "P1529006")
   end
   it "sends notifications to the depositor, school approvers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", "P1529006", etd.depositor)
   end
 end

--- a/spec/services/hyrax/workflow/comment_notification_spec.rb
+++ b/spec/services/hyrax/workflow/comment_notification_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Hyrax::Workflow::CommentNotification do
   end
   it "can find approvers" do
     expect(notification.approvers).to be_instance_of(Array)
-    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2")
+    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2")
   end
   it "sends notifications to the depositor, school approvers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2", etd.depositor)
   end
 end

--- a/spec/services/hyrax/workflow/hidden_notification_spec.rb
+++ b/spec/services/hyrax/workflow/hidden_notification_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Hyrax::Workflow::HiddenNotification do
   end
   it "can find approvers" do
     expect(notification.approvers).to be_instance_of(Array)
-    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2")
+    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2")
   end
   it "sends notifications to the depositor, school approvers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2", etd.depositor)
   end
 end

--- a/spec/services/hyrax/workflow/pending_approval_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_approval_notification_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Hyrax::Workflow::PendingApprovalNotification do
   end
   it "can find approvers" do
     expect(notification.approvers).to be_instance_of(Array)
-    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2")
+    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2")
   end
   it "sends notifications to the depositor, school approvers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2", etd.depositor)
   end
 end

--- a/spec/services/hyrax/workflow/pending_review_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_review_notification_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification do
   end
   it "can find reviewers" do
     expect(notification.reviewers).to be_instance_of(Array)
-    expect(notification.reviewers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "laneyadmin", "laneyadmin2")
+    expect(notification.reviewers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "laneyadmin", "laneyadmin2")
   end
   it "sends notifications to the depositor, school reviewers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "laneyadmin", "laneyadmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "laneyadmin", "laneyadmin2", etd.depositor)
   end
 end

--- a/spec/services/hyrax/workflow/reviewed_notification_spec.rb
+++ b/spec/services/hyrax/workflow/reviewed_notification_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Hyrax::Workflow::ReviewedNotification do
   end
   it "can find reviewers" do
     expect(notification.reviewers).to be_instance_of(Array)
-    expect(notification.reviewers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "laneyadmin", "laneyadmin2")
+    expect(notification.reviewers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "laneyadmin", "laneyadmin2")
   end
   it "sends notifications to the depositor, school reviewers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "laneyadmin", "laneyadmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "laneyadmin", "laneyadmin2", etd.depositor)
   end
 end

--- a/spec/services/hyrax/workflow/unhidden_notification_spec.rb
+++ b/spec/services/hyrax/workflow/unhidden_notification_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Hyrax::Workflow::UnhiddenNotification do
   end
   it "can find approvers" do
     expect(notification.approvers).to be_instance_of(Array)
-    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2")
+    expect(notification.approvers.pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2")
   end
   it "sends notifications to the depositor, school approvers and superusers and no one else" do
-    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "candleradmin", "candleradmin2", etd.depositor)
+    expect(notification.recipients["to"].pluck(:ppid)).to contain_exactly("admin_set_owner", "superman001", "wonderwoman001", "P1529006", "candleradmin", "candleradmin2", etd.depositor)
   end
 end


### PR DESCRIPTION
We have to mark shibboleth accounts as belonging to shibboleth.
@acozine This should fix the problem Bethany is having immediately. It will take a little longer to switch us over to using uid for account management.