### PR TITLE
Add a published step to workflow so admins can see published works

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,10 @@ Rails/FindBy:
 
 RSpec/ExampleLength:
   Enabled: false
+  
+RSpec/MessageSpies:
+  Exclude:
+    - 'spec/controllers/hyrax/admin/workflows_controller_spec.rb'
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -1,0 +1,31 @@
+# Overridden from Hyrax 1.0.5: app/controllers/hyrax/admin/workflows_controller.rb
+# Needed to override this here to change the value of `deposited_workflow_state_name`
+
+module Hyrax
+  # Presents a list of works in workflow
+  class Admin::WorkflowsController < ApplicationController
+    before_action :ensure_admin!
+    layout 'admin'
+
+    def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.toolbar.admin.menu'), hyrax.admin_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
+      add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
+      @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
+      @published_list = Hyrax::Workflow::StatusListService.new(self, "workflow_state_name_ssim:#{deposited_workflow_state_name}")
+    end
+
+    private
+
+      def ensure_admin!
+        # Even though the user can view this admin set, they may not be able to view
+        # it on the admin page.
+        authorize! :read, :admin_dashboard
+      end
+
+      def deposited_workflow_state_name
+        'published'
+      end
+  end
+end

--- a/app/services/regraduation_service.rb
+++ b/app/services/regraduation_service.rb
@@ -1,11 +1,14 @@
-# An automated service that:
+# A manual job meant for (hopefully) one time use.
+# Does everything that graduation job does but does it even if the person has a graduation date recorded already.
+# This is so we can re-process all the graudates in our first graduation run who didn't
+# have proquest packages sent, or have their workflow updated correctly
 # 1. Checks the repository for works in the `approved` workflow state but which have no `degree_awarded` value
 # 2. For each of these works, query the registrar data to see if the student has graduated
 # 3. If so, call GraduationJob for the given work and the graduation_date returned by registrar data
 # @param [String] The path to the data JSON file. Expects location of registrar data to be set in REGISTRAR_DATA_PATH, e.g., in .env.production
 # @example How to call this service
-#  GraduationService.run
-class GraduationService
+#  RegraduationService.run
+class RegraduationService
   def self.run(registrar_data_path = ENV['REGISTRAR_DATA_PATH'])
     raise "Cannot find registrar data" unless registrar_data_path && File.file?(registrar_data_path)
     Rails.logger.info("Running graduation service with file #{registrar_data_path}")
@@ -14,7 +17,6 @@ class GraduationService
       degree_awarded_date = GraduationService.check_degree_status(work)
       GraduationJob.perform_later(work.id, degree_awarded_date.to_s) if degree_awarded_date
     end
-    remove_instance_variable(:@registrar_data)
   end
 
   # Load the Registrar's data from the JSON file.
@@ -23,12 +25,12 @@ class GraduationService
     @registrar_data = JSON.parse(File.read(path_to_data))
   end
 
-  # Find all Etds in the 'approved' workflow state that do not yet have a degree_awarded value
+  # Find all Etds in the 'approved' workflow state that have a degree awarded in 2018
   # @return [Array<Etd>] An Array of ETD objects
   def self.graduation_eligible_works
     eligible_works = []
     problem_works = []
-    no_degree_yet = Etd.where(degree_awarded: nil).to_a
+    no_degree_yet = Etd.where(degree_awarded: "2018-*").to_a
     no_degree_yet.each do |etd|
       begin
         eligible_works << etd if etd.to_sipity_entity.workflow_state_name == 'approved'

--- a/app/views/hyrax/base/_workflow_actions.html.erb
+++ b/app/views/hyrax/base/_workflow_actions.html.erb
@@ -1,0 +1,43 @@
+<!-- Overriding this from Hyrax 1.0.5 because although we need a Publish workflow step,
+We should never call it from the UI. It should only be triggered by a graduation event. -->
+<div id="workflow_controls"class="panel panel-default workflow-affix">
+  <div class="panel-heading">
+    <a data-toggle="collapse" href="#workflow_controls_collapse">
+      <h2 class="panel-title">Review and Approval</h2>
+    </a>
+  </div>
+  <div id="workflow_controls_collapse" class="row panel-body panel-collapse collapse">
+    <%= form_tag main_app.hyrax_workflow_action_path(presenter), method: :put do %>
+      <div class="col-sm-3 workflow-actions">
+        <h3>Actions</h3>
+
+        <% presenter.workflow.actions.each do |key, label| %>
+          <% unless key == "publish" %>
+            <div class="radio">
+              <label>
+                <input type="radio" name="workflow_action[name]" id="workflow_action_name_<%= key %>" value="<%= key %>">
+                <%= label %>
+              </label>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="col-sm-9 workflow-comments">
+        <div class="form-group">
+          <label for="workflow_action_comment">Review comment:</label>
+          <textarea class="form-control" name="workflow_action[comment]" id="workflow_action_comment"></textarea>
+        </div>
+
+        <input class="btn btn-primary" type="submit" value="Submit">
+
+        <h4>Previous Comments</h4>
+        <dl>
+          <% presenter.workflow.comments.each do |comment| %>
+            <dt><%= comment.name_of_commentor %></dt>
+            <dd><%= comment.comment %></dd>
+          <% end %>
+        </dl>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/emory/superusers.yml
+++ b/config/emory/superusers.yml
@@ -1,6 +1,5 @@
 superusers:
   database:
    - bess
