### PR TITLE
Update user model with info from shibboleth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,18 +24,19 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     Rails.logger.debug "auth = #{auth.inspect}"
     # Uncomment the debugger above to capture what a shib auth object looks like for testing
-    where(provider: auth.provider, uid: auth.info.uid).first_or_create do |user|
-      user.display_name = auth.info.display_name
-      user.uid = auth.info.uid
-      user.ppid = auth.uid
-      user.email = auth.info.uid + '@emory.edu'
-    end
+    user = where(provider: auth.provider, uid: auth.info.uid).first_or_create
+    user.display_name = auth.info.display_name
+    user.uid = auth.info.uid
+    user.ppid = auth.uid
+    user.email = auth.info.uid + '@emory.edu'
+    user.save
+    user
   end
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
   # the account.
   def to_s
-    ppid
+    uid
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,6 +26,31 @@ RSpec.describe User do
       expect(user.ppid).not_to eq nil
     end
   end
+  context "updating an existing user" do
+    let(:user) do
+      user = described_class.new(provider: "shibboleth", uid: "fake", ppid: "fake", display_name: nil)
+      user.save
+      user
+    end
+    let(:fake_auth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: 'shibboleth',
+        uid: "P0001",
+        info: {
+          display_name: "Boaty McBoatface",
+          uid: 'fake'
+        }
+      )
+    end
+    it "updates ppid and display_name with values from shibboleth" do
+      expect(user.ppid).to eq "fake"
+      expect(user.display_name).to eq nil
+      described_class.from_omniauth(fake_auth_hash)
+      changed_user = described_class.where(uid: "fake").first
+      expect(changed_user.ppid).to eq fake_auth_hash.uid
+      expect(changed_user.display_name).to eq fake_auth_hash.info.display_name
+    end
+  end
   context "signing in twice" do
     it "finds the original account instead of trying to make a new one" do
       expect(described_class.count).to eq 0


### PR DESCRIPTION
Fixes bug where ppid and display_name aren't being updated for pre-created approver accounts