### PR TITLE
Tripartite

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,6 @@
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"
+
 after 'deploy:published', 'laevigata:workflow_setup'
 # config valid only for current version of Capistrano
 lock "3.8.2"

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,5 @@
 # deploys to Emory production machine
 set :stage, :prod
 set :rails_env, 'production'
-server 'etd.library.emory.edu', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+server '13.59.122.177', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
 append :linked_files, "config/initializers/hyrax.rb", "config/environments/production.rb"

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,0 +1,5 @@
+# deploys to Emory production machine
+set :stage, :prod
+set :rails_env, 'production'
+server 'etd.library.emory.edu', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+append :linked_files, "config/initializers/hyrax.rb", "config/environments/production.rb"

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,5 @@
+# deploys to Emory qa machine
+set :stage, :qa
+set :rails_env, 'production'
+server 'qa-etd.library.emory.edu', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+append :linked_files, "config/initializers/hyrax.rb", "config/environments/production.rb"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,0 +1,5 @@
+# deploys to Emory Staging machine
+set :stage, :staging
+set :rails_env, 'production'
+server 'staging-etd.library.emory.edu', user: 'deploy', roles: [:web, :app, :db, :resque_pool]
+append :linked_files, "config/initializers/hyrax.rb", "config/environments/production.rb"


### PR DESCRIPTION
These changes allow us to deploy code changes to the three new Emory environments. Right now we have a total of 5 environments running:
emory-stress-test - on a single server on DCE infrastructure `cap stresstest deploy`
emory.curtionexperts.com - on 3 servers on Emory infrastructure `cap aws deploy`
staging-etd.library.emory.edu - on 3 servers on Emory infrastructure `cap staging deploy`
qa-etd.library.emory.edu - on 3 servers on Emory infrastructure `cap qa deploy`
etd.library.emory.edu-in-waiting - on 3 servers on Emory infrastructure `cap prod deploy`