### PR TITLE
Update user model to match new shibboleth AuthHash structure

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
     where(provider: auth.provider, uid: auth.info.uid).first_or_create do |user|
       user.display_name = auth.info.display_name
       user.uid = auth.info.uid
-      user.ppid = auth.ppid
+      user.ppid = auth.uid
       user.email = auth.info.uid + '@emory.edu'
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 auth_hash = OmniAuth::AuthHash.new(
   provider: 'shibboleth',
-  ppid: 'P000001',
+  uid: "P8806459",
   info: {
     display_name: "Brian Wilson",
     uid: 'brianbboys1967'
@@ -21,8 +21,9 @@ RSpec.describe User do
     it "has a shibboleth provided uid" do
       expect(user.uid).to eq auth_hash.info.uid
     end
-    it "has a shibboleth provided ppid" do
-      expect(user.ppid).to eq auth_hash.ppid
+    it "has a shibboleth provided ppid which is not nil" do
+      expect(user.ppid).to eq auth_hash.uid
+      expect(user.ppid).not_to eq nil
     end
   end
   context "signing in twice" do


### PR DESCRIPTION
Fixes an issue where Emory folks can't authenticate with shibboleth.