### PR TITLE
Cleanup temp files

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -38,3 +38,8 @@ end
 every :day, at: '11:55pm' do
   rake "blacklight:delete_old_searches[1]"
 end
+
+# Remove files in /tmp owned by the deploy user that are older than 7 days
+every :day, at: '1:00am' do
+  command "/usr/bin/find /tmp -type f -mtime +7 -user deploy -execdir /bin/rm -- {} \\;"
+end


### PR DESCRIPTION
browse-everything, imagemagick and ffmpeg
all leave temporary files in /tmp, which
eventually fill up the disk. This cron
job cleans up files owned by the deploy
user from /tmp that are older than seven
days.

Closes #850 