### PR TITLE
Enforce embargoes whether they are strings or booleans

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -29,16 +29,31 @@ class SolrDocument
     self[Solrizer.solr_name('abstract')]
   end
 
+  # If this is a boolean, return the boolean value
+  # If this is a string, transform it into a boolean
+  # If the value is nil or can't be determined, assume it is embargoed
   def abstract_embargoed
-    self['abstract_embargoed_bsi']
+    return self['abstract_embargoed_bsi'] if self['abstract_embargoed_bsi']
+    return self['abstract_embargoed_tesim'].first.to_s == "true" if self['abstract_embargoed_tesim']
+    true
   end
 
+  # If this is a boolean, return the boolean value
+  # If this is a string, transform it into a boolean
+  # If the value is nil or can't be determined, assume it is embargoed
   def toc_embargoed
-    self['toc_embargoed_bsi']
+    return self['toc_embargoed_bsi'] if self['toc_embargoed_bsi']
+    return self['toc_embargoed_tesim'].first.to_s == "true" if self['toc_embargoed_tesim']
+    true
   end
 
+  # If this is a boolean, return the boolean value
+  # If this is a string, transform it into a boolean
+  # If the value is nil or can't be determined, assume it is embargoed
   def files_embargoed
-    self['files_embargoed_bsi']
+    return self['files_embargoed_bsi'] if self['files_embargoed_bsi']
+    return self['files_embargoed_tesim'].first.to_s == "true" if self['files_embargoed_tesim']
+    true
   end
 
   def table_of_contents

--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -126,9 +126,9 @@ FactoryBot.define do
         title ["Sample Data With Full Embargo: #{FFaker::Book.title}"]
         embargo { FactoryBot.create(:embargo, embargo_release_date: (Time.zone.today + 14.days)) }
         embargo_length "6 months"
-        files_embargoed true
-        abstract_embargoed true
-        toc_embargoed true
+        files_embargoed "true"
+        abstract_embargoed "true"
+        toc_embargoed "true"
 
         factory :sixty_day_expiration do
           degree_awarded { Time.zone.today - 2.years }


### PR DESCRIPTION
We have three fields that we use to determine what has been embargoed. Unfortunately, the application is not consistent about whether these should be a string value of "true" or a boolean value of `true`. This PR ensures that the presenter can interpret either case.

Fixes #897 