### PR TITLE
Check that the `Etd` model can load objects with `OkComputer`

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -14,4 +14,15 @@ class SmtpCheck < OkComputer::Check
   end
 end
 
-OkComputer::Registry.register "smtp", SmtpCheck.new
+class EtdLoadCheck < OkComputer::Check
+  def check
+    raise "We can't find an Etd object in the repository" if Etd.first.nil?
+  rescue => exception
+    Honeybadger.notify(exception)
+    mark_failure
+    mark_message exception.message
+  end
+end
+
+OkComputer::Registry.register "etd_load", EtdLoadCheck.new
+OkComputer::Registry.register "smtp",     SmtpCheck.new


### PR DESCRIPTION
Adds a model integration check for the `Etd` model. This check will fail if no `Etd` exists, or if a connection to Fedora/Solr fails.