### PR TITLE
Setup :ingest and :derivative queues

### DIFF
--- a/config/initializers/queues.rb
+++ b/config/initializers/queues.rb
@@ -1,0 +1,5 @@
+AttachFilesToWorkJob.queue_as(:ingest)
+CharacterizeJob.queue_as(:ingest)
+ContentDepositEventJob.queue_as(:ingest)
+CreateDerivativesJob.queue_as(:derivative)
+IngestFileJob.queue_as(:ingest)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,8 @@
 ---
 :queues:
-  - [ingest, 4]
+  - [ingest, 6]
   - [batch, 2]
+  - [derivative, 1]
   - [default, 1]
 
 test:


### PR DESCRIPTION
Use the ingest queue for high priority/low cost ingest jobs and heavily weight
it. This helps to organize jobs so expensive computations (e.g. derivative
generation) will less frequently block higher priority work.

See: https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues