### PR TITLE
Use honeybadger.io for exception tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,10 @@ gem 'whenever', require: false
 gem 'xray-rails'
 gem 'yard'
 
+group :production do
+  gem 'honeybadger', '~> 3.1'
+end
+
 group :development, :test do
   gem 'bixby' # bixby == the hydra community's rubocop rules
   # Call 'byebug' anywhere in the code to stop execution and get a debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,7 @@ GEM
       concurrent-ruby (~> 1.0)
     hashie (3.5.6)
     hiredis (0.6.1)
+    honeybadger (3.1.2)
     htmlentities (4.3.4)
     httmultiparty (0.3.16)
       httparty (>= 0.7.3)
@@ -904,6 +905,7 @@ DEPENDENCIES
   factory_girl_rails
   fcrepo_wrapper
   ffaker
+  honeybadger (~> 3.1)
   hydra-role-management
   hyrax (~> 1.0)
   jasmine
@@ -943,4 +945,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/capfile
+++ b/capfile
@@ -39,3 +39,5 @@ install_plugin Capistrano::SCM::Git
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
+
+require 'capistrano/honeybadger'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,6 +33,7 @@ append :linked_files, "config/redis.yml"
 append :linked_files, "config/resque-pool.yml"
 append :linked_files, "config/secrets.yml"
 append :linked_files, "config/solr.yml"
+append :linked_files, "config/honeybadger.yml"
 
 # restart resque-pool
 require 'resque'

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,2 @@
+---
+api_key: 'your key here'


### PR DESCRIPTION
I would like to try using honeybadger.io to track exceptions in production. Right now we are trying to diagnose Emory submission problems and grepping through the log files feels like a time sink. Let's give this a try. 