### PR TITLE
ProQuest export fixes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,6 @@ module Laevigata
     config.generators do |g|
       g.test_framework :rspec, spec: true
     end
-    # Run jobs inline
     config.active_job.queue_adapter = :sidekiq
     config.autoload_paths += %W[#{config.root}/lib]
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,5 +1,6 @@
 #config/solr_wrapper_test.yml
 version: 6.6.2
+download_dir: /var/tmp
 port: 8985
 instance_dir: tmp/solr-test
 collection:

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -1,4 +1,5 @@
 require 'etd_factory'
+Rails.application.config.active_job.queue_adapter = :inline
 
 namespace :sample_data do
   desc "Build basic sample data"
@@ -183,7 +184,7 @@ namespace :sample_data do
     puts "Exporting sample ProQuest package"
     etd = proquest_demo
     ProquestJob.perform_now(etd)
-    export_location = Rails.configuration.proquest_export_directory.join("#{etd.export_id}.zip").to_s
+    export_location = "#{etd.export_directory}/#{etd.upload_file_id}.zip"
     puts "ProQuest sample exported to #{export_location}"
   end
 

--- a/spec/models/proquest_behaviors_etd_spec.rb
+++ b/spec/models/proquest_behaviors_etd_spec.rb
@@ -70,14 +70,46 @@ RSpec.describe Etd do
     it "gets the primary pdf filename" do
       expect(etd.primary_pdf_file_name).to eq "joey_thesis.pdf"
     end
+    it "starts export package with upload_" do
+      expect(etd.upload_file_id).to match(/^upload_/)
+    end
+    it "names data file according to ProQuest specs" do
+      expect(etd.xml_filename).to match(/_DATA.xml/)
+    end
+    it "names the supplemental files dir as directed" do
+      expect(etd.supplemental_files_directory).to match(/_Media/)
+    end
     context "exporting packages" do
       it "zips the exported directory" do
         allow(etd).to receive(:depositor).and_return("P0000002")
         etd.export_zipped_proquest_package
-        export_file = "#{etd.export_directory}/#{etd.export_id}.zip"
+        export_file = "#{etd.export_directory}/#{etd.upload_file_id}.zip"
         expect(File.exist?(export_file)).to eq true
         File.delete(export_file)
       end
+    end
+  end
+
+  context "proquest embargo codes" do
+    it "no embargo" do
+      etd.embargo_length = nil
+      expect(etd.embargo_code).to eq 0
+    end
+    it "6 months" do
+      etd.embargo_length = "6 months"
+      expect(etd.embargo_code).to eq 1
+    end
+    it "1 year" do
+      etd.embargo_length = "1 year"
+      expect(etd.embargo_code).to eq 2
+    end
+    it "2 years" do
+      etd.embargo_length = "2 years"
+      expect(etd.embargo_code).to eq 3
+    end
+    it "6 years" do
+      etd.embargo_length = "6 years"
+      expect(etd.embargo_code).to eq 4
     end
   end
 
@@ -123,7 +155,7 @@ RSpec.describe Etd do
 
   context "DISS_accept_date" do
     it "formats the degree awarded date as expected" do
-      expect(etd.proquest_diss_accept_date).to eq etd.degree_awarded.strftime("%d/%m/%Y")
+      expect(etd.proquest_diss_accept_date).to eq etd.degree_awarded.strftime("%m/%d/%Y")
     end
   end
 


### PR DESCRIPTION
Exported package should be named as upload_*.zip
Exported XML file should be named as *_DATA.xml
Page number should default to 1 if page number cannot
be determined.
Add publishing_option and embargo_code to DISS_submission
Add DISS_processing_code
Put supplemental files in their own directory
Sample data rake task should run background jobs inline

Fixes #737 