### PR TITLE
supplemental files metadata

### DIFF
--- a/app/assets/javascripts/about_my_supplemental_files.es6
+++ b/app/assets/javascripts/about_my_supplemental_files.es6
@@ -1,0 +1,65 @@
+export default class AboutMySupplementalFiles {
+  constructor() {
+    this.attach_metadata_listeners()
+    this.uniqueSupplementalFiles()
+  }
+
+  //do this on the created table, before showing it.
+  //going to need to fix the duplicate file problem.
+
+  uniqueSupplementalFiles(){
+    $('#supplemental_fileupload').bind('fileuploadfinished', function (e, data) {
+      var seen = {};
+      var dup = false;
+      $('#supplemental_files tbody.files tr').each(function() {
+          var txt = $(this).find('p.name').text();
+          if (seen[txt]){
+            console.log('seen', seen[txt])
+            $(this).first().remove();
+            dup = true
+          } else {
+            seen[txt] = true;
+          }
+      });
+      if (dup){
+        $("#duplicate-files-error").removeClass('hidden')
+      } else {
+        $("#duplicate-files-error").addClass('hidden')
+      }
+    });
+  }
+
+  displayMetadata(){
+    var form = this
+    $('#supplemental_fileupload tbody.files tr').each(function(ind, el){
+      //get filename from each row
+      form.populateMetadataTable($(el).find('p.name').text(), ind)
+    });
+  }
+
+  populateMetadataTable(filename, iterator){
+    var formatted_filename = filename.replace(/(\r\n|\n|\r)/gm,"");
+    var final_filename = formatted_filename.trim();
+    //TODO: strip extra whitespace from filename
+    //needs to be unique names, same problem as with committee members, dynamic fields need to be uniquely named --- or just serialize into array and add into hidden element's value at submission.
+    var row = $('<tr><td>'+ final_filename +'<input name="etd[supplemental_file_metadata]['+iterator+']filename" id="supplemental_file_filename" type="hidden" value="'+final_filename+'"></td><td><input name="etd[supplemental_file_metadata]['+iterator+']title" id="supplemental_file_title" type="text"></td></tr>');
+      $('#supplemental_files_metatdata tbody').append(row);
+  }
+
+  attach_metadata_listeners(){
+    var form = this
+      //make this an html element
+    $('#supplemental_fileupload').bind('fileuploadfinished', function (e, data) {
+      $('#supplemental_fileupload tbody.files').append($('#additional_metadata_link').show());
+    });
+
+    $('#additional_metadata').on('show.bs.collapse', function(){
+      $('#additional_metadata_link').text('Hide Additional Metadata');
+      form.displayMetadata()
+    });
+
+    $('#additional_metadata').on('hide.bs.collapse', function(){
+      $('#additional_metadata_link').text('Show Additional Metadata');
+    });
+  }
+}

