### PR TITLE
Toggle read-only mode with a rake task

### DIFF
--- a/lib/tasks/read_only.rake
+++ b/lib/tasks/read_only.rake
@@ -1,0 +1,23 @@
+namespace :emory do
+  namespace :read_only do
+    desc "Put the system in read-only mode to enable consistent backups"
+    task :on do
+      puts "Going into read-only mode to enable backups."
+      read_only_feature = Hyrax::Feature.find_by_key("read_only")
+      read_only_feature.enabled = true
+      read_only_feature.save
+      Rake::Task['sidekiq:stop'].invoke
+      puts "Read only mode: #{Flipflop.read_only?}"
+    end
+
+    desc "Turn off read-only mode: restore normal operations."
+    task :off do
+      puts "Restoring normal operations."
+      read_only_feature = Hyrax::Feature.find_by_key("read_only")
+      read_only_feature.enabled = false
+      read_only_feature.save
+      Rake::Task['sidekiq:start'].invoke
+      puts "Read only mode: #{Flipflop.read_only?}"
+    end
+  end
+end

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,0 +1,33 @@
+# Usage: bundle exec rake sidekiq:restart RAILS_ENV=<environment name>
+
+namespace :sidekiq do
+  sidekiq_pid_file = Rails.root + 'tmp/pids/sidekiq-0.pid'
+  sidekiq_log_file = Rails.root + 'log/sidekiq.log'
+
+  desc "Sidekiq stop"
+  task :stop do
+    puts "--- Trying to stop Sidekiq Now ---"
+    if File.exist?(sidekiq_pid_file)
+      puts "Stopping sidekiq now #PID-#{File.readlines(sidekiq_pid_file).first}..."
+      system "sidekiqctl stop #{sidekiq_pid_file}" # stops sidekiq process here
+    else
+      puts "--- Sidekiq Not Running ---"
+    end
+  end
+
+  desc "Sidekiq start"
+  task :start do
+    puts "Starting Sidekiq..."
+    system "bundle exec sidekiq -e#{Rails.env} -C config/sidekiq.yml -P #{sidekiq_pid_file} -d -L #{sidekiq_log_file}" # starts sidekiq process here
+    sleep(2)
+    puts "Sidekiq started #PID-#{File.readlines(sidekiq_pid_file).first}."
+  end
+
+  desc "Sidekiq restart"
+  task :restart do
+    puts "#### Trying to restart Sidekiq Now !!! ####"
+    Rake::Task['sidekiq:stop'].invoke
+    Rake::Task['sidekiq:start'].invoke
+    puts "#### Sidekiq restarted successfully !!! ####"
+  end
+end


### PR DESCRIPTION
This lets our nightly backup process put the
system into read-only mode so it can stay on
while we make backups.