### PR TITLE
Handle case where members exist, but not primary files

### DIFF
--- a/app/views/hyrax/base/_primary_pdf.html.erb
+++ b/app/views/hyrax/base/_primary_pdf.html.erb
@@ -9,9 +9,8 @@
         <th><%= t('.actions') %></th>
       </tr>
     </thead>
+    <% if member = @presenter.member_presenters.select { |mp| mp.solr_document["pcdm_use_tesim"].include?("primary")}.first %>
     <tbody>
-      <% member = @presenter.member_presenters.select { |mp| mp.solr_document["pcdm_use_tesim"] == ["primary"]}.first %>
-
       <tr class="<%= dom_class(member) %> attributes">
         <td class="thumbnail">
           <% if @presenter.files_embargo_check %>
@@ -36,6 +35,7 @@
         </td>
       </tr>
     </tbody>
+    <% end %>
   </table>
 <% elsif can? :edit, presenter.id %>
     <div class="alert alert-warning" role="alert"><%= t('.empty', type: presenter.human_readable_type) %></div>


### PR DESCRIPTION
If a user creates an item with supplementary files but no primary files, the
view would break on `NoMethodError` for a `nil`. This is because we were
guarding on whether *any* members existed, but actually seeking a `#primary?`
FileSet member. In leiu of a larger refactor, we add a second guard to prevent
the primary file from displaying.

This case would also be triggered between processing of multiple
`AttachFileToWorkJob` jobs shortly after upload. Since the jobs are
asynchronous, it's possible for a supplementary file to be attached before the
primary--even when a primary file will eventually exist for the object.

Closes #921.