### PR TITLE
Graduation date is a string, not a Date

### DIFF
--- a/app/jobs/proquest_job.rb
+++ b/app/jobs/proquest_job.rb
@@ -34,13 +34,13 @@ class ProquestJob < ActiveJob::Base
     # Do not submit hidden works
     return false if work.hidden
     # Condition 0: Has is already been submitted to ProQuest?
-    return false if work.proquest_submission_date.first.instance_of?(Date)
+    return false unless work.proquest_submission_date.empty?
     # Condition 1: Is it from Laney Graduate School?
     return false unless work.school.first == "Laney Graduate School"
     # Condition 2: Has it been approved?
     return false unless work.to_sipity_entity.workflow_state_name == 'approved'
     # Condition 3: Has the degree been awarded?
-    return false unless work.degree_awarded.instance_of?(Date)
+    return false unless work.degree_awarded
     # Condition 4: Is this a PhD?
     return true if work.degree.first == "PhD"
     # Condition 5: Or is this a Master's student who has chosen to submit?

--- a/app/models/proquest_behaviors.rb
+++ b/app/models/proquest_behaviors.rb
@@ -122,11 +122,11 @@ module ProquestBehaviors
   end
 
   def proquest_diss_accept_date
-    degree_awarded.strftime("%m/%d/%Y")
+    Date.parse(degree_awarded.to_s).strftime("%m/%d/%Y")
   end
 
   def proquest_diss_comp_date
-    degree_awarded.strftime("%Y")
+    Date.parse(degree_awarded.to_s).strftime("%Y")
   end
 
   def proquest_code(field_name)

--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -153,7 +153,7 @@ FactoryBot.define do
       end
       factory :ready_for_proquest_submission_phd do
         title ["ProQuest PhD: #{FFaker::Book.title}"]
-        degree_awarded { Time.zone.today - 1.week }
+        degree_awarded { (Time.zone.today - 1.week).strftime('%Y-%m-%d') }
         submitting_type { [] << "Dissertation" }
         school ["Laney Graduate School"]
         admin_set do

--- a/spec/jobs/proquest_job_spec.rb
+++ b/spec/jobs/proquest_job_spec.rb
@@ -45,7 +45,8 @@ describe ProquestJob do
       expect(etd.school).to contain_exactly("Laney Graduate School")
       expect(etd.degree).to contain_exactly("PhD")
       expect(etd.to_sipity_entity.workflow_state_name).to eq "approved"
-      expect(etd.degree_awarded).to be_instance_of(Date)
+      expect(etd.proquest_submission_date).to be_empty
+      expect(etd.degree_awarded).not_to be_empty
       expect(described_class.submit_to_proquest?(etd)).to eq true
     end
     it "does not submit a hidden work" do

--- a/spec/models/proquest_behaviors_etd_spec.rb
+++ b/spec/models/proquest_behaviors_etd_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Etd do
 
   context "DISS_accept_date" do
     it "formats the degree awarded date as expected" do
-      expect(etd.proquest_diss_accept_date).to eq etd.degree_awarded.strftime("%m/%d/%Y")
+      expect(etd.proquest_diss_accept_date).to eq Date.parse(etd.degree_awarded.to_s).strftime("%m/%d/%Y")
     end
   end
 


### PR DESCRIPTION
Check for graduation date more broadly. Check
for its existence, not specifically for whether it
is a Date object.
Fix test factory to better mimic what we see from
registrar data. (A string, not a Date object)

Fixes #893 