### PR TITLE
Box remote URLs sometimes result in an error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ group :development, :test do
   gem 'rspec-rails', "~> 3.5"
   gem 'shoulda-matchers'
   gem 'solr_wrapper', '>= 0.3'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.3)
     daemons (1.2.6)
     database_cleaner (1.6.2)
@@ -301,6 +303,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashdiff (0.3.2)
     hashie (3.5.7)
     hiredis (0.6.1)
     honeybadger (3.3.0)
@@ -733,6 +736,7 @@ GEM
       oauth2
     ruby-progressbar (1.9.0)
     rubyzip (1.2.1)
+    safe_yaml (1.0.4)
     sanitize (4.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
@@ -854,6 +858,7 @@ GEM
     uglifier (4.1.6)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -861,6 +866,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -933,7 +942,9 @@ DEPENDENCIES
   twitter-bootstrap-rails
   tzinfo-data
   uglifier (>= 1.3.0)
+  vcr
   web-console (>= 3.3.0)
+  webmock
   whenever
   xray-rails
   yard

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -1,0 +1,64 @@
+require 'uri'
+require 'tempfile'
+require 'browse_everything/retriever'
+
+# Given a FileSet that has an import_url property,
+# download that file and put it into Fedora
+# Called by AttachFilesToWorkJob (when files are uploaded to s3)
+# and CreateWithRemoteFilesActor when files are located in some other service.
+class ImportUrlJob < ActiveJob::Base
+  queue_as Hyrax.config.ingest_queue_name
+
+  before_enqueue do |job|
+    operation = job.arguments.last
+    operation.pending_job(job)
+  end
+
+  # @param [FileSet] file_set
+  # @param [Hyrax::BatchCreateOperation] operation
+  def perform(file_set, operation)
+    operation.performing!
+    user = User.find_by_user_key(file_set.depositor)
+
+    Tempfile.open(file_set.id.tr('/', '_')) do |f|
+      copy_remote_file(file_set, f)
+
+      # reload the FileSet once the data is copied since this is a long running task
+      file_set.reload
+
+      # We invoke the FileSetActor in a synchronous way so that this tempfile is available
+      # when IngestFileJob is invoked. If it was asynchronous the IngestFileJob may be invoked
+      # on a machine that did not have this temp file on it's file system.
+      # NOTE: The return status may be successful even if the content never attaches.
+      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f, 'original_file', false)
+        # send message to user on download success
+        Hyrax.config.callback.run(:after_import_url_success, file_set, user)
+        operation.success!
+      else
+        Hyrax.config.callback.run(:after_import_url_failure, file_set, user)
+        operation.fail!(file_set.errors.full_messages.join(' '))
+      end
+    end
+  end
+
+  class RetrievalError < RuntimeError; end
+
+  protected
+
+    def copy_remote_file(file_set, f)
+      f.binmode
+      # download file from url
+      uri = URI(file_set.import_url)
+      spec = { 'url' => uri }
+      retriever = BrowseEverything::Retriever.new
+      retriever.retrieve(spec) do |chunk|
+        # Check to see whether this is an error message
+        if chunk =~ /error_box/
+          Hyrax::Workflow::BoxErrorNotification.send_notification(file_set.parent.id)
+          raise RetrievalError, "Could not retrieve file from uri #{uri}"
+        end
+        f.write(chunk)
+      end
+      f.rewind
+    end
+end

--- a/app/services/hyrax/workflow/box_error_notification.rb
+++ b/app/services/hyrax/workflow/box_error_notification.rb
@@ -1,0 +1,49 @@
+require 'workflow_setup'
+
+module Hyrax
+  module Workflow
+    # Notification to a depositor that a file they attempted to attach from Box
+    # could not be retrieved.
+    # Should notify work depositor only.
+    class BoxErrorNotification
+      def self.send_notification(work_id)
+        BoxErrorNotification.new(work_id).call
+      end
+
+      def initialize(work_id)
+        @work = Etd.find(work_id)
+        @message = message
+        @subject = subject
+      end
+
+      def message
+        "Your ETD submission #{@work.title.first} has encountered an error during processing.
+
+        You recently attempted to attach a file from box.com to an ETD submission
+        at https://etd.library.emory.edu/concern/etds/#{@work.id}. Unfortunately, attempting to retrieve that
+        file from box.com resulted in an error. Please return to your ETD submission
+        and re-submit the file.
+
+        When you submit a file from Box.com, please leave the file in place on Box until
+        your ETD submission has been approved.
+        "
+      end
+
+      def subject
+        "Failed to attach file to #{@work.title.first}"
+      end
+
+      def call
+        user = ::User.find_or_create_by(uid: WorkflowSetup::NOTIFICATION_OWNER)
+        recipients.each do |recipient|
+          user.send_message(recipient, @message, @subject)
+        end
+      end
+
+      # Send this to the depositor only
+      def recipients
+        Array.wrap(::User.find_by_user_key(@work.depositor))
+      end
+    end
+  end
+end

