### PR TITLE
Set embargo_length, not embargo_release_date

### DIFF
--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -6,7 +6,7 @@ module Hyrax
       def create(attributes)
         @attributes = attributes
         save_embargo_length
-        @attributes.delete(:embargo_release_date)
+        @attributes.delete(:embargo_length)
         @attributes[:visibility] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         apply_pre_graduation_embargo
         curation_concern.save
@@ -14,22 +14,15 @@ module Hyrax
       end
 
       def update(attributes)
-        @attributes = attributes
-        save_embargo_length
-        attributes.delete(:embargo_release_date)
-        attributes[:visibility] = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-        apply_pre_graduation_embargo
-        curation_concern.save
-        next_actor.update(attributes)
+        create(attributes)
       end
 
       private
 
         # Save embargo_length so we can apply it post-graduation
         def save_embargo_length
-          return unless curation_concern.class == Etd
-          return unless @attributes[:embargo_release_date]
-          curation_concern.embargo_length = @attributes[:embargo_release_date]
+          return unless @attributes[:embargo_length]
+          curation_concern.embargo_length = @attributes[:embargo_length]
         end
 
         # Parse date from string. Returns nil if date_string is not a valid date
@@ -54,7 +47,6 @@ module Hyrax
         # relevant views check for the existence of an embargo and the
         # authorization of the current user, and display embargoed fields accordingly.
         def apply_pre_graduation_embargo
-          return unless curation_concern.class == Etd # don't set a pre-graduation embargo for the FileSet
           return unless curation_concern.embargo_length # don't set a pre-graduation embargo unless there is an embargo length
           six_years_from_today = Time.zone.today + 6.years
           curation_concern.apply_embargo(

--- a/app/assets/javascripts/etd_save_work_control.es6
+++ b/app/assets/javascripts/etd_save_work_control.es6
@@ -153,7 +153,7 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
     }
 
     // this is not a check of the file type, but given that the app writes the filename to the page, and a student would have to change their Primary PDF file's type while uploading in order to foil this, I feel this is sufficient.
