### PR TITLE
Bugfix: admin sets should display when description is empty

### DIFF
--- a/app/views/hyrax/collections/_collection_description.erb
+++ b/app/views/hyrax/collections/_collection_description.erb
@@ -1,0 +1,3 @@
+<% presenter.description.try(:each) do |description| %>
+    <p class="collection_description"><%= iconify_auto_link(description) %></p>
+<% end %>

--- a/spec/features/show_admin_set_spec.rb
+++ b/spec/features/show_admin_set_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'show admin set' do
+  let(:admin_set) { FactoryBot.create(:admin_set) }
+  let(:admin) { FactoryBot.create(:admin) }
+
+  scenario "show admin set" do
+    login_as admin
+    visit("/admin/admin_sets/#{admin_set.id}")
+    expect(page).to have_content admin_set.title.first
+  end
+end


### PR DESCRIPTION
Fixes #856 