### PR TITLE
hiding save buttons with css

### DIFF
--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -99,6 +99,17 @@ ul.admin-sidebar {
   height: inherit;
 }
 
+input#about_my_etd_data {
+  color: #fff;
+  background-color: #fff;
+  border-color: #fff;
+  height: 1px;
+  width: 1px;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
 table#uploaded_pdf th, table#uploaded_supplemental_files th {
   text-align: center;
   background-color: #fff;

--- a/app/views/hyrax/base/_form_about_me.html.erb
+++ b/app/views/hyrax/base/_form_about_me.html.erb
@@ -44,7 +44,3 @@
     <button type="button" id="add-another-member" class="btn btn-link add"><span class="glyphicon glyphicon-plus"></span><span class="controls-add-text">Add another Committee Member</span></button>
   </div>
 </div>
-
-<input name="about_me_and_my_program" value="Save About Me" class="btn btn-primary" id="about_me_and_my_program" type="submit" />
-
-<div id="success"></div>

--- a/app/views/hyrax/base/_form_about_my_etd.html.erb
+++ b/app/views/hyrax/base/_form_about_my_etd.html.erb
@@ -30,6 +30,5 @@
       3) Does your thesis or dissertation disclose or describe any inventions or discoveries that could potentially have commercial application and therefore may be patented? <b>If so, please contact the Office of Technology Transfer (OTT) at Phone: (404) 727-2211.</b></p>
       <%= f.input :copyright_question_three, as: :radio_buttons, label: "", input_html: { class: 'copyright'} %>
     </div>
-    <input name="about_my_etd_data" value="Save My ETD" class="btn btn-primary" id="about_my_etd_data" type="submit" />
 
-    <div id="my-etd-success"></div>
+    <input name="about_my_etd_data" value="Save My ETD" class="btn btn-primary" id="about_my_etd_data" type="submit" />

--- a/spec/features/create_etd_about_my_etd_spec.rb
+++ b/spec/features/create_etd_about_my_etd_spec.rb
@@ -38,8 +38,8 @@ RSpec.feature 'Create an Etd: My Etd' do
       tinymce_fill_in('etd_table_of_contents', 'Chapter One')
       select 'Aeronomy', from: 'Research Field'
       fill_in 'Keyword', with: "Courtship"
-      click_on('about_my_etd_data')
-      expect(page).to have_content 'Successfully saved About My Etd'
+
+      click_on('Save My ETD')
       expect(page).to have_css 'li#required-my-etd.complete'
     end
 


### PR DESCRIPTION
@bess @little9 this PR hides one of the save buttons rather than removing it only because the create review spec (the most complete test of the create feature) can't pass without it. I tried for a better solution all day with no reliable success, and while this is no one's first choice for a solution, it will work. 