### PR TITLE
Only use active ids in controlled vocabularies

### DIFF
--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -65,13 +65,13 @@ module EtdHelper
       def departments(school)
         return unless school
         if school.include? 'Emory'
-          Hyrax::EmoryService.new.select_all_options
+          Hyrax::EmoryService.new.select_active_options
         elsif school.include? 'Laney'
-          Hyrax::LaneyService.new.select_all_options
+          Hyrax::LaneyService.new.select_active_options
         elsif school.include? 'Candler'
-          Hyrax::CandlerService.new.select_all_options
+          Hyrax::CandlerService.new.select_active_options
         elsif school.include? 'Rollins'
-          Hyrax::RollinsService.new.select_all_options
+          Hyrax::RollinsService.new.select_active_options
         else
           ''
         end
@@ -79,21 +79,21 @@ module EtdHelper
 
       def subfields(department)
         if department == 'Biological and Biomedical Sciences'
-          Hyrax::BiologicalService.new.select_all_options
+          Hyrax::BiologicalService.new.select_active_options
         elsif department == 'Business'
-          Hyrax::BusinessService.new.select_all_options
+          Hyrax::BusinessService.new.select_active_options
         elsif department == 'Executive Masters of Public Health - MPH'
-          Hyrax::EmphService.new.select_all_options
+          Hyrax::EmphService.new.select_active_options
         elsif department == 'Biostatistics and Bioinformatics'
-          Hyrax::BiostatisticsService.new.select_all_options
+          Hyrax::BiostatisticsService.new.select_active_options
         elsif department == 'Environmental Health'
-          Hyrax::EnvironmentService.new.select_all_options
+          Hyrax::EnvironmentService.new.select_active_options
         elsif department == 'Epidemiology'
-          Hyrax::EpidemiologyService.new.select_all_options
+          Hyrax::EpidemiologyService.new.select_active_options
         elsif department == 'Psychology'
-          Hyrax::PsychologyService.new.select_all_options
+          Hyrax::PsychologyService.new.select_active_options
         elsif department.include? 'Religion'
-          Hyrax::ReligionService.new.select_all_options
+          Hyrax::ReligionService.new.select_active_options
         else
           ''
         end

--- a/app/services/graduationdate_service.rb
+++ b/app/services/graduationdate_service.rb
@@ -1,5 +1,5 @@
 # services/graduationdate_service.rb
-class GraduationdateService < Hyrax::QaSelectService
+class GraduationdateService < Hyrax::LaevigataAuthorityService
   def initialize
     super('graduation_dates')
   end

--- a/app/services/hyrax/biological_service.rb
+++ b/app/services/hyrax/biological_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class BiologicalService < Hyrax::QaSelectService
+  class BiologicalService < LaevigataAuthorityService
     def initialize
       super('biological_programs')
     end

--- a/app/services/hyrax/biostatistics_service.rb
+++ b/app/services/hyrax/biostatistics_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class BiostatisticsService < Hyrax::QaSelectService
+  class BiostatisticsService < LaevigataAuthorityService
     def initialize
       super('biostatistics_programs')
     end

--- a/app/services/hyrax/business_service.rb
+++ b/app/services/hyrax/business_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class BusinessService < Hyrax::QaSelectService
+  class BusinessService < LaevigataAuthorityService
     def initialize
       super('business_programs')
     end

--- a/app/services/hyrax/candler_service.rb
+++ b/app/services/hyrax/candler_service.rb
@@ -1,6 +1,6 @@
 # services/emory_service.rb
 module Hyrax
-  class CandlerService < Hyrax::QaSelectService
+  class CandlerService < LaevigataAuthorityService
     def initialize
       super('candler_programs')
     end

--- a/app/services/hyrax/degree_service.rb
+++ b/app/services/hyrax/degree_service.rb
@@ -1,6 +1,6 @@
 # services/degree_service.rb
 module Hyrax
-  class DegreeService < Hyrax::QaSelectService
+  class DegreeService < LaevigataAuthorityService
     def initialize
       super('degree')
     end

--- a/app/services/hyrax/emory_service.rb
+++ b/app/services/hyrax/emory_service.rb
@@ -1,6 +1,6 @@
 # services/emory_service.rb
 module Hyrax
-  class EmoryService < Hyrax::QaSelectService
+  class EmoryService < LaevigataAuthorityService
     def initialize
       super('emory_programs')
     end

--- a/app/services/hyrax/environmental_service.rb
+++ b/app/services/hyrax/environmental_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class EnvironmentalService < Hyrax::QaSelectService
+  class EnvironmentalService < LaevigataAuthorityService
     def initialize
       super('environmental_programs')
     end

--- a/app/services/hyrax/epidemiology_service.rb
+++ b/app/services/hyrax/epidemiology_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class EpidemiologyService < Hyrax::QaSelectService
+  class EpidemiologyService < LaevigataAuthorityService
     def initialize
       super('epidemiology_programs')
     end

--- a/app/services/hyrax/executive_service.rb
+++ b/app/services/hyrax/executive_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class ExecutiveService < Hyrax::QaSelectService
+  class ExecutiveService < LaevigataAuthorityService
     def initialize
       super('executive_programs')
     end

