### PR TITLE
Support multiple original files in migration

### DIFF
--- a/app/lib/importer/migration_import_job.rb
+++ b/app/lib/importer/migration_import_job.rb
@@ -33,15 +33,17 @@ module Importer
       primary_file.close
       File.unlink(primary_file)
 
-      original_binary = record.mapper.original_file
-      original_file   = File.open(tmp_path(original_binary.name), 'w', encoding: 'ascii-8bit')
-      original_file.write(original_binary.content)
+      record.mapper.original_files
+        .each_with_object(attributes[:uploaded_files]) do |original_binary, files|
+        file = File.open(tmp_path(original_binary.name), 'w', encoding: 'ascii-8bit')
+        file.write(original_binary.content)
 
-      attributes[:uploaded_files] <<
-        Hyrax::UploadedFile.create(user: depositor, file: original_file, pcdm_use: FileSet::ORIGINAL).id
+        files <<
+          Hyrax::UploadedFile.create(user: depositor, file: file, pcdm_use: FileSet::ORIGINAL).id
 
-      original_file.close
-      File.unlink(original_file)
+        file.close
+        File.unlink(file)
+      end
 
       record.mapper
         .supplementary_files

--- a/app/lib/importer/migration_import_job.rb
+++ b/app/lib/importer/migration_import_job.rb
@@ -33,6 +33,16 @@ module Importer
       primary_file.close
       File.unlink(primary_file)
 
+      original_binary = record.mapper.original_file
+      original_file   = File.open(tmp_path(original_binary.name), 'w', encoding: 'ascii-8bit')
+      original_file.write(original_binary.content)
+
+      attributes[:uploaded_files] <<
+        Hyrax::UploadedFile.create(user: depositor, file: original_file, pcdm_use: FileSet::ORIGINAL).id
+
+      original_file.close
+      File.unlink(original_file)
+
       record.mapper
         .supplementary_files
         .each_with_object(attributes[:uploaded_files]) do |supplementary_file, files|
@@ -54,6 +64,7 @@ module Importer
                                                                 file:     premis_file,
                                                                 pcdm_use: FileSet::PREMIS,
                                                                 title:    'premis.xml').id
+
       premis_file.close
       premis_file.unlink
 

--- a/app/lib/importer/migration_mapper.rb
+++ b/app/lib/importer/migration_mapper.rb
@@ -62,6 +62,10 @@ module Importer
       repository_object.premis.content
     end
 
+    def original_file
+      BinaryFile.new(repository_object.original_file)
+    end
+
     def embargo_lift_date
       date_str =
         mods_node
@@ -313,10 +317,13 @@ module Importer
       def original_file
         @original_file ||=
           begin
+            original_file_nodes = rels.as_xml.xpath('.//rel:hasOriginal', NAMESPACES)
+
+            raise "OMG I HAVE MORE THAN ONE ORIGINAL FILE. CRASH HARD." unless
+              original_file_nodes.count == 1
+
             original_file_id =
-              rels.as_xml
-                .xpath('.//rel:hasOriginal', NAMESPACES).first
-                .attributes['resource'].value.split('/').last
+              original_file_nodes.first.attributes['resource'].value.split('/').last
 
             RepositoryObject.new(pid: original_file_id, source_host: source_host)
           end
@@ -324,8 +331,6 @@ module Importer
 
       def supplementary_files
         return enum_for(:supplementary_files) unless block_given?
-
-        yield original_file if original_file
 
         rels.as_xml.xpath('.//rel:hasSupplement', NAMESPACES).each do |node|
           file_id = node.attributes['resource'].value.split('/').last

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -2,6 +2,7 @@
 class FileSet < ActiveFedora::Base
   include ::Hyrax::FileSetBehavior
 
+  ORIGINAL      = 'original'.freeze
   PREMIS        = 'premis'.freeze
   PRIMARY       = 'primary'.freeze
   SUPPLEMENTARY = 'supplementary'.freeze
@@ -19,6 +20,10 @@ class FileSet < ActiveFedora::Base
     index.as :facetable
   end
 
+  def original?
+    pcdm_use == ORIGINAL
+  end
+
   def premis?
     pcdm_use == PREMIS
   end
@@ -28,6 +33,6 @@ class FileSet < ActiveFedora::Base
   end
 
   def supplementary?
-    !primary? && !premis?
+    !primary? && !premis? && !original?
   end
 end

--- a/spec/importer/asynchronous_record_importer_spec.rb
+++ b/spec/importer/asynchronous_record_importer_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe Importer::AsynchronousRecordImporter do
         expect(Etd.last.representative).to be_primary
       end
 
-      it 'has a supplementary (original) file' do
+      it 'has an original file' do
         importer.import(record: record)
 
-        expect(Etd.last.supplemental_files_fs.first)
-          .not_to be_primary
+        expect(Etd.last.file_sets.find(&:original?).label)
+          .to eq 'MoominDissertation.pdf'
       end
 
       it 'has a premis file' do

--- a/spec/importer/migration_mapper_spec.rb
+++ b/spec/importer/migration_mapper_spec.rb
@@ -216,6 +216,12 @@ RSpec.describe Importer::MigrationMapper do
     end
   end
 
+  describe '#original_files' do
+    it 'has an original file' do
+      expect(mapper.original_files.to_a).not_to be_empty
+    end
+  end
+
   describe '#supplementary_files' do
     it 'does not have any supplementary files' do
       expect(mapper.supplementary_files.to_a).to be_empty

--- a/spec/importer/migration_mapper_spec.rb
+++ b/spec/importer/migration_mapper_spec.rb
@@ -210,9 +210,15 @@ RSpec.describe Importer::MigrationMapper do
     end
   end
 
+  describe '#original_file' do
+    it 'has an original file' do
+      expect(mapper.original_file.content).not_to be_empty
+    end
+  end
+
   describe '#supplementary_files' do
     it 'does not have any supplementary files' do
-      expect(mapper.supplementary_files.to_a).not_to be_empty
+      expect(mapper.supplementary_files.to_a).to be_empty
     end
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe FileSet do
     its(:file_type) { is_expected.to be_nil }
   end
 
+  context 'when original' do
+    subject(:file_set) { described_class.new(pcdm_use: described_class::ORIGINAL) }
+
+    its(:pcdm_use) { is_expected.to eq described_class::ORIGINAL }
+
+    it { is_expected.not_to be_premis }
+    it { is_expected.not_to be_primary }
+    it { is_expected.not_to be_supplementary }
+    it { is_expected.to be_original }
+  end
+
   context 'when premis' do
     subject(:file_set) { described_class.new(pcdm_use: described_class::PREMIS) }
 
@@ -20,6 +31,7 @@ RSpec.describe FileSet do
     it { is_expected.to be_premis }
     it { is_expected.not_to be_primary }
     it { is_expected.not_to be_supplementary }
+    it { is_expected.not_to be_original }
   end
 
   context 'when primary' do
@@ -30,6 +42,7 @@ RSpec.describe FileSet do
     it { is_expected.not_to be_premis }
     it { is_expected.to be_primary }
     it { is_expected.not_to be_supplementary }
+    it { is_expected.not_to be_original }
   end
 
   context 'when supplementary' do
@@ -40,5 +53,6 @@ RSpec.describe FileSet do
     it { is_expected.not_to be_premis }
     it { is_expected.not_to be_primary }
     it { is_expected.to be_supplementary }
+    it { is_expected.not_to be_original }
   end
 end


### PR DESCRIPTION
Some legacy objects have multiple original files. In this case, all of these files need to migrate.