### PR TITLE
helper method for skipping specs in ci

### DIFF
--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -2,3 +2,7 @@ def show_page
   save_page Rails.root.join('public', 'capybara.html')
   `launchy http://localhost:3000/capybara.html`
 end
+
+def continuous_integration?
+  ENV.fetch("TRAVIS", false)
+end


### PR DESCRIPTION
might want this method to use like this: `scenario "Miranda previews, agrees to Emory submission policy and submits her ETD", js: true, unless: continuous_integration? do ... end`