### PR TITLE
Handle `degree_awarded => false` case in admin embargo display

### DIFF
--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -116,10 +116,15 @@ class EtdPresenter < Hyrax::WorkShowPresenter
 
   def toc_for_admin
     admin_return_message = ""
-    if embargo_release_date && toc_embargoed && degree_awarded
-      admin_return_message += "[Table of contents embargoed until #{formatted_embargo_release_date}] "
-    elsif embargo_release_date && toc_embargoed
-      admin_return_message += "[Table of contents embargoed until #{embargo_length.first} post-graduation] "
+    if embargo_release_date && toc_embargoed
+      admin_return_message +=
+        if embargo_length && !degree_awarded
+          "[Table of contents embargoed until #{embargo_length.first} post-graduation] "
+        elsif embargo_release_date
+          "[Table of contents embargoed until #{formatted_embargo_release_date}] "
+        else
+          "[Table of contents embargoed until post-graduation] "
+        end
     end
     admin_return_message + table_of_contents.first
   end


### PR DESCRIPTION
When `degree_awarded` is false, but `embargo_length` is nil, the
`EtdPresenter#toc_for_admin` method failed with `NoMethodError`. This causes a
problem for some migration objects. This refactors the method to support ETD.

Closes #928 