### PR TITLE
Fix bug where stats break if a user has been deleted or changed

### DIFF
--- a/app/services/hyrax/statistics/depositors/summary.rb
+++ b/app/services/hyrax/statistics/depositors/summary.rb
@@ -1,0 +1,56 @@
+# Gather information about the depositors who have contributed to the repository
+module Hyrax
+  module Statistics
+    module Depositors
+      class Summary
+        include Blacklight::SearchHelper
+
+        # @param [Time] start_date optionally specify the start date to gather the stats from
+        # @param [Time] end_date optionally specify the end date to gather the stats from
+        def initialize(start_date, end_date)
+          @start_dt = start_date
+          @end_dt = end_date
+        end
+
+        attr_accessor :start_dt, :end_dt
+
+        def depositors
+          # step through the array by twos to get each pair
+          results.map do |key, deposits|
+            user = ::User.find_by_user_key(key)
+            # Don't raise this error. Sometimes a user has been deleted or their ppid has changed. Just cope.
+            # raise "Unable to find user '#{key}'\nResults was: #{results.inspect}" unless user
+            { key: key, deposits: deposits, user: user }
+          end
+        end
+
+        private
+
+          delegate :blacklight_config, to: CatalogController
+          delegate :depositor_field, to: DepositSearchBuilder
+
+          # results come from Solr in an array where the first item is the user and
+          # the second item is the count
+          # [ abc123, 55, ccczzz, 205 ]
+          # @return [#each] an enumerable object of tuples (user and count)
+          def results
+            facet_results = repository.search(query)
+            facet_results.facet_fields[depositor_field].each_slice(2)
+          end
+
+          def search_builder
+            DepositSearchBuilder.new([:include_depositor_facet], self)
+          end
+
+          # TODO: This can probably be pushed into the DepositSearchBuilder
+          def query
+            search_builder.merge(q: date_query).query
+          end
+
+          def date_query
+            Hyrax::QueryService.new.build_date_query(start_dt, end_dt) unless start_dt.blank?
+          end
+      end
+    end
+  end
+end

--- a/app/views/hyrax/admin/stats/_deposits.html.erb
+++ b/app/views/hyrax/admin/stats/_deposits.html.erb
@@ -1,0 +1,14 @@
+<h3>Deposits By Users (<%= @presenter.date_filter_string %>)</h3>
+<ul>
+  <% @presenter.depositors.each do |usr| %>
+    <li>
+      <% if usr[:user] %>
+        <a href="<%= hyrax.profile_path(usr[:key]) %>" title="View user's profile"><%= usr[:user].name %></a>
+        deposited <%= pluralize(usr[:deposits], "file") %>
+      <% else %>
+        <%= "Unknown User ID #{usr[:key]}" %>
+        deposited <%= pluralize(usr[:deposits], "file") %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/spec/services/hyrax/statistics/depositors/summary_spec.rb
+++ b/spec/services/hyrax/statistics/depositors/summary_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::Statistics::Depositors::Summary do
+  let(:user) { FactoryBot.create(:user) }
+  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
+  it "does not raise an exception when a user has been deleted" do
+    expect(etd.depositor).to eq(user.user_key)
+    user.ppid = "changed"
+    user.save
+    expect { described_class.new(nil, nil).depositors }.not_to raise_exception
+  end
+end


### PR DESCRIPTION
Fixes #764 

I wish I could figure out how to override less of summary.rb, since I really only need to remove one line. Any suggestions welcome.

<img width="722" alt="show_stat____emory_electronic_theses_and_dissertations" src="https://user-images.githubusercontent.com/65608/33389478-f2a0d320-d500-11e7-8348-a63dc89b4bdd.png">