-   - alicia
   shibboleth:
    - tezprox # tezprox

--- a/config/workflows/emory_one_step_approval.json
+++ b/config/workflows/emory_one_step_approval.json
@@ -53,6 +53,13 @@
                       "Hyrax::Workflow::RevokeEditFromDepositor"
                     ]
                 }, {
+                    "name": "publish",
+                    "from_states": [{"names": ["approved"], "roles": []}],
+                    "transition_to": "published",
+                    "methods": [
+                      "Hyrax::Workflow::ActivateObject"
+                    ]
+                }, {
                     "name": "request_review",
                     "from_states": [{"names": ["changes_required"], "roles": ["depositing"]}],
                     "transition_to": "pending_approval",

--- a/config/workflows/laney_graduate_school.json
+++ b/config/workflows/laney_graduate_school.json
@@ -86,6 +86,13 @@
                       "Hyrax::Workflow::DeactivateObject"
                     ]
                 }, {
+                    "name": "publish",
+                    "from_states": [{"names": ["approved"], "roles": []}],
+                    "transition_to": "published",
+                    "methods": [
+                      "Hyrax::Workflow::ActivateObject"
+                    ]
+                }, {
                     "name": "comment_only",
                     "from_states": [
                         { "names": ["pending_review", "pending_approval", "approved"], "roles": ["reviewing", "approving"] },

--- a/spec/jobs/graduation_job_spec.rb
+++ b/spec/jobs/graduation_job_spec.rb
@@ -28,11 +28,17 @@ describe GraduationJob do
       expect(etd.degree_awarded).to eq nil
       expect(etd.embargo.embargo_release_date).to eq six_years_from_today
       expect(etd.embargo_length).to eq "6 months"
-      described_class.perform_now(etd.id, Time.zone.tomorrow)
+      graduation_job = described_class.new
+      # Don't try to publish the object in this context, we haven't set up workflow here.
+      allow(graduation_job).to receive(:publish_object)
+      graduation_job.perform(etd.id, Time.zone.tomorrow)
       etd.reload
     end
     it "records the graduation date" do
       expect(etd.degree_awarded).to eq Time.zone.tomorrow
+    end
+    it "updates the depositor's email address" do
+      expect(depositing_user.email).to eq(etd.post_graduation_email.first)
     end
     it "resets the embargo_release_date" do
       expect(etd.embargo.embargo_release_date).to eq Time.zone.tomorrow + 6.months
@@ -42,6 +48,30 @@ describe GraduationJob do
     end
     it "sends notifications" do
       expect(Hyrax::Workflow::DegreeAwardedNotification).to have_received(:send_notification)
+    end
+  end
+  context "workflow transition" do
+    let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
+    let(:etd) { FactoryBot.create(:sample_data, school: ["Emory College"]) }
+    let(:depositing_user) { User.where(ppid: etd.depositor).first }
+    let(:approving_user) { User.where(uid: "ecadmin").first }
+    before do
+      allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
+      ActiveFedora::Cleaner.clean!
+      w.setup
+      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
+      actor.create({})
+
+      # The approving user approves the ETD before graduation
+      subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
+      sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
+      Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
+      described_class.perform_now(etd.id, Time.zone.today)
+    end
+    it "transitions the object's workflow to 'graduated' and makes it active (visible)" do
+      etd.reload
+      expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "published"
+      expect(etd.state).to eq Vocab::FedoraResourceStatus.active
     end
   end
 end


### PR DESCRIPTION
* Add a workflow step called published that objects use after the
student has graudated and the work has been made public.
* Override Hyrax workflow admin dashboard behavior to show admins
works in the published state.
* Make GraduationJob use this workflow state instead of just setting
the work to public.
* Make GraduationSerivce return fake graduation data in dev environment
so we can more easily test whether GraduationService is working
as expected.

Fixes #895 