### PR TITLE
Add pcdm_use to uploaded_file and copy it to file set

### DIFF
--- a/app/actors/hyrax/default_admin_set_actor.rb
+++ b/app/actors/hyrax/default_admin_set_actor.rb
@@ -23,6 +23,7 @@ module Hyrax
         school = attributes["school"] ? attributes["school"] : curation_concern.school
         department = attributes["department"] ? attributes["department"] : curation_concern.department
         curation_concern.assign_admin_set(school, department)
+        raise "Could not assign admin_set for #{curation_concern.id}" if curation_concern.admin_set.nil?
         attributes[:admin_set_id] = curation_concern.admin_set.id
       end
   end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -1,0 +1,35 @@
+# Converts UploadedFiles into FileSets and attaches them to works.
+class AttachFilesToWorkJob < ActiveJob::Base
+  queue_as Hyrax.config.ingest_queue_name
+
+  # @param [ActiveFedora::Base] work - the work object
+  # @param [Array<UploadedFile>] uploaded_files - an array of files to attach
+  def perform(work, uploaded_files)
+    uploaded_files.each do |uploaded_file|
+      file_set = FileSet.new
+      user = User.find_by_user_key(work.depositor)
+      actor = Hyrax::Actors::FileSetActor.new(file_set, user)
+      actor.create_metadata(visibility: work.visibility)
+      attach_content(actor, uploaded_file.file)
+      actor.attach_file_to_work(work)
+      actor.file_set.permissions_attributes = work.permissions.map(&:to_hash)
+      file_set.pcdm_use = uploaded_file.pcdm_use
+      file_set.save
+      uploaded_file.update(file_set_uri: file_set.uri)
+    end
+  end
+
+  private
+
+    # @param [Hyrax::Actors::FileSetActor] actor
+    # @param [Hyrax::UploadedFileUploader] file file.file must be a CarrierWave::SanitizedFile or file.url must be present
+    def attach_content(actor, file)
+      if file.file.is_a? CarrierWave::SanitizedFile
+        actor.create_content(file.file.to_file)
+      elsif file.url.present?
+        actor.import_url(file.url)
+      else
+        raise ArgumentError, "#{file.class} received with #{file.file.class} object and no URL"
+      end
+    end
+end

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -1,0 +1,11 @@
+module Hyrax
+  # Store a file uploaded by a user. Eventually these files get
+  # attached to FileSets and pushed into Fedora.
+  class UploadedFile < ActiveRecord::Base
+    self.table_name = 'uploaded_files'
+    mount_uploader :file, UploadedFileUploader
+    belongs_to :user, class_name: '::User'
+
+    before_destroy :remove_file!
+  end
+end

--- a/db/migrate/20170716022050_add_pcdm_use_to_uploaded_files.rb
+++ b/db/migrate/20170716022050_add_pcdm_use_to_uploaded_files.rb
@@ -1,0 +1,5 @@
+class AddPcdmUseToUploadedFiles < ActiveRecord::Migration[5.0]
+  def change
+    add_column :uploaded_files, :pcdm_use, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710204158) do
+ActiveRecord::Schema.define(version: 20170716022050) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -431,6 +431,7 @@ ActiveRecord::Schema.define(version: 20170710204158) do
     t.string   "file_set_uri"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
+    t.string   "pcdm_use"
     t.index ["file_set_uri"], name: "index_uploaded_files_on_file_set_uri"
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end

--- a/lib/tasks/build_sample_data.rake
+++ b/lib/tasks/build_sample_data.rake
@@ -33,10 +33,14 @@ task :sample_data_with_workflow do
       etd.assign_admin_set
       user = User.where(ppid: etd.depositor).first
       ability = ::Ability.new(user)
+
+      file1 = File.open("#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf")
+      file2 = File.open("#{::Rails.root}/spec/fixtures/miranda/image.tif")
+      upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
+      upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
       actor = Hyrax::CurationConcern.actor(etd, ability)
-      # TODO: Figure out how to attach files via the actor.create hash
-      # actor.create(admin_set_id: etd.admin_set.id, files: [Hyrax::UploadedFile.create(file: File.open("#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"))])
-      actor.create(admin_set_id: etd.admin_set.id)
+      attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
+      actor.create(attributes_for_actor)
       puts "Created #{etd.id}"
     end
   end

--- a/spec/models/hyrax/uploaded_file_spec.rb
+++ b/spec/models/hyrax/uploaded_file_spec.rb
@@ -1,0 +1,15 @@
+libdir = File.expand_path('../../../../', __FILE__)
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+require 'rails_helper'
+
+describe Hyrax::UploadedFile do
+  let(:file1) { File.open(fixture_path + '/joey/joey_thesis.pdf') }
+  let(:uploaded_file) { described_class.create(file: file1) }
+
+  context "new file metadata" do
+    it "has a pcdm_use" do
+      uploaded_file.pcdm_use = FileSet::PRIMARY
+      expect(uploaded_file.pcdm_use).to eq FileSet::PRIMARY
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to mark primary and supplementary files when they are uploaded, and persist that information after the files are attached to the work.