### PR TITLE
Respect `bsi` false values for embargoes

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -33,7 +33,7 @@ class SolrDocument
   # If this is a string, transform it into a boolean
   # If the value is nil or can't be determined, assume it is embargoed
   def abstract_embargoed
-    return self['abstract_embargoed_bsi'] if self['abstract_embargoed_bsi']
+    return self['abstract_embargoed_bsi'] unless self['abstract_embargoed_bsi'].nil?
     return self['abstract_embargoed_tesim'].first.to_s == "true" if self['abstract_embargoed_tesim']
     true
   end
@@ -42,7 +42,7 @@ class SolrDocument
   # If this is a string, transform it into a boolean
   # If the value is nil or can't be determined, assume it is embargoed
   def toc_embargoed
-    return self['toc_embargoed_bsi'] if self['toc_embargoed_bsi']
+    return self['toc_embargoed_bsi'] unless self['toc_embargoed_bsi'].nil?
     return self['toc_embargoed_tesim'].first.to_s == "true" if self['toc_embargoed_tesim']
     true
   end
@@ -51,7 +51,7 @@ class SolrDocument
   # If this is a string, transform it into a boolean
   # If the value is nil or can't be determined, assume it is embargoed
   def files_embargoed
-    return self['files_embargoed_bsi'] if self['files_embargoed_bsi']
+    return self['files_embargoed_bsi'] unless self['files_embargoed_bsi'].nil?
     return self['files_embargoed_tesim'].first.to_s == "true" if self['files_embargoed_tesim']
     true
   end


### PR DESCRIPTION
False boolean values were previously ignored due to the `if` guard. We change this to an explicit type check for `nil`, so `false` is respected.