### PR TITLE
Updates error message for unpublished ETDs

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -22,6 +22,8 @@ en:
       form_files:
         external_upload: "Upload Large Files"
         local_upload: "Upload Small Files"
+    workflow:
+        unauthorized: "The work is not currently available because it has not yet completed the publishing process"
     works:
       progress:
         header: "Submission Checklist"

--- a/spec/features/candler_workflow_etd_spec.rb
+++ b/spec/features/candler_workflow_etd_spec.rb
@@ -87,12 +87,12 @@ RSpec.feature 'Candler approval workflow' do
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content(etd.abstract.first)
-      expect(page).not_to have_content("The work is not currently available")
+      expect(page).not_to have_content("The work is not currently available because it has not yet completed the publishing process")
 
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")
-      expect(page).to have_content "The work is not currently available"
+      expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Run the graduation service
       allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
@@ -100,7 +100,7 @@ RSpec.feature 'Candler approval workflow' do
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")
-      expect(page).not_to have_content "The work is not currently available"
+      expect(page).not_to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Check for graduation notifications
       login_as depositing_user

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -110,12 +110,12 @@ RSpec.feature 'Laney Graduate School two step approval workflow' do
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content(etd.abstract.first)
-      expect(page).not_to have_content("The work is not currently available")
+      expect(page).not_to have_content("The work is not currently available because it has not yet completed the publishing process")
 
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")
-      expect(page).to have_content "The work is not currently available"
+      expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Run the graduation service
       allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
@@ -123,7 +123,7 @@ RSpec.feature 'Laney Graduate School two step approval workflow' do
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")
-      expect(page).not_to have_content "The work is not currently available"
+      expect(page).not_to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Check for graduation notifications
       login_as depositing_user

--- a/spec/features/rollins_workflow_etd_spec.rb
+++ b/spec/features/rollins_workflow_etd_spec.rb
@@ -87,12 +87,12 @@ RSpec.feature 'Create a Rollins ETD' do
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content(etd.abstract.first)
-      expect(page).not_to have_content("The work is not currently available")
+      expect(page).not_to have_content("The work is not currently available because it has not yet completed the publishing process")
 
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")
-      expect(page).to have_content "The work is not currently available"
+      expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Run the graduation service
       allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
@@ -100,7 +100,7 @@ RSpec.feature 'Create a Rollins ETD' do
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")
-      expect(page).not_to have_content "The work is not currently available"
+      expect(page).not_to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Check for graduation notifications
       login_as depositing_user

--- a/spec/features/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/features/undergrad_honors_workflow_etd_spec.rb
@@ -80,12 +80,12 @@ RSpec.feature 'Emory College approval workflow' do
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content(etd.abstract.first)
-      expect(page).not_to have_content("The work is not currently available")
+      expect(page).not_to have_content("The work is not currently available because it has not yet completed the publishing process")
 
       # Visit the ETD as a public user. It should not be visible.
       logout
       visit("/concern/etds/#{etd.id}")
-      expect(page).to have_content "The work is not currently available"
+      expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Run the graduation service
       allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
@@ -93,7 +93,7 @@ RSpec.feature 'Emory College approval workflow' do
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")
-      expect(page).not_to have_content "The work is not currently available"
+      expect(page).not_to have_content "The work is not currently available because it has not yet completed the publishing process"
 
       # Check for graduation notifications
       login_as depositing_user


### PR DESCRIPTION
Our workflow finishes with publishing, rather than approval, and this new message reflects that.

Fixes emory-libraries/etd-issues#23