-    
+
     isAPdf(){
       if( $('#fileupload p.name span').text().includes('.pdf')){
         $("#pdf-format-error").addClass('hidden')
@@ -255,13 +255,13 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
     }
 
     attachNonLaneyEmbargoDurations(){
-      $('#etd_embargo_release_date').empty();
-      $('#etd_embargo_release_date').html(this.nonLaneyEmbargoDurations)
+      $('#etd_embargo_length').empty();
+      $('#etd_embargo_length').html(this.nonLaneyEmbargoDurations)
     }
 
     attachLaneyEmbargoDurations(){
-      $('#etd_embargo_release_date').empty();
-      $('#etd_embargo_release_date').html(this.laneyEmbargoDurations)
+      $('#etd_embargo_length').empty();
+      $('#etd_embargo_length').html(this.laneyEmbargoDurations)
     }
 
     setEmbargoReleaseDates(){

--- a/app/assets/javascripts/review_my_etd.es6
+++ b/app/assets/javascripts/review_my_etd.es6
@@ -83,7 +83,7 @@ export default class ReviewMyETD {
   }
 
   aboutMyEmbargoData(){
-    let data = $.merge($('#my_embargoes #embargo_type'), $('#my_embargoes #etd_embargo_release_date')).serializeArray()
+    let data = $.merge($('#my_embargoes #embargo_type'), $('#my_embargoes #etd_embargo_length')).serializeArray()
 
     let row_data = [{'name': "Embargoed ETD Content", 'value': "No Embargoed Content"}]
     let embargo_type = $('#embargo_type :selected').text()

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -31,7 +31,7 @@ module Hyrax
     self.terms += [:copyright_question_three]
     self.terms += [:no_supplemental_files]
     # my embargo terms
-
+    self.terms += [:embargo_length]
     self.terms += [:embargo_release_date]
     self.terms += [:files_embargoed]
     self.terms += [:abstract_embargoed]

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -5,6 +5,10 @@ class FileSet < ActiveFedora::Base
   PRIMARY = 'primary'.freeze
   SUPPLEMENTARY = 'supplementary'.freeze
 
+  property :embargo_length, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
+    index.as :displayable
+  end
+
   property :pcdm_use, predicate: 'http://pcdm.org/use', multiple: false do |index|
     index.as :facetable
   end

--- a/app/views/hyrax/base/_form_embargoes.html.erb
+++ b/app/views/hyrax/base/_form_embargoes.html.erb
@@ -25,7 +25,7 @@
   </div>
 
   <h4>How long will the embargo last?</h4>
-  <%= f.input :embargo_release_date, as: :select, collection: ["6 months", "1 year", "2 years", "6 years"], required: false, label: false, hint: "Choose the length of time for your embargo.", input_html: { class: 'form-control required-embargo' } %>
+  <%= f.input :embargo_length, as: :select, collection: ["6 months", "1 year", "2 years", "6 years"], required: false, label: false, hint: "Choose the length of time for your embargo.", input_html: { class: 'form-control required-embargo' } %>
 </div>
 
 

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -15,7 +15,6 @@
       <% end %>
     </td>
     <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>
-    <td class="attribute permission"><%= member.permission_badge %></td>
     <td>
       <%= render 'actions', member: member %>
     </td>

--- a/app/views/hyrax/base/_primary_pdf.html.erb
+++ b/app/views/hyrax/base/_primary_pdf.html.erb
@@ -6,7 +6,6 @@
         <th><%= t('.thumbnail') %></th>
         <th><%= t('.title') %></th>
         <th><%= t('.date_uploaded') %></th>
-        <th><%= t('.visibility') %></th>
         <th><%= t('.actions') %></th>
       </tr>
     </thead>

--- a/app/views/hyrax/base/_supplementary_files.html.erb
+++ b/app/views/hyrax/base/_supplementary_files.html.erb
@@ -6,7 +6,6 @@
         <th><%= t('.thumbnail') %></th>
         <th><%= t('.title') %></th>
         <th><%= t('.date_uploaded') %></th>
-        <th><%= t('.visibility') %></th>
         <th><%= t('.actions') %></th>
       </tr>
     </thead>

--- a/lib/tasks/build_sample_data.rake
+++ b/lib/tasks/build_sample_data.rake
@@ -74,7 +74,7 @@ namespace :sample_data do
 
   task :preapproved_embargo_demo do
     puts "Making preapproved embargo data"
-    etd = FactoryGirl.build(
+    etd = FactoryGirl.create(
       :sample_data_with_everything_embargoed,
       title: ["Interpret Visibility Demo: #{FFaker::Book.title}"],
       submitting_type: ["Master's Thesis"],
@@ -90,7 +90,7 @@ namespace :sample_data do
     upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
     upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
     actor = Hyrax::CurationConcern.actor(etd, ability)
-    attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
+    attributes_for_actor = { embargo_length: etd.embargo_length, uploaded_files: [upload1.id, upload2.id] }
     actor.create(attributes_for_actor)
     approving_user = User.where(ppid: 'candleradmin').first
     subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -23,7 +23,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
     context 'when visibility is set to open' do
       let(:attributes) do
         { visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
-          embargo_release_date: date.to_s }
+          embargo_length: "6 months" }
       end
 
       it 'removes embargo_release_date from attributes' do
@@ -42,7 +42,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
           "creator" => ["Sneddon, River"],
           "keyword" => [],
           "language" => [""],
-          "embargo_release_date" => "6 months",
+          "embargo_length" => "6 months",
           "graduation_date" => [""],
           "school" => ["Candler School of Theology"],
           "department" => ["Divinity"],
@@ -58,7 +58,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
           actor.create(attributes)
           expect(etd.embargo.embargo_release_date).to eq six_years_from_today
         end
-        it "saves the embargo lenth" do
+        it "saves the embargo length" do
           actor.create(attributes)
           expect(etd.embargo_length).to eq "6 months"
         end

--- a/spec/features/create_etd_embargo_spec.rb
+++ b/spec/features/create_etd_embargo_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Create an Etd: My Embargoes' do
 
       select('Laney Graduate School', from: 'embargo_school')
 
-      select('6 months', from: 'etd_embargo_release_date')
+      select('6 months', from: 'etd_embargo_length')
 
       expect(page).to have_css('li#required-embargoes.complete')
     end

--- a/spec/features/create_etd_review_spec.rb
+++ b/spec/features/create_etd_review_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature 'Create an Etd' do
 
       select('Laney Graduate School', from: 'embargo_school')
 
-      select('6 months', from: 'etd_embargo_release_date')
+      select('6 months', from: 'etd_embargo_length')
 
       expect(page).to have_css('li#required-embargoes.complete')
 

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FileSet do
       subject { described_class.new }
 
       its(:pcdm_use) { is_expected.to be_nil }
+      its(:embargo_length) { is_expected.to be_nil }
       its(:primary?) { is_expected.to be false }
       its(:supplementary?) { is_expected.to be true }
     end


### PR DESCRIPTION
We are really setting an embargo_length, not an embargo_release_date, so I re-named it throughout to be less confusing. This will also make it easier to later implement a form widget for Fran and Bethany that really does set "embargo release date" with a date. 