### PR TITLE
Show `false` for embargo types when value is empty

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -31,29 +31,29 @@ class SolrDocument
 
   # If this is a boolean, return the boolean value
   # If this is a string, transform it into a boolean
-  # If the value is nil or can't be determined, assume it is embargoed
+  # If the value is nil or can't be determined, assume it is NOT embargoed
   def abstract_embargoed
     return self['abstract_embargoed_bsi'] unless self['abstract_embargoed_bsi'].nil?
     return self['abstract_embargoed_tesim'].first.to_s == "true" if self['abstract_embargoed_tesim']
-    true
+    false
   end
 
   # If this is a boolean, return the boolean value
   # If this is a string, transform it into a boolean
-  # If the value is nil or can't be determined, assume it is embargoed
+  # If the value is nil or can't be determined, assume it is NOT embargoed
   def toc_embargoed
     return self['toc_embargoed_bsi'] unless self['toc_embargoed_bsi'].nil?
     return self['toc_embargoed_tesim'].first.to_s == "true" if self['toc_embargoed_tesim']
-    true
+    false
   end
 
   # If this is a boolean, return the boolean value
   # If this is a string, transform it into a boolean
-  # If the value is nil or can't be determined, assume it is embargoed
+  # If the value is nil or can't be determined, assume it is NOT embargoed
   def files_embargoed
     return self['files_embargoed_bsi'] unless self['files_embargoed_bsi'].nil?
     return self['files_embargoed_tesim'].first.to_s == "true" if self['files_embargoed_tesim']
-    true
+    false
   end
 
   def table_of_contents

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -24,9 +24,9 @@
       <%= presenter.attribute_to_html(:copyright_question_one, label: t("hyrax.works.copyright_question_one_label"))%>
       <%= presenter.attribute_to_html(:copyright_question_two, label: t("hyrax.works.copyright_question_two_label"))%>
       <%= presenter.attribute_to_html(:copyright_question_three, label: t("hyrax.works.copyright_question_three_label"))%>
-      <%= presenter.attribute_to_html(:files_embargoed, label: "Files Under Embargo")%>
-      <%= presenter.attribute_to_html(:abstract_embargoed, label: "Abstract Under Embargo")%>
-      <%= presenter.attribute_to_html(:toc_embargoed, label: "Table of Contents Under Embargo")%>
+      <%= presenter.attribute_to_html(:files_embargoed, label: "Files Under Embargo", include_empty: true)%>
+      <%= presenter.attribute_to_html(:abstract_embargoed, label: "Abstract Under Embargo", include_empty: true)%>
+      <%= presenter.attribute_to_html(:toc_embargoed, label: "Table of Contents Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:embargo_length, label: "Length of Embargo")%>
     <% end %>
   </tbody>

--- a/spec/features/show_etd_spec.rb
+++ b/spec/features/show_etd_spec.rb
@@ -4,7 +4,16 @@ require 'workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.feature 'Display ETD metadata' do
-  let(:etd) { FactoryBot.create(:sample_data_with_copyright_questions, partnering_agency: ["CDC"], school: ["Candler School of Theology"], embargo_length: "6 months") }
+  let(:etd) do
+    FactoryBot.create(:sample_data_with_copyright_questions,
+                      partnering_agency: ["CDC"],
+                      school: ["Candler School of Theology"],
+                      embargo_length: "6 months",
+                      files_embargoed: false,
+                      toc_embargoed: nil,
+                      abstract_embargoed: '')
+  end
+
   let(:approving_user) { User.where(uid: "candleradmin").first }
 
   # set up the creation of an approving user
@@ -85,9 +94,9 @@ RSpec.feature 'Display ETD metadata' do
     expect(page).to have_content I18n.t("hyrax.works.copyright_question_three_label")
 
     # Embargo questions
-    expect(page).to have_content "Files Under Embargo"
-    expect(page).to have_content "Abstract Under Embargo"
-    expect(page).to have_content "Table of Contents Under Embargo"
+    expect(find('li.files_embargoed')).to have_content false
+    expect(find('li.toc_embargoed')).to have_content false
+    expect(find('li.abstract_embargoed')).to have_content false
     expect(page).to have_content "Length of Embargo"
     logout
   end


### PR DESCRIPTION
Empty values previously displayed as true. When an `Etd`'s `#toc_embargoed`,
`#abstract_embargoed`, or `#files_embargoed` is an of `''`, `nil`, `false`, or
`'false'`, we want to display `false` as the metadata value.

To do this, we need to send `include_empty: true` to the `#attribute_to_html`
options. Also, because the indexers treat empty strings as `nil` when generating
JSON for Solr, we need to treat the `nil` case for all related fields as `false`
in the presenter.

The feature test is updated to catch the previously untested cases.

Closes #926.