### PR TITLE
Do not submit hidden works to ProQuest

### DIFF
--- a/app/jobs/proquest_job.rb
+++ b/app/jobs/proquest_job.rb
@@ -31,6 +31,8 @@ class ProquestJob < ActiveJob::Base
   # @param [ActiveFedora::Base] work - the work object
   # @return [Boolean]
   def self.submit_to_proquest?(work)
+    # Do not submit hidden works
+    return false if work.hidden
     # Condition 0: Has is already been submitted to ProQuest?
     return false if work.proquest_submission_date.first.instance_of?(Date)
     # Condition 1: Is it from Laney Graduate School?

--- a/spec/jobs/proquest_job_spec.rb
+++ b/spec/jobs/proquest_job_spec.rb
@@ -48,5 +48,11 @@ describe ProquestJob do
       expect(etd.degree_awarded).to be_instance_of(Date)
       expect(described_class.submit_to_proquest?(etd)).to eq true
     end
+    it "does not submit a hidden work" do
+      etd.hidden = true
+      etd.save
+      expect(etd.hidden).to eq true
+      expect(described_class.submit_to_proquest?(etd)).to eq false
+    end
   end
 end


### PR DESCRIPTION
If a work is marked as hidden, exclude it from
ProQuest submission.

Closes #879 