### PR TITLE
Change default workflow to go directly to "published"

### DIFF
--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -9,7 +9,7 @@
                 {
                     "name": "deposit",
                     "from_states": [],
-                    "transition_to": "deposited",
+                    "transition_to": "published",
                     "methods": [
                         "Hyrax::Workflow::GrantEditToDepositor",
                         "Hyrax::Workflow::ActivateObject"


### PR DESCRIPTION
Objects that do not need to go through the ususal `emory_one_step_approval`
workflow, should go directly to a "published" state, rather than lingering in
"deposited".

Workflows must be reloadod for this commit to take effect:
https://github.com/samvera/hyrax/wiki/Defining-a-Workflow#loading-workflows.