### PR TITLE
Always render an ETD for its depositor

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -18,5 +18,18 @@ module Hyrax
         super
       end
     end
+
+    # Override from Hyrax:app/controllers/concerns/hyrax/curation_concern_controller.rb
+    # Hyrax default behavior is that a user cannot see their own work if the document
+    # is "suppressed", which means Hyrax::Workflow::ActivateObject has not been called.
+    # In Emory's case, they do not want the object activated until the student has
+    # graduated. That means we need to override the default behavior.
+    def document_not_found!
+      doc = ::SolrDocument.find(params[:id])
+      # Render the document if the current_user == the depositor of the document
+      return doc if current_user && current_user.user_key == doc["depositor_ssim"].first
+      raise WorkflowAuthorizationException if doc.suppressed?
+      raise CanCan::AccessDenied.new(nil, :show)
+    end
   end
 end

--- a/spec/features/candler_workflow_etd_spec.rb
+++ b/spec/features/candler_workflow_etd_spec.rb
@@ -84,6 +84,11 @@ RSpec.feature 'Candler approval workflow' do
       expect(page).to have_content "Deposit #{etd.title.first} has been approved"
       expect(page).to have_content "#{etd.title.first} (#{etd.id}) has been approved by"
 
+      # Depositing user should be able to see their work, even if it hasn't been approved yet
+      visit("/concern/etds/#{etd.id}")
+      expect(page).to have_content(etd.abstract.first)
+      expect(page).not_to have_content("The work is not currently available")
+
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -107,6 +107,11 @@ RSpec.feature 'Laney Graduate School two step approval workflow' do
       expect(page).to have_content "#{etd.title.first} (#{etd.id}) has completed initial review and is awaiting final approval."
       expect(page).to have_content "#{etd.title.first} (#{etd.id}) has been approved by"
 
+      # Depositing user should be able to see their work, even if it hasn't been approved yet
+      visit("/concern/etds/#{etd.id}")
+      expect(page).to have_content(etd.abstract.first)
+      expect(page).not_to have_content("The work is not currently available")
+
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")

--- a/spec/features/rollins_workflow_etd_spec.rb
+++ b/spec/features/rollins_workflow_etd_spec.rb
@@ -77,6 +77,11 @@ RSpec.feature 'Create a Rollins ETD' do
       visit("/notifications?locale=en")
       expect(page).to have_content "#{etd.title.first} (#{etd.id}) has been approved by"
 
+      # Depositing user should be able to see their work, even if it hasn't been approved yet
+      visit("/concern/etds/#{etd.id}")
+      expect(page).to have_content(etd.abstract.first)
+      expect(page).not_to have_content("The work is not currently available")
+
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")

--- a/spec/features/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/features/undergrad_honors_workflow_etd_spec.rb
@@ -77,6 +77,11 @@ RSpec.feature 'Emory College approval workflow' do
       visit("/notifications?locale=en")
       expect(page).to have_content "#{etd.title.first} (#{etd.id}) has been approved by"
 
+      # Depositing user should be able to see their work, even if it hasn't been approved yet
+      visit("/concern/etds/#{etd.id}")
+      expect(page).to have_content(etd.abstract.first)
+      expect(page).not_to have_content("The work is not currently available")
+
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")


### PR DESCRIPTION
Fixes #575 