--- a/spec/fixtures/box_error.html
+++ b/spec/fixtures/box_error.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!-- saved from url=(0049)https://etd.library.emory.edu/downloads/7m01bk68h -->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+  <title>Box - Free Online File Storage, Internet File Sharing, RSS Sharing, Access Documents &amp; Files Anywhere, Backup Data, Share Files</title>
+  <style type="text/css">
+	body, html {height: 100%;}
+
+	body
+	{
+		margin: 0;
+		padding: 0;
+		background: #F8FEFE url(https://static.box.com/bc/error/img/linear_g.gif) left top repeat-x;
+		font-family: Arial;
+	}
+
+	div.outer
+	{
+		height: 100%;
+		overflow: visible;
+	}
+
+	div.content
+	{
+		top: 40%;
+		position: relative;
+	}
+
+	div.error_box
+	{
+		top: -80px;
+		position: relative;
+		/*width: 510px;*/
+		margin: auto;
+		text-align: center;
+	}
+
+	div.error_box img
+	{
+		border: 0;
+	}
+
+	div.error_box div.message
+	{
+		margin: 50px auto 0 auto;
+		padding-top: 10px;
+		font-size: 12px;
+		color: #489BD9;
+		width: 510px;
+		line-height: 20px;
+		text-align: center;
+	}
+
+	div.error_box div.message a
+	{
+		text-decoration: none;
+		color: #489BD9;
+		background: url(https://static.box.com/bc/error/img/blue3_1px.gif) left bottom repeat-x;
+	}
+
+  </style>
+</head>
+
+<body>
+  <div class="outer">
+
+    <div class="content">
+      <div class="error_box">
+        <a href="http://www.box.com/" onmousedown="return false;"><img src="./box_error_files/logo150.png" alt="Box.com"></a>
+        <div class="message">
+			The link you're trying to access can't be used to share files. Please ask the file owner to provide you with a shared link instead.
+			<a href="http://www.box.com/help"> Contact Box Support if you need help. </a>
+        </div>
+	</div>
+    </div>
+  </div>
+
+ 
+
+
+</body></html>

--- a/spec/fixtures/vcr_cassettes/box_error.yml
+++ b/spec/fixtures/vcr_cassettes/box_error.yml
@@ -1,0 +1,1415 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/tq/57/nr/00/tq57nr00k
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Content-Length:
+      - '315'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:36 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/tq/57/nr/00/tq57nr00k
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Content-Length:
+      - '315'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:36 GMT
+- request:
+    method: head
+    uri: https://staging-etd.library.emory.edu/downloads/5h73pw048
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:37 GMT
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - e790a02b-0ed3-4ff3-bf79-516073bd0c9f
+      Accept-Ranges:
+      - bytes
+      X-Runtime:
+      - '0.078472'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 5.1.6
+      Content-Length:
+      - '1864'
+      Status:
+      - 200 OK
+      Content-Type:
+      - text/html
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:37 GMT
+- request:
+    method: get
+    uri: https://staging-etd.library.emory.edu/downloads/5h73pw048
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:37 GMT
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Cache-Control:
+      - private
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 29f91994-3b76-4ce3-8c59-ff414421f097
+      Content-Disposition:
+      - inline; filename="box_error.html"
+      Accept-Ranges:
+      - bytes
+      Content-Transfer-Encoding:
+      - binary
+      X-Runtime:
+      - '0.081616'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 5.1.6
+      Last-Modified:
+      - Fri, 16 Mar 2018 16:08:48 GMT
+      Content-Length:
+      - '1864'
+      Status:
+      - 200 OK
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - text/html
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<!--
+        saved from url=(0049)https://etd.library.emory.edu/downloads/7m01bk68h -->\n<html
+        xmlns=\"http://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\"><head><meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1252\">\n
+        \ <title>Box - Free Online File Storage, Internet File Sharing, RSS Sharing,
+        Access Documents &amp; Files Anywhere, Backup Data, Share Files</title>\n
+        \ <style type=\"text/css\">\n\tbody, html {height: 100%;}\n\n\tbody\n\t{\n\t\tmargin:
+        0;\n\t\tpadding: 0;\n\t\tbackground: #F8FEFE url(https://static.box.com/bc/error/img/linear_g.gif)
+        left top repeat-x;\n\t\tfont-family: Arial;\n\t}\n\n\tdiv.outer\n\t{\n\t\theight:
+        100%;\n\t\toverflow: visible;\n\t}\n\n\tdiv.content\n\t{\n\t\ttop: 40%;\n\t\tposition:
+        relative;\n\t}\n\n\tdiv.error_box\n\t{\n\t\ttop: -80px;\n\t\tposition: relative;\n\t\t/*width:
+        510px;*/\n\t\tmargin: auto;\n\t\ttext-align: center;\n\t}\n\n\tdiv.error_box
+        img\n\t{\n\t\tborder: 0;\n\t}\n\n\tdiv.error_box div.message\n\t{\n\t\tmargin:
+        50px auto 0 auto;\n\t\tpadding-top: 10px;\n\t\tfont-size: 12px;\n\t\tcolor:
+        #489BD9;\n\t\twidth: 510px;\n\t\tline-height: 20px;\n\t\ttext-align: center;\n\t}\n\n\tdiv.error_box
+        div.message a\n\t{\n\t\ttext-decoration: none;\n\t\tcolor: #489BD9;\n\t\tbackground:
+        url(https://static.box.com/bc/error/img/blue3_1px.gif) left bottom repeat-x;\n\t}\n\n
+        \ </style>\n</head>\n\n<body>\n  <div class=\"outer\">\n\n    <div class=\"content\">\n
+        \     <div class=\"error_box\">\n        <a href=\"http://www.box.com/\" onmousedown=\"return
+        false;\"><img src=\"./box_error_files/logo150.png\" alt=\"Box.com\"></a>\n
+        \       <div class=\"message\">\n\t\t\tThe link you're trying to access can't
+        be used to share files. Please ask the file owner to provide you with a shared
+        link instead.\n\t\t\t<a href=\"http://www.box.com/help\"> Contact Box Support
+        if you need help. </a>\n        </div>\n\t</div>\n    </div>\n  </div>\n\n
+        \n\n\n</body></html>"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:37 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8985/solr/hydra-test/select?q=%7B!join%20from=proxy_in_ssi%20to=id%7Dordered_targets_ssim:9593tv123&qt=standard&rows=10000&wt=ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Etag:
+      - '"MmQyMDAwMDAwMDAwMDAwMFNvbHI="'
+      Content-Type:
+      - text/plain;charset=utf-8
+      Content-Length:
+      - '1068'
+    body:
+      encoding: UTF-8
+      string: "{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'q'=>'{!join
+        from=proxy_in_ssi to=id}ordered_targets_ssim:9593tv123','qt'=>'standard','rows'=>'10000','wt'=>'ruby'}},'response'=>{'numFound'=>1,'start'=>0,'docs'=>[{'system_create_dtsi'=>'2018-03-16T16:38:27Z','system_modified_dtsi'=>'2018-03-16T16:38:36Z','has_model_ssim'=>['Etd'],'id'=>'jq085j963','accessControl_ssim'=>['c95824e7-3517-40e5-a354-5d9fed24d6cf'],'title_tesim'=>['The
+        Bloody Woman'],'rights_statement_tesim'=>['Permission granted by the author
+        to include this thesis or dissertation in this repository. All rights reserved
+        by the author. Please contact the author for information regarding the reproduction
+        and use of this thesis or dissertation.'],'thumbnail_path_ss'=>'/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png','suppressed_bsi'=>false,'member_ids_ssim'=>['9593tv123'],'file_set_ids_ssim'=>['9593tv123'],'human_readable_type_tesim'=>['ETD'],'read_access_group_ssim'=>['public'],'_version_'=>1595113017562890240,'timestamp'=>'2018-03-16T16:38:36.613Z'}]}}\n"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:37 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:37 GMT
+      Etag:
+      - W/"6f3ed7801bdf3db353f679a93579108ad570bc1c"
+      Last-Modified:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/ld+json
+      Content-Length:
+      - '0'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:37 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:37 GMT
+      Etag:
+      - W/"6f3ed7801bdf3db353f679a93579108ad570bc1c"
+      Last-Modified:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4531'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns021:  <http://pcdm.org/> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns026:  <http://scholarsphere.psu.edu/ns#> .
+        @prefix ns004:  <https://schema.org/> .
+        @prefix ns025:  <http://id.loc.gov/vocabulary/identifiers/> .
+        @prefix ns003:  <http://open.vocab.org/terms/> .
+        @prefix ns024:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns002:  <http://vivoweb.org/ontology/core#> .
+        @prefix ns023:  <http://emory.edu/local/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix ns029:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns007:  <http://projecthydra.org/works/models#> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns006:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns027:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix ns005:  <http://pcdm.org/models#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://schema.org/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://purl.org/dc/terms/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns030:  <http://www.w3.org/2011/content#> .
+        @prefix ns015:  <http://purl.org/spar/fabio/> .
+        @prefix ns014:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns013:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns012:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns019:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix ns016:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963>
+                rdf:type               fedora:Container ;
+                rdf:type               ns007:Work ;
+                rdf:type               fedora:Resource ;
+                rdf:type               ns005:Object ;
+                fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:last             <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/list_source#g70134877643540> ;
+                ns001:hasModel         "Etd"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:created         "2018-03-16T16:38:27.191Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2018-03-16T16:38:36.481Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns008:dgg              "http://id.loc.gov/vocabulary/organizations/geu"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns012:accessControl    <http://127.0.0.1:8986/rest/test/c9/58/24/e7/c95824e7-3517-40e5-a354-5d9fed24d6cf> ;
+                ns006:rights           "Permission granted by the author to include this thesis or dissertation in this repository. All rights reserved by the author. Please contact the author for information regarding the reproduction and use of this thesis or dissertation."^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns011:title            "The Bloody Woman"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:first            <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/list_source#g70134877643540> ;
+                rdf:type               ldp:RDFSource ;
+                rdf:type               ldp:Container ;
+                fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent       <http://127.0.0.1:8986/rest/test> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/members> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/list_source> ;
+                ns005:hasMember        <http://127.0.0.1:8986/rest/test/95/93/tv/12/9593tv123> .
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:37 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:38 GMT
+      Etag:
+      - W/"6f3ed7801bdf3db353f679a93579108ad570bc1c"
+      Last-Modified:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/ld+json
+      Content-Length:
+      - '0'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:38 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 16:38:38 GMT
+      Etag:
+      - W/"6f3ed7801bdf3db353f679a93579108ad570bc1c"
+      Last-Modified:
+      - Fri, 16 Mar 2018 16:38:36 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4531'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns021:  <http://pcdm.org/> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns026:  <http://scholarsphere.psu.edu/ns#> .
+        @prefix ns004:  <https://schema.org/> .
+        @prefix ns025:  <http://id.loc.gov/vocabulary/identifiers/> .
+        @prefix ns003:  <http://open.vocab.org/terms/> .
+        @prefix ns024:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns002:  <http://vivoweb.org/ontology/core#> .
+        @prefix ns023:  <http://emory.edu/local/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix ns029:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns007:  <http://projecthydra.org/works/models#> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns006:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns027:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix ns005:  <http://pcdm.org/models#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://schema.org/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://purl.org/dc/terms/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns030:  <http://www.w3.org/2011/content#> .
+        @prefix ns015:  <http://purl.org/spar/fabio/> .
+        @prefix ns014:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns013:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns012:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns019:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix ns016:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963>
+                rdf:type               fedora:Container ;
+                rdf:type               ns007:Work ;
+                rdf:type               fedora:Resource ;
+                rdf:type               ns005:Object ;
+                fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:last             <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/list_source#g70134877643540> ;
+                ns001:hasModel         "Etd"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:created         "2018-03-16T16:38:27.191Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2018-03-16T16:38:36.481Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns008:dgg              "http://id.loc.gov/vocabulary/organizations/geu"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns012:accessControl    <http://127.0.0.1:8986/rest/test/c9/58/24/e7/c95824e7-3517-40e5-a354-5d9fed24d6cf> ;
+                ns006:rights           "Permission granted by the author to include this thesis or dissertation in this repository. All rights reserved by the author. Please contact the author for information regarding the reproduction and use of this thesis or dissertation."^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns011:title            "The Bloody Woman"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:first            <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/list_source#g70134877643540> ;
+                rdf:type               ldp:RDFSource ;
+                rdf:type               ldp:Container ;
+                fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent       <http://127.0.0.1:8986/rest/test> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/members> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/jq/08/5j/96/jq085j963/list_source> ;
+                ns005:hasMember        <http://127.0.0.1:8986/rest/test/95/93/tv/12/9593tv123> .
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 16:38:38 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/b2/77/3v/68/b2773v68h
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:12:31 GMT
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Content-Length:
+      - '315'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/b2/77/3v/68/b2773v68h
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:12:31 GMT
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Content-Length:
+      - '315'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8985/solr/hydra-test/select?q=%7B!join%20from=proxy_in_ssi%20to=id%7Dordered_targets_ssim:7w62f8209&qt=standard&rows=10000&wt=ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:12:30 GMT
+      Etag:
+      - '"NGEwMDAwMDAwMDAwMDAwU29scg=="'
+      Content-Type:
+      - text/plain;charset=utf-8
+      Content-Length:
+      - '1065'
+    body:
+      encoding: UTF-8
+      string: "{'responseHeader'=>{'status'=>0,'QTime'=>3,'params'=>{'q'=>'{!join
+        from=proxy_in_ssi to=id}ordered_targets_ssim:7w62f8209','qt'=>'standard','rows'=>'10000','wt'=>'ruby'}},'response'=>{'numFound'=>1,'start'=>0,'docs'=>[{'system_create_dtsi'=>'2018-03-16T18:12:21Z','system_modified_dtsi'=>'2018-03-16T18:12:30Z','has_model_ssim'=>['Etd'],'id'=>'5425k968s','accessControl_ssim'=>['79496daf-debf-4153-a379-6deab53d72ed'],'title_tesim'=>['Electric
+        Rain'],'rights_statement_tesim'=>['Permission granted by the author to include
+        this thesis or dissertation in this repository. All rights reserved by the
+        author. Please contact the author for information regarding the reproduction
+        and use of this thesis or dissertation.'],'thumbnail_path_ss'=>'/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png','suppressed_bsi'=>false,'member_ids_ssim'=>['7w62f8209'],'file_set_ids_ssim'=>['7w62f8209'],'human_readable_type_tesim'=>['ETD'],'read_access_group_ssim'=>['public'],'_version_'=>1595118925535772672,'timestamp'=>'2018-03-16T18:12:30.897Z'}]}}\n"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:12:31 GMT
+      Etag:
+      - W/"d2b19318d9a8e82f25f4be5796703f77b0778757"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:12:30 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/ld+json
+      Content-Length:
+      - '0'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:12:31 GMT
+      Etag:
+      - W/"d2b19318d9a8e82f25f4be5796703f77b0778757"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:12:30 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4528'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns021:  <http://pcdm.org/> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns026:  <http://scholarsphere.psu.edu/ns#> .
+        @prefix ns004:  <https://schema.org/> .
+        @prefix ns025:  <http://id.loc.gov/vocabulary/identifiers/> .
+        @prefix ns003:  <http://open.vocab.org/terms/> .
+        @prefix ns024:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns002:  <http://vivoweb.org/ontology/core#> .
+        @prefix ns023:  <http://emory.edu/local/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix ns029:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns007:  <http://projecthydra.org/works/models#> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns006:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns027:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix ns005:  <http://pcdm.org/models#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://schema.org/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://purl.org/dc/terms/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns030:  <http://www.w3.org/2011/content#> .
+        @prefix ns015:  <http://purl.org/spar/fabio/> .
+        @prefix ns014:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns013:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns012:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns019:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix ns016:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s>
+                rdf:type               fedora:Container ;
+                rdf:type               ns007:Work ;
+                rdf:type               fedora:Resource ;
+                rdf:type               ns005:Object ;
+                fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:last             <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/list_source#g70280770971680> ;
+                ns001:hasModel         "Etd"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:created         "2018-03-16T18:12:21.707Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2018-03-16T18:12:30.841Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns008:dgg              "http://id.loc.gov/vocabulary/organizations/geu"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns012:accessControl    <http://127.0.0.1:8986/rest/test/79/49/6d/af/79496daf-debf-4153-a379-6deab53d72ed> ;
+                ns006:rights           "Permission granted by the author to include this thesis or dissertation in this repository. All rights reserved by the author. Please contact the author for information regarding the reproduction and use of this thesis or dissertation."^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns011:title            "Electric Rain"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:first            <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/list_source#g70280770971680> ;
+                rdf:type               ldp:RDFSource ;
+                rdf:type               ldp:Container ;
+                fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent       <http://127.0.0.1:8986/rest/test> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/members> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/list_source> ;
+                ns005:hasMember        <http://127.0.0.1:8986/rest/test/7w/62/f8/20/7w62f8209> .
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:12:31 GMT
+      Etag:
+      - W/"d2b19318d9a8e82f25f4be5796703f77b0778757"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:12:30 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/ld+json
+      Content-Length:
+      - '0'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:12:31 GMT
+      Etag:
+      - W/"d2b19318d9a8e82f25f4be5796703f77b0778757"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:12:30 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4528'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns021:  <http://pcdm.org/> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns026:  <http://scholarsphere.psu.edu/ns#> .
+        @prefix ns004:  <https://schema.org/> .
+        @prefix ns025:  <http://id.loc.gov/vocabulary/identifiers/> .
+        @prefix ns003:  <http://open.vocab.org/terms/> .
+        @prefix ns024:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns002:  <http://vivoweb.org/ontology/core#> .
+        @prefix ns023:  <http://emory.edu/local/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix ns029:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns007:  <http://projecthydra.org/works/models#> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns006:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns027:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix ns005:  <http://pcdm.org/models#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://schema.org/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://purl.org/dc/terms/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns030:  <http://www.w3.org/2011/content#> .
+        @prefix ns015:  <http://purl.org/spar/fabio/> .
+        @prefix ns014:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns013:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns012:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns019:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix ns016:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s>
+                rdf:type               fedora:Container ;
+                rdf:type               ns007:Work ;
+                rdf:type               fedora:Resource ;
+                rdf:type               ns005:Object ;
+                fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:last             <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/list_source#g70280770971680> ;
+                ns001:hasModel         "Etd"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:created         "2018-03-16T18:12:21.707Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:lastModified    "2018-03-16T18:12:30.841Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns008:dgg              "http://id.loc.gov/vocabulary/organizations/geu"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns012:accessControl    <http://127.0.0.1:8986/rest/test/79/49/6d/af/79496daf-debf-4153-a379-6deab53d72ed> ;
+                ns006:rights           "Permission granted by the author to include this thesis or dissertation in this repository. All rights reserved by the author. Please contact the author for information regarding the reproduction and use of this thesis or dissertation."^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns011:title            "Electric Rain"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:first            <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/list_source#g70280770971680> ;
+                rdf:type               ldp:RDFSource ;
+                rdf:type               ldp:Container ;
+                fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent       <http://127.0.0.1:8986/rest/test> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/members> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/54/25/k9/68/5425k968s/list_source> ;
+                ns005:hasMember        <http://127.0.0.1:8986/rest/test/7w/62/f8/20/7w62f8209> .
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:12:31 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/mc/87/pq/24/mc87pq24j
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Content-Length:
+      - '315'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/mc/87/pq/24/mc87pq24j
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Content-Type:
+      - text/html; charset=ISO-8859-1
+      Cache-Control:
+      - must-revalidate,no-cache,no-store
+      Content-Length:
+      - '315'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8985/solr/hydra-test/select?q=%7B!join%20from=proxy_in_ssi%20to=id%7Dordered_targets_ssim:zw12z528p&qt=standard&rows=10000&wt=ruby
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Etag:
+      - '"NmFhMDAwMDAwMDAwMDAwMFNvbHI="'
+      Content-Type:
+      - text/plain;charset=utf-8
+      Content-Length:
+      - '1063'
+    body:
+      encoding: UTF-8
+      string: "{'responseHeader'=>{'status'=>0,'QTime'=>2,'params'=>{'q'=>'{!join
+        from=proxy_in_ssi to=id}ordered_targets_ssim:zw12z528p','qt'=>'standard','rows'=>'10000','wt'=>'ruby'}},'response'=>{'numFound'=>1,'start'=>0,'docs'=>[{'system_create_dtsi'=>'2018-03-16T18:12:59Z','system_modified_dtsi'=>'2018-03-16T18:13:05Z','has_model_ssim'=>['Etd'],'id'=>'js956f80d','accessControl_ssim'=>['1e92b46a-e5da-4f00-bf03-013b53a1d9ea'],'title_tesim'=>['Fake
+        Brains'],'rights_statement_tesim'=>['Permission granted by the author to include
+        this thesis or dissertation in this repository. All rights reserved by the
+        author. Please contact the author for information regarding the reproduction
+        and use of this thesis or dissertation.'],'thumbnail_path_ss'=>'/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png','suppressed_bsi'=>false,'member_ids_ssim'=>['zw12z528p'],'file_set_ids_ssim'=>['zw12z528p'],'human_readable_type_tesim'=>['ETD'],'read_access_group_ssim'=>['public'],'_version_'=>1595118962390073344,'timestamp'=>'2018-03-16T18:13:06.044Z'}]}}\n"
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Etag:
+      - W/"b39065152accd898b3d3ebcc6ffac8332ee86c28"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:13:05 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/ld+json
+      Content-Length:
+      - '0'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Etag:
+      - W/"b39065152accd898b3d3ebcc6ffac8332ee86c28"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:13:05 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4526'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns021:  <http://pcdm.org/> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns026:  <http://scholarsphere.psu.edu/ns#> .
+        @prefix ns004:  <https://schema.org/> .
+        @prefix ns025:  <http://id.loc.gov/vocabulary/identifiers/> .
+        @prefix ns003:  <http://open.vocab.org/terms/> .
+        @prefix ns024:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns002:  <http://vivoweb.org/ontology/core#> .
+        @prefix ns023:  <http://emory.edu/local/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix ns029:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns007:  <http://projecthydra.org/works/models#> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns006:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns027:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix ns005:  <http://pcdm.org/models#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://schema.org/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://purl.org/dc/terms/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns030:  <http://www.w3.org/2011/content#> .
+        @prefix ns015:  <http://purl.org/spar/fabio/> .
+        @prefix ns014:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns013:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns012:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns019:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix ns016:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d>
+                rdf:type               fedora:Container ;
+                rdf:type               ns007:Work ;
+                rdf:type               fedora:Resource ;
+                rdf:type               ns005:Object ;
+                fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:last             <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/list_source#g70150048565780> ;
+                ns001:hasModel         "Etd"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:lastModified    "2018-03-16T18:13:05.991Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2018-03-16T18:12:59.722Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns008:dgg              "http://id.loc.gov/vocabulary/organizations/geu"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns012:accessControl    <http://127.0.0.1:8986/rest/test/1e/92/b4/6a/1e92b46a-e5da-4f00-bf03-013b53a1d9ea> ;
+                ns006:rights           "Permission granted by the author to include this thesis or dissertation in this repository. All rights reserved by the author. Please contact the author for information regarding the reproduction and use of this thesis or dissertation."^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns011:title            "Fake Brains"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:first            <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/list_source#g70150048565780> ;
+                rdf:type               ldp:RDFSource ;
+                rdf:type               ldp:Container ;
+                fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent       <http://127.0.0.1:8986/rest/test> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/members> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/list_source> ;
+                ns005:hasMember        <http://127.0.0.1:8986/rest/test/zw/12/z5/28/zw12z528p> .
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+- request:
+    method: head
+    uri: http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Etag:
+      - W/"b39065152accd898b3d3ebcc6ffac8332ee86c28"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:13:05 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Content-Type:
+      - application/ld+json
+      Content-Length:
+      - '0'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
+      User-Agent:
+      - Faraday v0.12.2
+      Prefer:
+      - return=representation
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 16 Mar 2018 18:13:06 GMT
+      Etag:
+      - W/"b39065152accd898b3d3ebcc6ffac8332ee86c28"
+      Last-Modified:
+      - Fri, 16 Mar 2018 18:13:05 GMT
+      Link:
+      - <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
+      - <http://www.w3.org/ns/ldp#Container>;rel="type"
+      - <http://www.w3.org/ns/ldp#Resource>;rel="type"
+      Accept-Patch:
+      - application/sparql-update
+      Accept-Post:
+      - text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
+      Allow:
+      - MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
+      Preference-Applied:
+      - return=representation
+      Vary:
+      - Accept, Range, Accept-Encoding, Accept-Language
+      - Prefer
+      Content-Type:
+      - text/turtle;charset=utf-8
+      Content-Length:
+      - '4526'
+      Server:
+      - Jetty(9.2.3.v20140905)
+    body:
+      encoding: UTF-8
+      string: |
+        @prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
+        @prefix ns022:  <http://purl.org/spar/pso/embargoed#> .
+        @prefix ns021:  <http://pcdm.org/> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ns020:  <http://www.iana.org/assignments/relation/> .
+        @prefix ns026:  <http://scholarsphere.psu.edu/ns#> .
+        @prefix ns004:  <https://schema.org/> .
+        @prefix ns025:  <http://id.loc.gov/vocabulary/identifiers/> .
+        @prefix ns003:  <http://open.vocab.org/terms/> .
+        @prefix ns024:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix ns002:  <http://vivoweb.org/ontology/core#> .
+        @prefix ns023:  <http://emory.edu/local/> .
+        @prefix ns001:  <info:fedora/fedora-system:def/model#> .
+        @prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
+        @prefix ns008:  <http://id.loc.gov/vocabulary/relators/> .
+        @prefix ns029:  <http://projecthydra.org/ns/fits/> .
+        @prefix ns007:  <http://projecthydra.org/works/models#> .
+        @prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
+        @prefix ns028:  <http://www.w3.org/2003/12/exif/ns#> .
+        @prefix ns006:  <http://www.europeana.eu/schemas/edm/> .
+        @prefix ns027:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+        @prefix ns005:  <http://pcdm.org/models#> .
+        @prefix xml:  <http://www.w3.org/XML/1998/namespace> .
+        @prefix ns009:  <http://schema.org/> .
+        @prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
+        @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+        @prefix test:  <info:fedora/test/> .
+        @prefix ns011:  <http://purl.org/dc/terms/> .
+        @prefix ns010:  <http://example.com/> .
+        @prefix ns030:  <http://www.w3.org/2011/content#> .
+        @prefix ns015:  <http://purl.org/spar/fabio/> .
+        @prefix ns014:  <http://projecthydra.org/ns/auth/acl#> .
+        @prefix ns013:  <http://mappings.dbpedia.org/server/ontology/classes/> .
+        @prefix ns012:  <http://www.w3.org/ns/auth/acl#> .
+        @prefix ns019:  <http://www.openarchives.org/ore/terms/> .
+        @prefix ns018:  <http://pcdm.org/use#> .
+        @prefix ns017:  <http://fedora.info/definitions/1/0/access/ObjState#> .
+        @prefix ns016:  <http://dublincore.org/documents/dcmi-terms/#> .
+        @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
+        @prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+        @prefix ldp:  <http://www.w3.org/ns/ldp#> .
+        @prefix xs:  <http://www.w3.org/2001/XMLSchema> .
+        @prefix dc:  <http://purl.org/dc/elements/1.1/> .
+
+        <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d>
+                rdf:type               fedora:Container ;
+                rdf:type               ns007:Work ;
+                rdf:type               fedora:Resource ;
+                rdf:type               ns005:Object ;
+                fedora:lastModifiedBy  "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:last             <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/list_source#g70150048565780> ;
+                ns001:hasModel         "Etd"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:createdBy       "bypassAdmin"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                fedora:lastModified    "2018-03-16T18:13:05.991Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                fedora:created         "2018-03-16T18:12:59.722Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+                ns008:dgg              "http://id.loc.gov/vocabulary/organizations/geu"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns012:accessControl    <http://127.0.0.1:8986/rest/test/1e/92/b4/6a/1e92b46a-e5da-4f00-bf03-013b53a1d9ea> ;
+                ns006:rights           "Permission granted by the author to include this thesis or dissertation in this repository. All rights reserved by the author. Please contact the author for information regarding the reproduction and use of this thesis or dissertation."^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns011:title            "Fake Brains"^^<http://www.w3.org/2001/XMLSchema#string> ;
+                ns020:first            <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/list_source#g70150048565780> ;
+                rdf:type               ldp:RDFSource ;
+                rdf:type               ldp:Container ;
+                fedora:writable        "true"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+                fedora:hasParent       <http://127.0.0.1:8986/rest/test> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/members> ;
+                ldp:contains           <http://127.0.0.1:8986/rest/test/js/95/6f/80/js956f80d/list_source> ;
+                ns005:hasMember        <http://127.0.0.1:8986/rest/test/zw/12/z5/28/zw12z528p> .
+    http_version: 
+  recorded_at: Fri, 16 Mar 2018 18:13:06 GMT
+recorded_with: VCR 4.0.0

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe ImportUrlJob do
+  let(:admin) { FactoryBot.create(:admin) }
+  # The import_url on this fileset is pointed to a box error file. If you need to
+  # re-generate the VCR that recorded this HTTP interaction, put the "box_error.html"
+  # file from the fixtures directory online somewhere and point to it here.
+  let(:etd) { FactoryBot.create(:etd) }
+  let(:fileset) { FactoryBot.create(:primary_file_set, import_url: "https://staging-etd.library.emory.edu/downloads/5h73pw048") }
+
+  context 'raise a specific error if file retrieval results in a box error file' do
+    before do
+      etd.ordered_members << fileset
+      etd.save
+      fileset.reload
+    end
+    it 'raises an exception when it encounters a box error message' do
+      VCR.use_cassette("box_error", record: :new_episodes) do
+        operation = Hyrax::Operation.create!(user: admin, operation_type: "Attach Remote File")
+        expect { described_class.perform_now(fileset, operation) }.to raise_exception(ImportUrlJob::RetrievalError)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,13 @@ require 'capybara-screenshot/rspec'
 require 'capybara/webkit'
 require 'database_cleaner'
 require 'ffaker'
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "#{::Rails.root}/spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.allow_http_connections_when_no_cassette = true
+end
 
 # capybara testing
 Capybara.javascript_driver = :webkit


### PR DESCRIPTION
Sometimes a user attaches a file via box, and then
when the background job attempts to retrieve the file
it results in an error page. Instead of attaching the
error page to the object, recognize that an error has
occurred and raise an exception.

Additionally, send a notification to the depositor
informing them of the problem and asking them to
re-submit the file.

Fixes #919 