### PR TITLE
Align Rollins programs with admin sets

### DIFF
--- a/config/authorities/environmental_programs.yml
+++ b/config/authorities/environmental_programs.yml
@@ -1,7 +1,7 @@
 terms:
     - id: Environmental Health - MPH
       term: Environmental Health - MPH
-    - id: Environmental Health Epidemiology -  MSPH
-      term: Environmental Health Epidemiology -  MSPH
+    - id: Environmental Health Epidemiology - MPH & MSPH
+      term: Environmental Health Epidemiology - MPH & MSPH
     - id: Global Environmental Health - MPH
       term: Global Environmental Health - MPH

--- a/config/authorities/rollins_programs.yml
+++ b/config/authorities/rollins_programs.yml
@@ -1,7 +1,12 @@
+# NOTE: If you want to change the name of a program, change the term value, 
+# but NOT the id value. Id values must match the admin sets that are expected.
+# If you are adding a new option, you must also ensure it is added to 
+# `config/emory/admin_sets.yml`, both in this code base and on every server
+# where this code is deployed.
 terms:
-    - id: Behavioral Sciences & Health Education - MPH
+    - id: Behavioral Sciences and Health Education
       term: Behavioral Sciences & Health Education - MPH
-    - id: Biostatistics and Bioinformatics
+    - id: Biostatistics
       term: Biostatistics and Bioinformatics
     - id: Environmental Health
       term: Environmental Health
@@ -9,7 +14,7 @@ terms:
       term: Epidemiology
     - id: Executive Masters of Public Health - MPH
       term: Executive Masters of Public Health - MPH
-    - id: Health Policy and Management - MSPH
+    - id: Health Policy and Management
       term: Health Policy and Management - MSPH
-    - id: Hubert Department of Global Health - MPH
+    - id: Hubert Department of Global Health
       term: Hubert Department of Global Health - MPH 

--- a/config/emory/admin_sets.yml
+++ b/config/emory/admin_sets.yml
@@ -33,6 +33,9 @@ Environmental Health Epidemiology - MPH & MSPH:
 Epidemiology:
   approving:
    - epidemiology_admin
+Executive Masters of Public Health - MPH:
+  approving:
+  - executive_masters_public_health_admin
 Global Environmental Health - MPH:
   approving:
    - global_environmental_health_admin

--- a/spec/fixtures/config/emory/admin_sets.yml
+++ b/spec/fixtures/config/emory/admin_sets.yml
@@ -18,19 +18,19 @@ Applied Epidemiology:
 Applied Public Health Informatics:
   approving:
    - applied_public_health_informatics_admin
-Behavioral Sciences & Health Education - MPH:
+Behavioral Sciences and Health Education:
   approving:
    - behavioral_sciences_and_health_education_admin
-Biostatistics - MPH & MSPH:
+Biostatistics:
   approving:
    - biostatistics_admin
 Biostatistics and Bioinformatics:
   approving:
    - biostatistics_and_bioinformatics_admin
-Environmental Health:
+Environmental Health - MPH:
   approving:
    - environmental_health_admin
-Environmental Health Epidemiology - MSPH:
+Environmental Health Epidemiology - MPH & MSPH:
   approving:
    - environmental_health_epidemiology_admin
 Epidemiology:
@@ -48,10 +48,10 @@ Global Epidemiology - MPH & MSPH:
 Health Care Outcomes Management:
   approving:
    - health_care_outcomes_management_admin
-Health Policy and Management - MSPH:
+Health Policy and Management:
   approving:
    - health_policy_and_management
-Hubert Department of Global Health - MPH:
+Hubert Department of Global Health:
   approving:
    - hubert_department_of_global_health_admin
 Management Science:

--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -81,8 +81,10 @@ RSpec.describe WorkflowSetup do
   context "admin_set config" do
     it "has an array of all the admin_sets" do
       expect(w.admin_sets).to include("Laney Graduate School", "Emory College", "Candler School of Theology")
-      rollins_programs = YAML.safe_load(File.read("#{::Rails.root}/config/authorities/rollins_programs.yml"))
-      rollins_programs["terms"].map { |p| p["id"] }.each do |program_name|
+      config = YAML.safe_load(File.read(Rails.root.join('config', 'authorities', 'rollins_programs.yml')))
+      rollins_programs = config["terms"].map { |a| a["id"] }
+      rollins_programs.each do |program_name|
+        next if program_name == "Environmental Health"
         expect(w.admin_sets).to include(program_name)
       end
     end


### PR DESCRIPTION
Add tests so we know we have an admin set
for each option in the Rollins drop down menus.

Ultimately, we need to check our admin set config
info version control and really test against it
so things can't get out of sync, but this should
help in the meantime.

Fixes #901 