--- a/app/assets/javascripts/about_my_supplemental_files.es6
+++ b/app/assets/javascripts/about_my_supplemental_files.es6
@@ -31,6 +31,13 @@ export default class AboutMySupplementalFiles {
 
   displayMetadata(){
     var form = this
+
+    var table_headings = $('<thead><th>File Name</th><th>Title</th><th>Description</th><th>File Type</th></thead>');
+    var table_body = $('<tbody></tbody>');
+
+    $('#supplemental_files_metadata').append(table_headings);
+    $('#supplemental_files_metadata').append(table_body);
+
     $('#supplemental_fileupload tbody.files tr').each(function(ind, el){
       //get filename from each row
       form.populateMetadataTable($(el).find('p.name').text(), ind)
@@ -40,26 +47,50 @@ export default class AboutMySupplementalFiles {
   populateMetadataTable(filename, iterator){
     var formatted_filename = filename.replace(/(\r\n|\n|\r)/gm,"");
     var final_filename = formatted_filename.trim();
-    //TODO: strip extra whitespace from filename
-    //needs to be unique names, same problem as with committee members, dynamic fields need to be uniquely named --- or just serialize into array and add into hidden element's value at submission.
-    var row = $('<tr><td>'+ final_filename +'<input name="etd[supplemental_file_metadata]['+iterator+']filename" id="supplemental_file_filename" type="hidden" value="'+final_filename+'"></td><td><input name="etd[supplemental_file_metadata]['+iterator+']title" id="supplemental_file_title" type="text"></td></tr>');
-      $('#supplemental_files_metatdata tbody').append(row);
+    //needs to be unique names, same problem as with committee members, dynamic fields need to be uniquely named --- or just serialize into array and add into hidden element's value at submission?
+
+    var html = '<tr>';
+
+    // filename td and hidden input
+    html += '<td>' + final_filename +'<input name="etd[supplemental_file_metadata]['+iterator+']filename" id="supplemental_file_filename" type="hidden" value="'+final_filename+'"></td>';
+
+    // title td and text input
+    html += '<td><input name="etd[supplemental_file_metadata]['+iterator+']title" id="supplemental_file_title" type="text"></td>';
+
+    // description td and text input
+    html += '<td><input name="etd[supplemental_file_metadata]['+iterator+']description" id="supplemental_file_description" type="text"></td>';
+
+    // file type td and dropdown: Text, Dataset, Video, Image, Software, Sound
+    html += '<td><select name="etd[supplemental_file_metadata]['+iterator+']file_type" id="supplemental_file_file_type"><option id="text">Text</option><option id="dataset">Dataset</option><option id="video">Video</option><option id="image">Image</option><option id="software">Software</option><option id="sound">Sound</option></select></td>';
+
+    //end of row
+    html += '</tr>';
+
+    var row = $(html);
+    $('#supplemental_files_metadata tbody').append(row);
   }
 
   attach_metadata_listeners(){
+    console.log('hey, hello from attach');
     var form = this
       //make this an html element
     $('#supplemental_fileupload').bind('fileuploadfinished', function (e, data) {
-      $('#supplemental_fileupload tbody.files').append($('#additional_metadata_link').show());
+      $('#link_goes_here').append($('#additional_metadata_link').show());
     });
 
     $('#additional_metadata').on('show.bs.collapse', function(){
       $('#additional_metadata_link').text('Hide Additional Metadata');
-      form.displayMetadata()
+      form.displayMetadata();
     });
 
     $('#additional_metadata').on('hide.bs.collapse', function(){
+      console.log('hey, hello from hide event');
       $('#additional_metadata_link').text('Show Additional Metadata');
+    });
+
+    $('#additional_metadata').on('hidden.bs.collapse', function(){
+      //clear table
+      $('#supplemental_files_metadata').empty();
     });
   }
 }

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -14,6 +14,9 @@ Hyrax.editor = function() {
       var aboutMeAndMyProgram = require('about_me_and_my_program')
       new aboutMeAndMyProgram()
 
+      var AboutMySupplementalFiles = require('about_my_supplemental_files')
+      new AboutMySupplementalFiles()
+
       var reviewMyETD = require('review_my_etd')
       new reviewMyETD("#review_my_etd", "#preview_my_etd")
   }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,6 +28,7 @@
 //= require required_fields
 //= require about_my_etd
 //= require about_me_and_my_program
+//= require about_my_supplemental_files
 //= require review_my_etd
 //= require hydra-editor/manage_repeating_fields
 //= require etd_editor

--- a/app/assets/javascripts/etd_save_work_control.es6
+++ b/app/assets/javascripts/etd_save_work_control.es6
@@ -9,6 +9,7 @@ import SaveWorkControl from 'hyrax/save_work/save_work_control'
 export default class EtdSaveWorkControl extends SaveWorkControl {
     constructor(element, adminSetWidget) {
         super(element, adminSetWidget)
+        this.supplemental_file_list = [];
     }
     //  * This seems to occur when focus is on one of the visibility buttons
     //  */
@@ -104,7 +105,6 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
       this.setEmbargoContentListener()
       this.setAgreementListener()
       this.getTinyContent()
-      this.addSupplementalFilesMetadata()
     }
 
     getTinyContent(){
@@ -183,26 +183,11 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
       }
     }
 
+
     supplementalFilesListener(){
       let form = this
       $('#etd_no_supplemental_files').on('change', function(){
         form.validateSupplementalFiles()
-      });
-    }
-
-    addSupplementalFilesMetadata(){
-      //is this called by both local and cloud? this is a local event handler
-
-      // better to just have our own, watches for files in the uploaded table, submits to uploads controller?
-      $('#supplemental_fileupload').bind('fileuploaddone', function (e, data) {
-        $('#additional_metadata_link').show();
-        //show metadata fields -- ajax post to uploads controller with them?
-        //
-        // $.ajax({
-        //   type: "POST",
-        //   url: "/uploads",
-        //   data: "a string"
-        // });
       });
     }
 
@@ -358,6 +343,7 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
     this.requiredPDF.uncheck()
     return false
   }
+
 
   validateSupplementalFiles() {
     if ($('#etd_no_supplemental_files').prop('checked')){

--- a/app/assets/javascripts/etd_save_work_control.es6
+++ b/app/assets/javascripts/etd_save_work_control.es6
@@ -104,6 +104,7 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
       this.setEmbargoContentListener()
       this.setAgreementListener()
       this.getTinyContent()
+      this.addSupplementalFilesMetadata()
     }
 
     getTinyContent(){
@@ -186,6 +187,22 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
       let form = this
       $('#etd_no_supplemental_files').on('change', function(){
         form.validateSupplementalFiles()
+      });
+    }
+
+    addSupplementalFilesMetadata(){
+      //is this called by both local and cloud? this is a local event handler
+
+      // better to just have our own, watches for files in the uploaded table, submits to uploads controller?
+      $('#supplemental_fileupload').bind('fileuploaddone', function (e, data) {
+        $('#additional_metadata_link').show();
+        //show metadata fields -- ajax post to uploads controller with them?
+        //
+        // $.ajax({
+        //   type: "POST",
+        //   url: "/uploads",
+        //   data: "a string"
+        // });
       });
     }
 

--- a/app/assets/javascripts/hyrax/browse_everything.js
+++ b/app/assets/javascripts/hyrax/browse_everything.js
@@ -15,6 +15,29 @@ Blacklight.onLoad( function() {
     var evt = { isDefaultPrevented: function() { return false; } };
     var files = $.map(data, function(d) { return { name: d.file_name, size: d.file_size, id: d.url } });
     $.blueimp.fileupload.prototype.options.done.call($('#supplemental_fileupload').fileupload(), evt, { result: { files: files }});
-  })
+    //validate for uniqueSupplementalFiles
+    // also show the additional metadata button
+    //maybe require the class here, rather than duplicating this code?
+    //TODO: comment about where other function is and why
 
+    $('#supplemental_fileupload tbody.files').append($('#additional_metadata_link').show());
+
+    var seen = {};
+    var dup = false;
+    $('#supplemental_files tbody.files tr').each(function() {
+        var txt = $(this).find('p.name').text();
+        if (seen[txt]){
+          console.log('seen', seen[txt])
+          $(this).first().remove();
+          dup = true
+        } else {
+          seen[txt] = true;
+        }
+    });
+    if (dup){
+      $("#duplicate-files-error").removeClass('hidden')
+    } else {
+      $("#duplicate-files-error").addClass('hidden')
+    }
+  })
 });

