### PR TITLE
Make the admin user display screen more helpful

### DIFF
--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -22,10 +22,14 @@
           <% @presenter.users.each do |user| %>
             <tr>
               <td><%= link_to hyrax.profile_path(user) do %>
-                    <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+                    <%= user.display_name %>
                   <% end %>
               </td>
-              <td><%= link_to user.email, hyrax.profile_path(user) %></td>
+              <td>
+                <%= link_to hyrax.profile_path(user) do %>
+                  <%= user.uid %>
+                <% end %>
+              </td>
               <td><% roles = @presenter.user_roles(user) %>
                   <ul><% roles.each do |role| %>
                     <li><%= role %></li>


### PR DESCRIPTION
Show user display_name and uid since most people don't have email addresses.

Fixes #467 

<img width="888" alt="index_user____emory_electronic_theses_and_dissertations" src="https://user-images.githubusercontent.com/65608/33345686-2f0255a6-d45b-11e7-9739-8e397cc3a0d7.png">
