### PR TITLE
Assign admin set according to subfield when necessary

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -58,12 +58,13 @@ class Etd < ActiveFedora::Base
   # Determine what admin set an ETD should belong to, based on what school and
   # department it belongs to
   # @return [String] the name of an admin set
-  def determine_admin_set(school = self.school, department = self.department)
+  def determine_admin_set(school = self.school, department = self.department, subfield = self.subfield)
     valid_admin_sets = YAML.safe_load(File.read(WorkflowSetup::DEFAULT_ADMIN_SETS_CONFIG)).keys
     admin_set_determined_by_school = ["Laney Graduate School", "Candler School of Theology", "Emory College"]
     return school.first if admin_set_determined_by_school.include?(school.first) && valid_admin_sets.include?(school.first)
     return department.first if valid_admin_sets.include?(department.first)
-    raise "Cannot find admin set config where school = #{school.first} and department = #{department.first}"
+    return subfield.first if valid_admin_sets.include?(subfield.first)
+    raise "Cannot find admin set config where school = #{school.first} and department = #{department.first} and subfield = #{subfield.first}"
   end
 
   # Assign an admin_set based on what is returned by #determine_admin_set

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Etd do
       etd.department = ["Epidemiology"]
       expect(etd.determine_admin_set).to eq "Epidemiology"
     end
+    it "assigns according to subfield for Rollins when necessary" do
+      etd.school = ["Rollins School of Public Health"]
+      etd.department = ["Environmental Health"]
+      etd.subfield = ["Environmental Health - MPH"]
+      expect(etd.determine_admin_set).to eq "Environmental Health - MPH"
+    end
     it "raises an error if it can't find the admin set in the config" do
       etd.school = ["Fake School"]
       expect { etd.determine_admin_set }.to raise_error(RuntimeError, /Cannot find admin set config/)


### PR DESCRIPTION
Sometimes it isn't possible to know the admin set just from the
school and department, we must also look at the subfield.

Fixes #844 