### PR TITLE
Grant depositor read on their own submission

### DIFF
--- a/config/workflows/emory_one_step_approval.json
+++ b/config/workflows/emory_one_step_approval.json
@@ -18,7 +18,9 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::DeactivateObject"
+                      "Hyrax::Workflow::DeactivateObject",
+                      "Hyrax::Workflow::RevokeEditFromDepositor",
+                      "Hyrax::Workflow::GrantReadToDepositor"
                     ]
                 }, {
                     "name": "request_changes",
@@ -32,7 +34,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::DeactivateObject"
+                      "Hyrax::Workflow::GrantEditToDepositor",
+                      "Hyrax::Workflow::DeactivateObject"
                     ]
                 }, {
                     "name": "approve",
@@ -46,7 +49,9 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::ActivateObject"
+                      "Hyrax::Workflow::GrantReadToDepositor",
+                      "Hyrax::Workflow::RevokeEditFromDepositor",
+                      "Hyrax::Workflow::ActivateObject"
                     ]
                 }, {
                     "name": "request_review",

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -89,10 +89,6 @@ RSpec.feature 'Create an Etd' do
       approve_etd(etd, workflow_setup.superusers.first)
       expect(etd.to_sipity_entity.workflow_state_name).to eq 'approved'
 
-      # TODO: For now, we need to set the visibility, but this is a bug.  The visibility should be changed automatically as part of approval process.
-      etd.visibility = 'open'
-      etd.save!
-
       # After it is approved, we can view the ETD
       visit hyrax_etd_path(etd)
 


### PR DESCRIPTION
Fixes #482 

@val99erie I think this fixes the bug you found. It should leave embargo or other visibility measures in place, but grant the depositor the ability to see their own work. It should have been this way from the start. Good catch. 