### PR TITLE
Add inactive `research_field` authority values

### DIFF
--- a/config/authorities/research_fields.yml
+++ b/config/authorities/research_fields.yml
@@ -819,3 +819,33 @@ terms:
       term: "0646"
     - id: "Women's Studies"
       term: "0453"
+    - id: "Education, History of"
+      term: "0337"
+      active: false
+    - id: "History, Church"
+      term: "0330"
+      active: false
+    - id: "Chemistry, Pharmaceutical"
+      term: "0491"
+      active: false
+    - id: "Health Sciences, Hygiene"
+      term: "0568"
+      active: false
+    - id: "Health Sciences, Education"
+      term: "0350"
+      active: false
+    - id: "Biology, Animal Physiology"
+      term: "0433"
+      active: false
+    - id: "Biology, Plant Physiology"
+      term: "0817"
+      active: false
+    - id: "Chemistry, Radiation"
+      term: "0754"
+      active: false
+    - id: "Biology, Radiation"
+      term: "0821"
+      active: false
+    - id: "Biophysics, Medical"
+      term: "0760"
+      active: false

--- a/spec/services/research_field_service_spec.rb
+++ b/spec/services/research_field_service_spec.rb
@@ -15,7 +15,7 @@ describe ResearchFieldService do
       expect(research_field_options).to include ['0287', 'Biology, Anatomy']
       expect(research_field_options).to include ['0452', 'Social Work']
       expect(research_field_options).to include ['0778', 'Biology, Veterinary Science']
-      expect(research_field_options.size).to eq 410
+      expect(research_field_options.size).to be >= 410
     end
   end
 


### PR DESCRIPTION
Migrated objects require removed `research_field` values; this adds several of these in support of migration.