### PR TITLE
Standardizes attaching files in features.

### DIFF
--- a/spec/features/create_etd_review_spec.rb
+++ b/spec/features/create_etd_review_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Create an Etd' do
       expect(page).to have_content('Add Primary PDF')
 
       within('#fileupload') do
-        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf")
+        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf", visible: false, wait: 10)
       end
 
       expect(page).to have_css('li#required-files.complete')
@@ -66,7 +66,7 @@ RSpec.feature 'Create an Etd' do
       expect(page).to have_content('Add Supplemental Files')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
 
       expect(page).to have_css('li#required-supplemental-files.incomplete')
@@ -174,7 +174,7 @@ RSpec.feature 'Create an Etd' do
       expect(page).to have_content('Add Primary PDF')
 
       within('#fileupload') do
-        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf")
+        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf", visible: false, wait: 10)
       end
 
       expect(page).to have_css('li#required-files.complete')
@@ -184,7 +184,7 @@ RSpec.feature 'Create an Etd' do
       expect(page).to have_content('Add Supplemental Files')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
 
       expect(page).to have_css('li#required-supplemental-files.incomplete')
@@ -295,7 +295,7 @@ RSpec.feature 'Create an Etd' do
       click_on('My PDF')
 
       within('#fileupload') do
-        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf")
+        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf", visible: false, wait: 10)
       end
 
       expect(page).to have_css('li#required-files.complete')

--- a/spec/features/upload_files_spec.rb
+++ b/spec/features/upload_files_spec.rb
@@ -18,14 +18,14 @@ RSpec.feature 'Primary PDF' do
       expect(page).to have_content('Add Primary PDF')
 
       within('#fileupload') do
-        page.attach_file('primary_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('primary_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
 
       expect(page).to have_content('The primary file must be in the PDF format.')
       expect(page).to have_css('li#required-files.incomplete')
 
       within('#fileupload') do
-        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf")
+        page.attach_file('primary_files[]', "#{fixture_path}/miranda/miranda_thesis.pdf", visible: false, wait: 10)
       end
 
       expect(page).not_to have_content('The Primary PDF must be a file in the .pdf format.')

--- a/spec/features/upload_supplemental_files_spec.rb
+++ b/spec/features/upload_supplemental_files_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Supplemental files' do
       expect(page).not_to have_content('File Name')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
 
       expect(page).to have_content('Required Metadata')
@@ -42,12 +42,12 @@ RSpec.feature 'Supplemental files' do
       click_on('Supplemental Files')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
       wait_for_ajax
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
       wait_for_ajax
       expect(page).to have_content('Duplicate found. This file has already been uploaded.')
@@ -57,7 +57,7 @@ RSpec.feature 'Supplemental files' do
       click_on('Supplemental Files')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
 
       expect(page).to have_content('magic_warrior_cat.jpg')
@@ -74,12 +74,12 @@ RSpec.feature 'Supplemental files' do
       click_on('Supplemental Files')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
       expect(page).to have_select('etd[supplemental_file_metadata][0]file_type')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/nasa.jpeg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/nasa.jpeg", visible: false, wait: 10)
       end
       expect(page).to have_select('etd[supplemental_file_metadata][1]file_type')
 
@@ -102,12 +102,12 @@ RSpec.feature 'Supplemental files' do
       expect(page).to have_content('Add Supplemental Files')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
       end
       expect(page).to have_select('etd[supplemental_file_metadata][0]file_type')
 
       within('#supplemental_fileupload') do
-        page.attach_file('supplemental_files[]', "#{fixture_path}/nasa.jpeg")
+        page.attach_file('supplemental_files[]', "#{fixture_path}/nasa.jpeg", visible: false, wait: 10)
       end
       expect(page).to have_select('etd[supplemental_file_metadata][1]file_type')
 

--- a/spec/features/validate_new_etd_supplemental_files_spec.rb
+++ b/spec/features/validate_new_etd_supplemental_files_spec.rb
@@ -16,7 +16,9 @@ RSpec.feature 'Form Validation: "Supplemental Files" tab' do
       expect(page).to have_css('li#required-supplemental-files.incomplete')
 
       # Student uploads a file and fills in some of the metadata fields
-      page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg")
+      within('#supplemental_fileupload') do
+        page.attach_file('supplemental_files[]', "#{fixture_path}/magic_warrior_cat.jpg", visible: false, wait: 10)
+      end
       expect(page).to have_css("input[name='etd[supplemental_file_metadata][0]title']")
       fill_in name: 'etd[supplemental_file_metadata][0]title', with: 'supp title'
       fill_in name: 'etd[supplemental_file_metadata][0]description', with: 'supp desc'


### PR DESCRIPTION
Always uses a `within` block, and adds `visibility: false, wait: 10` to each `#attach_file`