### PR TITLE
Add read-only mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,26 @@ class ApplicationController < ActionController::Base
   # Adds Hyrax behaviors into the application controller
   include Hyrax::Controller
   include Hyrax::ThemedLayoutController
+
+  # Check to see if we're in read_only mode
+  before_action :check_read_only, except: [:show, :index]
+
   with_themed_layout '1_column'
 
   protect_from_forgery with: :exception
+
+  # What to do if read_only mode has been enabled, via FlipFlop
+  # If read_only is enabled, redirect any requests that would allow
+  # changes to the system. This is to enable easier migrations.
+  def check_read_only
+    return unless Flipflop.read_only?
+    # Exempt the FlipFlop controller itself from read_only mode, so it can be turned off
+    return if self.class.to_s == Hyrax::Admin::StrategiesController.to_s
+    redirect_back(
+      fallback_location: root_path,
+      alert: "This system is in read-only mode for maintenance. No submissions or edits can be made at this time."
+    )
+  end
 
   # Override from Hyrax
   # Provide a place for Devise to send the user to after signing in

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,5 @@
+Flipflop.configure do
+  feature :read_only,
+          default: false,
+          description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled. For use in "
+end

--- a/spec/features/read_only_mode_spec.rb
+++ b/spec/features/read_only_mode_spec.rb
@@ -1,0 +1,25 @@
+# Generated via `rails generate hyrax:work Etd`
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+RSpec.feature 'Read Only Mode' do
+  let(:student) { create :user }
+
+  context 'a logged in user' do
+    before do
+      login_as student
+    end
+
+    scenario "View Etd Tabs", js: false do
+      visit("/concern/etds/new")
+      expect(page).to have_content("Submission Checklist")
+      allow(Flipflop).to receive(:read_only?).and_return(true)
+      visit("/concern/etds/new")
+      expect(page).to have_content("This system is in read-only mode for maintenance.")
+      allow(Flipflop).to receive(:read_only?).and_return(false)
+      visit("/concern/etds/new")
+      expect(page).to have_content("Submission Checklist")
+    end
+  end
+end


### PR DESCRIPTION
Add a FlipFlop feature toggle that puts
the system into read-only mode.
This will allow us to more easily migrate
data behind the scenes.

Closes #944 