--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -65,6 +65,7 @@ span.disabled_element input[disabled] {
  .navbar-text {
  margin:0px !important;
 }
+
 #submission-agreement-copy {
   padding: 5%;
   height: 200px;
@@ -80,4 +81,8 @@ ul.admin-sidebar {
   div ul.navbar-right {
     margin-right: 0;
   }
+}
+
+#additional_metadata_link{
+  display: none;
 }

--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -88,6 +88,10 @@ ul.admin-sidebar {
 }
 
 #additional_metadata {
-  min-height: 30px;
+  // min-height: 30px;
   display: block;
+}
+
+#supplemental_files_metadata{
+  height: inherit;
 }

--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -83,6 +83,11 @@ ul.admin-sidebar {
   }
 }
 
-#additional_metadata_link{
+#additional_metadata_link {
   display: none;
+}
+
+#additional_metadata {
+  min-height: 30px;
+  display: block;
 }

--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -10,6 +10,7 @@ module Hyrax
     self.show_presenter = EtdPresenter
 
     def create
+      apply_supplemental_file_metadata(params) if params["etd"]["supplemental_file_metadata"]
       # TODO: make this a case statement for each tab
       if params.fetch('partial_data', false) == "true"
         @etd_about_me = params.fetch('etd')
@@ -30,6 +31,31 @@ module Hyrax
       return doc if current_user && current_user.user_key == doc["depositor_ssim"].first
       raise WorkflowAuthorizationException if doc.suppressed?
       raise CanCan::AccessDenied.new(nil, :show)
