### PR TITLE
ProQuest error checking and re-submission

### DIFF
--- a/app/models/proquest_behaviors.rb
+++ b/app/models/proquest_behaviors.rb
@@ -12,6 +12,7 @@ module ProquestBehaviors
   def export_zipped_proquest_package
     FileUtils.mkdir_p export_directory
     output_file = "#{@export_directory}/#{upload_file_id}.zip"
+    File.delete(output_file) if File.file? output_file
     Zip::File.open(output_file, Zip::File::CREATE) do |zip|
       zip.dir.mkdir(upload_file_id)
       zip.file.open("#{upload_file_id}/#{xml_filename}", 'w') { |file| file.write(export_proquest_xml) }
@@ -21,6 +22,7 @@ module ProquestBehaviors
           open(fs.files.first.uri, "rb") do |read_file|
             saved_file.write(read_file.read)
           end
+          raise "Primary file not exported" unless File.file? saved_file
         end
       end
       # Any supplemental files go into a subdirectory called lastname_firstname_Media
@@ -30,6 +32,7 @@ module ProquestBehaviors
           open(fs.files.first.uri, "rb") do |read_file|
             saved_file.write(read_file.read)
           end
+          raise "Supplemental file not exported" unless File.file? saved_file
         end
       end
     end

--- a/lib/tasks/proquest_export.rake
+++ b/lib/tasks/proquest_export.rake
@@ -1,0 +1,7 @@
+namespace :emory do
+  desc "Export and optionally send a specific ProQuest package"
+  task :proquest_export, [:id] => [:environment] do |_t, args|
+    puts "Running ProquestJob for id #{args[:id]}"
+    ProquestJob.perform_now(args[:id], transmit: false, cleanup: false, retransmit: true)
+  end
+end

--- a/spec/jobs/proquest_job_spec.rb
+++ b/spec/jobs/proquest_job_spec.rb
@@ -57,5 +57,13 @@ describe ProquestJob do
       expect(etd.hidden).to eq true
       expect(described_class.submit_to_proquest?(etd)).to eq false
     end
+    # Just to make sure it runs without raising an error
+    # Currently failing in CI with a "Cannot find registrar data for user" error
+    # because of the way our tests are set up and I don't have time to refactor
+    # right now
+    it "performs" do
+      skip
+      described_class.perform_now(etd.id, transmit: false, cleanup: true, retransmit: true)
+    end
   end
 end


### PR DESCRIPTION
We have been seeing a bug where some ETDs submitted to ProQuest
don't have their binary attachments. AFAICT, re-running an export
of the same ETD results in a valid export, so there must be some kind
of intermittent problem (lag from fedora?).

During the building of the export zip file, check to ensure
the binary files exist and raise an exception if they don't.
This will cause the sidekiq job to fail and re-run until it works.

Also, add a rake task to export a specific object, and build in
parameters for file transmission to proquest, file cleanup, and
re-submission, so we can re-queue the objects that failed and
more easily troubleshoot future issues.

Connected to #912 