### PR TITLE
Catch and report logging errors in ContentEventJob

### DIFF
--- a/app/jobs/content_event_job.rb
+++ b/app/jobs/content_event_job.rb
@@ -1,0 +1,34 @@
+# We keep getting errors in our background jobs saying
+# "undefined method `log_profile_event' for nil:NilClass". It seems that the depositor
+# is not being passed to this job as expected. Until we can track that down properly,
+# I am overriding the job here and reporting the error to Honeybadger. However, I don't want
+# the job itself to fail because it can't log.
+#
+# A generic job for sending events about repository objects to a user and their followers.
+#
+# @attr [String] repo_object the object event is specified for
+#
+require 'honeybadger'
+
+class ContentEventJob < EventJob
+  attr_reader :repo_object
+  def perform(repo_object, depositor)
+    @repo_object = repo_object
+    super(depositor)
+    log_event(repo_object)
+  end
+
+  # Log the event to the object's stream
+  def log_event(repo_object)
+    repo_object.log_event(event)
+  rescue => exception
+    Honeybadger.notify(exception)
+  end
+
+  # log the event to the users profile stream
+  def log_user_event(depositor)
+    depositor.log_profile_event(event)
+  rescue => exception
+    Honeybadger.notify(exception)
+  end
+end

--- a/spec/jobs/content_event_job_spec.rb
+++ b/spec/jobs/content_event_job_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+describe ContentEventJob do
+  let(:depositor) { FactoryBot.create(:user) }
+  it "does not fail when logging an event" do
+    expect { FileSetAttachedEventJob.new.log_user_event(depositor) }.not_to raise_exception
+  end
+end


### PR DESCRIPTION
Connected to #836 

Just in case these exceptions are preventing the job from completing successfully, let's catch and report them, but not leave them as a raised exception.