--- a/app/services/hyrax/laevigata_authority_service.rb
+++ b/app/services/hyrax/laevigata_authority_service.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  ##
+  # A custom authority service with optional `active:` tags.
+  #
+  # Active flag in qa is meant to be optional, with a default of `true`. This
+  # module reinstates that as a strict subclass of `Hyrax::QaSelectService`.
+  #
+  # @see https://github.com/samvera/questioning_authority/#list-of-id-and-term-keys-and-optionally-active-key
+  class LaevigataAuthorityService < Hyrax::QaSelectService
+    def active?(id)
+      authority.find(id).fetch('active', true)
+    end
+
+    def active_elements
+      authority.all.select { |e| e.fetch('active', true) }
+    end
+  end
+end

--- a/app/services/hyrax/laney_service.rb
+++ b/app/services/hyrax/laney_service.rb
@@ -1,6 +1,6 @@
 # services/laney_service.rb
 module Hyrax
-  class LaneyService < Hyrax::QaSelectService
+  class LaneyService < LaevigataAuthorityService
     def initialize
       super('laney_programs')
     end

--- a/app/services/hyrax/language_service.rb
+++ b/app/services/hyrax/language_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class LanguageService < Hyrax::QaSelectService
+  class LanguageService < LaevigataAuthorityService
     def initialize
       super('languages_list')
     end

--- a/app/services/hyrax/psychology_service.rb
+++ b/app/services/hyrax/psychology_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class PsychologyService < Hyrax::QaSelectService
+  class PsychologyService < LaevigataAuthorityService
     def initialize
       super('psychology_programs')
     end

--- a/app/services/hyrax/religion_service.rb
+++ b/app/services/hyrax/religion_service.rb
@@ -1,5 +1,5 @@
 module Hyrax
-  class ReligionService < Hyrax::QaSelectService
+  class ReligionService < LaevigataAuthorityService
     def initialize
       super('religion_programs')
     end

--- a/app/services/hyrax/rollins_service.rb
+++ b/app/services/hyrax/rollins_service.rb
@@ -1,6 +1,6 @@
 # services/rollins_service.rb
 module Hyrax
-  class RollinsService < Hyrax::QaSelectService
+  class RollinsService < LaevigataAuthorityService
     def initialize
       super('rollins_programs')
     end

--- a/app/services/hyrax/school_service.rb
+++ b/app/services/hyrax/school_service.rb
@@ -1,6 +1,6 @@
 # services/submitting_service.rb
 module Hyrax
-  class SchoolService < Hyrax::QaSelectService
+  class SchoolService < LaevigataAuthorityService
     def initialize
       super('school')
     end

--- a/app/services/partners_service.rb
+++ b/app/services/partners_service.rb
@@ -1,5 +1,5 @@
 # services/partners_service.rb
-class PartnersService < Hyrax::QaSelectService
+class PartnersService < Hyrax::LaevigataAuthorityService
   def initialize
     super('partnering_agencies')
   end

--- a/app/services/research_field_service.rb
+++ b/app/services/research_field_service.rb
@@ -1,10 +1,14 @@
 # services/research_field_service.rb
-class ResearchFieldService < Hyrax::QaSelectService
+class ResearchFieldService < Hyrax::LaevigataAuthorityService
   def initialize
     super('research_fields')
   end
 
   def select_all_ids
     authority.all.map { |e| [e[:id], e[:id]] }
+  end
+
+  def select_active_ids
+    select_active_options.map { |_, id| [id, id] }
   end
 end

--- a/app/services/submitting_service.rb
+++ b/app/services/submitting_service.rb
@@ -1,5 +1,5 @@
 # services/submitting_service.rb
-class SubmittingService < Hyrax::QaSelectService
+class SubmittingService < Hyrax::LaevigataAuthorityService
   def initialize
     super('submitting_type')
   end

--- a/app/views/records/edit_fields/_research_field.html.erb
+++ b/app/views/records/edit_fields/_research_field.html.erb
@@ -1,6 +1,6 @@
 <% research_field_service = ResearchFieldService.new %>
 <%= f.input :research_field, as: :etd_multi_value_select,
-    collection: research_field_service.select_all_ids,
+    collection: research_field_service.select_active_ids,
     label: 'Research Field', hint: 'Select at least one, but no more than three, research fields that best describe your work. List your primary field first. If you do not see your exact field, pick the closest option.',
     input_html: { class: 'form-control' },
     include_blank: true, required: true

--- a/spec/services/research_field_service_spec.rb
+++ b/spec/services/research_field_service_spec.rb
@@ -19,6 +19,12 @@ describe ResearchFieldService do
     end
   end
 
+  describe "select_active_ids" do
+    it { expect(research_field_service.select_active_ids).to include ['Aeronomy', 'Aeronomy'] }
+    it { expect(research_field_service.select_active_ids).to include ['Social Work', 'Social Work'] }
+    it { expect(research_field_service.select_active_ids).not_to include ['Biology, Radiation', 'Biology, Radiation'] }
+  end
+
   describe "label" do
     subject { research_field_service.label('Art Criticism') }
 


### PR DESCRIPTION
Controlled vocabulary terms can be marked inactive by including `active: false`
in their YAML specifications. To date, we have ignored this designation, but we
must support inactive terms in order to import items with legacy terms. Using
`#select_active_options` throughout ensures these inactive terms won't be
incorrectly available to users in dropdown menus.