+    end
+
+    # Take supplemental file metadata and write it to the appropriate UploadedFile
+    # @param [ActionController::Parameters] params
+    # @return [ActionController::Parameters] params
+    def apply_supplemental_file_metadata(params)
+      no_supplemental_files = params["etd"].delete("no_supplemental_files")
+      return if no_supplemental_files == 1
+      uploaded_file_ids = params["uploaded_files"]
+      return if uploaded_file_ids.nil?
+      uploaded_file_ids.each do |uploaded_file_id|
+        uploaded_file = Hyrax::UploadedFile.find(uploaded_file_id)
+        next if uploaded_file.pcdm_use == "primary"
+        supplemental_file_metadata = params["etd"]["supplemental_file_metadata"]
+        supplemental_file_metadata.keys.each do |key|
+          next unless File.basename(uploaded_file.file.file.file) == supplemental_file_metadata[key]["filename"]
+          uploaded_file.title = supplemental_file_metadata[key]["title"]
+          uploaded_file.description = supplemental_file_metadata[key]["description"]
+          uploaded_file.file_type = supplemental_file_metadata[key]["file_type"]
+          uploaded_file.save
+          supplemental_file_metadata.delete(key)
+        end
+      end
+      params["etd"].delete("supplemental_file_metadata")
+      params # return the params after processing, for ease of testing
     end
   end
 end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -14,6 +14,13 @@ class AttachFilesToWorkJob < ActiveJob::Base
       actor.attach_file_to_work(work)
       actor.file_set.permissions_attributes = work.permissions.map(&:to_hash)
       file_set.pcdm_use = uploaded_file.pcdm_use
+      if uploaded_file.pcdm_use == 'primary'
+        file_set.title = work.title
+      else
+        file_set.title = Array.wrap(uploaded_file.title)
+        file_set.description = Array.wrap(uploaded_file.description)
+        file_set.file_type = uploaded_file.file_type
+      end
       file_set.save
       uploaded_file.update(file_set_uri: file_set.uri)
     end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -13,6 +13,10 @@ class FileSet < ActiveFedora::Base
     index.as :facetable
   end
 
+  property :file_type, predicate: 'http://purl.org/dc/elements/1.1/format', multiple: false do |index|
+    index.as :facetable
+  end
+
   def primary?
     pcdm_use == PRIMARY
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -65,6 +65,10 @@ class SolrDocument
     self[Solrizer.solr_name('department')]
   end
 
+  def description
+    self[Solrizer.solr_name('description')]
+  end
+
   def embargo_length
     self['embargo_length_ssm']
   end

--- a/app/presenters/file_set_presenter.rb
+++ b/app/presenters/file_set_presenter.rb
@@ -1,5 +1,6 @@
 class FileSetPresenter < Hyrax::FileSetPresenter
   delegate :pcdm_use,
+           :description,
            to: :solr_document
 
   def primary?

--- a/app/views/hyrax/base/_form_supplemental_files.html.erb
+++ b/app/views/hyrax/base/_form_supplemental_files.html.erb
@@ -17,6 +17,7 @@
                <span>Add Supplemental Files</span>
                <input type="file" name="supplemental_files[]" multiple>
            </span>
+
            <% if browser_supports_directory_upload? %>
            <!-- The fileinput-button span is used to style the file input field as button -->
            <span class="btn btn-success fileinput-button">
@@ -49,3 +50,15 @@
 <h2><%= t('hyrax.base.form_files.external_upload') %></h2>
 <%= render 'browse_everything_supplemental', f: f %>
 <% end %>
+
+<%= link_to "Show Additional Metadata",
+            '#additional_metadata',
+            id: 'additional_metadata_link',
+            class: 'btn btn-default additional-fields',
+            data: { toggle: 'collapse' },
+            role: "button",
+            'aria-expanded'=> "false",
+            'aria-controls'=> "additional_metadata" %>
+<div id="additional_metadata" class='collapse'>
+some stuff
+</div>

--- a/app/views/hyrax/base/_form_supplemental_files.html.erb
+++ b/app/views/hyrax/base/_form_supplemental_files.html.erb
@@ -8,9 +8,10 @@
   <%= f.input :no_supplemental_files, as: :boolean, label: "I have no supplemental files." %>
    <!-- The table listing the files available for upload/download -->
    <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-   <div id="additional_metadata" class='collapse col-xs-12'>
-     <table class='metadata' id='supplemental_files_metatdata'>
-       <tbody></tbody>
+
+   <div id='link_goes_here'></div>
+   <div id="additional_metadata" class='collapse'>
+     <table class='table table-striped metadata' id='supplemental_files_metadata'>
      </table>
    </div>
    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->

--- a/app/views/hyrax/base/_form_supplemental_files.html.erb
+++ b/app/views/hyrax/base/_form_supplemental_files.html.erb
@@ -4,10 +4,15 @@
 <div id="supplemental_fileupload">
   <h2><%= t('hyrax.base.form_files.local_upload') %></h2>
   <div class="alert alert-success form-instructions">For supplemental files 100MB or smaller, upload from your computer.</div>
+  <div id='duplicate-files-error' class='alert alert-warning hidden col-xs-12'>NO DUPLICATE FILES.</div>
   <%= f.input :no_supplemental_files, as: :boolean, label: "I have no supplemental files." %>
    <!-- The table listing the files available for upload/download -->
    <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-
+   <div id="additional_metadata" class='collapse col-xs-12'>
+     <table class='metadata' id='supplemental_files_metatdata'>
+       <tbody></tbody>
+     </table>
+   </div>
    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
    <div class="row fileupload-buttonbar">
        <div class="col-xs-7">
@@ -59,6 +64,3 @@
             role: "button",
             'aria-expanded'=> "false",
             'aria-controls'=> "additional_metadata" %>
-<div id="additional_metadata" class='collapse'>
-some stuff
-</div>

--- a/app/views/hyrax/base/_member.html.erb
+++ b/app/views/hyrax/base/_member.html.erb
@@ -11,7 +11,10 @@
       <% if @presenter.files_embargo_check %>
         <%= @presenter.files_embargo_check %>
       <% else %>
-      <%= link_to(member.link_name, contextual_path(member, @presenter)) %>
+        <%= link_to(member.link_name, contextual_path(member, @presenter)) %>
+        <% if member.description %>
+          <%= " (#{member.description.first})" %>
+        <% end %>
       <% end %>
     </td>
     <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>

--- a/db/migrate/20170803214050_add_title_to_uploaded_file.rb
+++ b/db/migrate/20170803214050_add_title_to_uploaded_file.rb
@@ -1,0 +1,5 @@
+class AddTitleToUploadedFile < ActiveRecord::Migration[5.0]
+  def change
+    add_column :uploaded_files, :title, :string
+  end
+end

--- a/db/migrate/20170804150016_add_description_to_uploaded_file.rb
+++ b/db/migrate/20170804150016_add_description_to_uploaded_file.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToUploadedFile < ActiveRecord::Migration[5.0]
+  def change
+    add_column :uploaded_files, :description, :string
+  end
+end

--- a/db/migrate/20170804150336_add_file_type_to_uploaded_file.rb
+++ b/db/migrate/20170804150336_add_file_type_to_uploaded_file.rb
@@ -1,0 +1,5 @@
+class AddFileTypeToUploadedFile < ActiveRecord::Migration[5.0]
+  def change
+    add_column :uploaded_files, :file_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170716022050) do
+ActiveRecord::Schema.define(version: 20170804150336) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -432,6 +432,9 @@ ActiveRecord::Schema.define(version: 20170716022050) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.string   "pcdm_use"
+    t.string   "title"
+    t.string   "description"
+    t.string   "file_type"
     t.index ["file_set_uri"], name: "index_uploaded_files_on_file_set_uri"
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end

--- a/lib/etd_factory.rb
+++ b/lib/etd_factory.rb
@@ -18,18 +18,17 @@ class EtdFactory
   end
 
   def attach_primary_pdf_file
-    uf = Hyrax::UploadedFile.create(file: File.open(primary_pdf_file))
+    uf = Hyrax::UploadedFile.create(file: File.open(primary_pdf_file), pcdm_use: FileSet::PRIMARY)
     AttachFilesToWorkJob.perform_now(etd, [uf])
     primary_file_set = etd.ordered_members.to_a.first
     primary_file_set.embargo = etd.embargo
-    primary_file_set.pcdm_use = FileSet::PRIMARY
     primary_file_set.save
   end
 
   def attach_supplemental_files
     return unless supplemental_files && supplemental_files.count > 0
     supplemental_files.each do |sf|
