### PR TITLE
requires ssl and restrains logging in prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,11 +40,11 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Related to #173. As currently deployed, `config/environments/production.rb` is a shared file. The relevant changes have already been made in the appropriate environments, but I think changing the codebase is a good idea for Future Us.