### PR TITLE
Do not display user info

### DIFF
--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -1,0 +1,4 @@
+<!-- User info intentionally suppressed -->
+<dl id="user_info">
+
+</dl>

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     ppid { ActiveFedora::Noid::Service.new.mint }
     uid { FFaker::Internet.user_name }
     display_name { FFaker::Name.name }
+    email { FFaker::Internet.email }
 
     transient do
       # Allow for custom groups when a user is instantiated.

--- a/spec/features/show_user_spec.rb
+++ b/spec/features/show_user_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.feature 'show user profile' do
+  let(:user) { FactoryBot.create(:user) }
+
+  scenario "show user profile but not email address" do
+    visit("/users/#{user.user_key}")
+    expect(page).not_to have_content user.email
+  end
+end


### PR DESCRIPTION
Err on the side of privacy and do not display
any user info on the public user page.

Closes #920 