-      uf = Hyrax::UploadedFile.create(file: File.open(sf))
+      uf = Hyrax::UploadedFile.create(file: File.open(sf), pcdm_use: FileSet::SUPPLEMENTARY)
       AttachFilesToWorkJob.perform_now(etd, [uf])
     end
     mark_supplemental_files

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -25,6 +25,43 @@ namespace :sample_data do
     end
   end
 
+  desc "Sample data with supplementary file metadata"
+  task :with_supplementary_file_metadata do
+    puts "Making sample data with supplementary file metadata"
+    sample_data = [
+      :sample_data,
+      :sample_data_with_everything_embargoed,
+      :sample_data_with_only_files_embargoed
+    ]
+    sample_data.each do |s|
+      etd = FactoryGirl.create(s)
+      uploaded_files = []
+      primary_pdf_file = "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"
+      supplementary_file_one = "#{::Rails.root}/spec/fixtures/miranda/rural_clinics.zip"
+      supplementary_file_two = "#{::Rails.root}/spec/fixtures/miranda/image.tif"
+      uploaded_files << Hyrax::UploadedFile.create(
+        file: File.open(primary_pdf_file),
+        pcdm_use: FileSet::PRIMARY
+      )
+      uploaded_files << Hyrax::UploadedFile.create(
+        file: File.open(supplementary_file_one),
+        pcdm_use: FileSet::SUPPLEMENTARY,
+        title: "Rural Clinics in Georgia",
+        description: "GIS shapefile showing rural clinics",
+        file_type: "Dataset"
+      )
+      uploaded_files << Hyrax::UploadedFile.create(
+        file: File.open(supplementary_file_two),
+        pcdm_use: FileSet::SUPPLEMENTARY,
+        title: "Photographer",
+        description: "a portrait of the artist",
+        file_type: "Image"
+      )
+      AttachFilesToWorkJob.perform_now(etd, uploaded_files)
+      puts "Created #{etd.id}"
+    end
+  end
+
   task :workflow do
     sample_data = [:sample_data, :sample_data_with_everything_embargoed, :sample_data_with_only_files_embargoed]
     school_based_admin_sets = ["Laney Graduate School", "Emory College", "Candler School of Theology"]

--- a/spec/factories/uploaded_file.rb
+++ b/spec/factories/uploaded_file.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :uploaded_file, class: Hyrax::UploadedFile do
+    id { ActiveFedora::Noid::Service.new.mint }
+    file { "fake_title.pdf" }
+    user_id { 1 }
+    pcdm_use { "supplementary" }
+  end
+end

--- a/spec/features/embargo_show_spec.rb
+++ b/spec/features/embargo_show_spec.rb
@@ -36,8 +36,8 @@ RSpec.feature 'Display an ETD with embargoed content' do
       expect(page).to have_content "Table of Contents"
       expect(page).to have_content etd.table_of_contents.first
       expect(page).to have_content "[Table of contents embargoed until #{etd.embargo_length} post-graduation"
-      expect(page).to have_content "joey_thesis.pdf"
-      expect(page).to have_link "joey_thesis.pdf"
+      expect(page).to have_content etd.title.first
+      expect(page).to have_link etd.title.first
       expect(page).to have_link "Download"
       expect(page).to have_css "td.thumbnail/a/img" # thumbnail image link
     end
@@ -53,8 +53,8 @@ RSpec.feature 'Display an ETD with embargoed content' do
       expect(page).to have_content "Table of Contents"
       expect(page).to have_content etd.table_of_contents.first
       expect(page).to have_content "[Table of contents embargoed until #{formatted_embargo_release_date(etd)}"
-      expect(page).to have_content "joey_thesis.pdf"
-      expect(page).to have_link "joey_thesis.pdf"
+      expect(page).to have_content etd.title.first
+      expect(page).to have_link etd.title.first
       expect(page).to have_link "Download"
       expect(page).to have_css "td.thumbnail/a/img" # thumbnail image link
     end
@@ -70,8 +70,8 @@ RSpec.feature 'Display an ETD with embargoed content' do
       expect(page).to have_content "Table of Contents"
       expect(page).to have_content etd.table_of_contents.first
       expect(page).to have_content "[Table of contents embargoed until #{etd.embargo_length} post-graduation"
-      expect(page).to have_content "joey_thesis.pdf"
-      expect(page).to have_link "joey_thesis.pdf"
+      expect(page).to have_content etd.title.first
+      expect(page).to have_link etd.title.first
       expect(page).to have_link "Download"
       expect(page).to have_css "td.thumbnail/a/img" # thumbnail image link
     end
@@ -86,8 +86,8 @@ RSpec.feature 'Display an ETD with embargoed content' do
       expect(page).to have_content "Table of Contents"
       expect(page).to have_content etd.table_of_contents.first
       expect(page).to have_content "[Table of contents embargoed until #{formatted_embargo_release_date(etd)}"
-      expect(page).to have_content "joey_thesis.pdf"
-      expect(page).to have_link "joey_thesis.pdf"
+      expect(page).to have_content etd.title.first
+      expect(page).to have_link etd.title.first
       expect(page).to have_link "Download"
       expect(page).to have_css "td.thumbnail/a/img" # thumbnail image link
     end
@@ -100,8 +100,7 @@ RSpec.feature 'Display an ETD with embargoed content' do
       expect(page).to have_content "Table of Contents"
       expect(page).not_to have_content etd.table_of_contents.first
       expect(page).to have_content "This table of contents is under embargo until #{formatted_embargo_release_date(etd)}"
-      expect(page).not_to have_content "joey_thesis.pdf"
-      expect(page).not_to have_link "joey_thesis.pdf"
+      expect(page).not_to have_link etd.title.first
       expect(page).not_to have_link "Download"
       expect(page).to have_css "td.thumbnail/img[alt='No preview']" # "no preview" image
       expect(page).to have_css "img.representative-media[alt='No preview']" # "no preview" large image

--- a/spec/features/show_etd_spec.rb
+++ b/spec/features/show_etd_spec.rb
@@ -22,6 +22,31 @@ RSpec.feature 'Display ETD metadata' do
       "partnering_agency"
     ]
   end
+  before do
+    uploaded_files = []
+    primary_pdf_file = "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"
+    supplementary_file_one = "#{::Rails.root}/spec/fixtures/miranda/rural_clinics.zip"
+    supplementary_file_two = "#{::Rails.root}/spec/fixtures/miranda/image.tif"
+    uploaded_files << Hyrax::UploadedFile.create(
+      file: File.open(primary_pdf_file),
+      pcdm_use: FileSet::PRIMARY
+    )
+    uploaded_files << Hyrax::UploadedFile.create(
+      file: File.open(supplementary_file_one),
+      pcdm_use: FileSet::SUPPLEMENTARY,
+      title: "Rural Clinics in Georgia",
+      description: "GIS shapefile showing rural clinics",
+      file_type: "Dataset"
+    )
+    uploaded_files << Hyrax::UploadedFile.create(
+      file: File.open(supplementary_file_two),
+      pcdm_use: FileSet::SUPPLEMENTARY,
+      title: "Photographer",
+      description: "a portrait of the artist",
+      file_type: "Image"
+    )
+    AttachFilesToWorkJob.perform_now(etd, uploaded_files)
+  end
   scenario "Show all expected ETD fields" do
     visit("/concern/etds/#{etd.id}")
     required_fields.each do |field|
@@ -29,5 +54,7 @@ RSpec.feature 'Display ETD metadata' do
       expect(value).not_to eq nil
       expect(page).to have_content value
     end
+    expect(page).to have_content "Rural Clinics in Georgia (GIS shapefile showing rural clinics)"
+    expect(page).to have_content "Photographer (a portrait of the artist)"
   end
 end

--- a/spec/features/upload_files_spec.rb
+++ b/spec/features/upload_files_spec.rb
@@ -31,15 +31,11 @@ RSpec.feature 'Primary PDF' do
       expect(page).not_to have_content('The Primary PDF must be a file in the .pdf fomat.')
       expect(page).to have_css('li#required-files.complete')
     end
-<<<<<<< HEAD
-
     scenario "Supplemental Files", js: true do
       click_on('Supplemental Files')
       expect(page).to have_content('I have no supplemental files.')
       expect(page).to have_content('Add Supplemental Files')
       # expect(page).to have_content('Browse cloud files')
     end
-=======
->>>>>>> test and show metadata button working
   end
 end

--- a/spec/features/upload_files_spec.rb
+++ b/spec/features/upload_files_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Upload Files' do
+RSpec.feature 'Primary PDF' do
   let(:user) { create :user }
-  context 'a logged in user' do
+  context 'a logged in user uploads Primary PDF' do
     before do
       login_as user
       visit("/concern/etds/new")
+    end
+
+    after do
+      logout
     end
 
     scenario "Primary Pdf requires pdf format", js: true do
@@ -27,6 +31,7 @@ RSpec.feature 'Upload Files' do
       expect(page).not_to have_content('The Primary PDF must be a file in the .pdf fomat.')
       expect(page).to have_css('li#required-files.complete')
     end
+<<<<<<< HEAD
 
     scenario "Supplemental Files", js: true do
       click_on('Supplemental Files')
@@ -34,5 +39,7 @@ RSpec.feature 'Upload Files' do
       expect(page).to have_content('Add Supplemental Files')
       # expect(page).to have_content('Browse cloud files')
     end
+=======
+>>>>>>> test and show metadata button working
   end
 end

--- a/spec/features/upload_supplemental_files_spec.rb
+++ b/spec/features/upload_supplemental_files_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'Supplemental files' do
+  let(:user) { create :user }
+  context 'logged in user uploads Supplemental files' do
+    before do
+      login_as user
+      visit("/concern/etds/new")
+    end
+
+    after do
+      logout
+    end
+
+    scenario "Supplemental Files Content", js: true do
+      click_on('Supplemental Files')
+      expect(page).to have_content('I have no supplemental files.')
+      expect(page).to have_content('Add Supplementary files...')
+      # expect(page).to have_content('Browse cloud files')
+    end
+
+    scenario "Students can add metadata to their Supplemental Files", js: true do
+      click_on('Supplemental Files')
+
+      expect(page).not_to have_content('Show Additional Metadata')
+
+      page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+
+      expect(page).to have_content('Show Additional Metadata')
+    end
+  end
+end

--- a/spec/features/upload_supplemental_files_spec.rb
+++ b/spec/features/upload_supplemental_files_spec.rb
@@ -27,7 +27,19 @@ RSpec.feature 'Supplemental files' do
 
       page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
 
-      expect(page).to have_content('Show Additional Metadata')
+      expect(page).to have_link('Show Additional Metadata')
+
+      click_on('Show Additional Metadata')
+
+      expect(page).to have_css('table.metadata')
+      expect(page).to have_content('Hide Additional Metadata')
+
+      # click_on('Hide Additional Metadata')
+
+      # why doesn't this js collapse event occur?
+      # the first one does
+      # expect(page).not_to have_content('some good things')
+      # expect(page).to have_link('Show Additional Metadata')
     end
   end
 end

--- a/spec/features/upload_supplemental_files_spec.rb
+++ b/spec/features/upload_supplemental_files_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Supplemental files' do
   let(:user) { create :user }
   context 'logged in user uploads Supplemental files' do
     before do
+      page.driver.console_messages # need capybara confg debug = true also to see them
       login_as user
       visit("/concern/etds/new")
     end
@@ -31,15 +32,18 @@ RSpec.feature 'Supplemental files' do
 
       click_on('Show Additional Metadata')
 
-      expect(page).to have_css('table.metadata')
-      expect(page).to have_content('Hide Additional Metadata')
+      expect(page).to have_content('File Name')
+      expect(page).to have_link('Hide Additional Metadata')
 
-      # click_on('Hide Additional Metadata')
+      click_link('Hide Additional Metadata')
+      
+      # expect will wait for dom to finish up
+      expect(page).to have_content('magic_warrior_cat.jpg')
 
       # why doesn't this js collapse event occur?
       # the first one does
-      # expect(page).not_to have_content('some good things')
-      # expect(page).to have_link('Show Additional Metadata')
+      expect(page).not_to have_content('File Name')
+      expect(page).to have_link('Show Additional Metadata')
     end
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe FileSet do
       its(:embargo_length) { is_expected.to be_nil }
       its(:primary?) { is_expected.to be false }
       its(:supplementary?) { is_expected.to be true }
+      its(:title) { is_expected.to eq [] }
+      its(:description) { is_expected.to eq [] }
+      its(:file_type) { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
@jenlindner Would you take a look, please? This builds off of your branch. It saves the supplemental file metadata, copies it to the FileSet, and displays it on the show page. I believe the only failing test is the one you mentioned, but let's see what Travis says. 

Also, I think this doesn't quite close #507. I haven't checked to see if supplemental file metadata is required if you upload a supplemental file, and I don't think it's displaying on the preview before submit page.

Addresses #507 
Fixes #525 