### PR TITLE
Rollins and frontend fixes

### DIFF
--- a/app/assets/javascripts/dependent_dropdowns.js
+++ b/app/assets/javascripts/dependent_dropdowns.js
@@ -1,6 +1,6 @@
 Blacklight.onLoad(function() {
 	$('select[data-option-dependent=true]').each(function (i) {
-		var observer_dom_id = $(this).attr('id');
+		var observer_dom_id = $(this).prop('id');
 		var observed_dom_id = $(this).data('option-observed');
 		var url_mask = $(this).data('option-url');
 		var key_method = $(this).data('option-key-method');
@@ -12,7 +12,7 @@ Blacklight.onLoad(function() {
 		var observed = $('#' + observed_dom_id);
 
 		if (!observer.val() && observed.size() > 1) {
-			observer.attr('disabled', true);
+			observer.prop('disabled', true);
 		}
 		observed.on('change', function () {
 			observer.empty().append(prompt);
@@ -24,9 +24,13 @@ Blacklight.onLoad(function() {
 				$.getJSON(url, function (data) {
 					$.each(data, function (i, object) {
 						observer.append($('<option>').attr('value', object.id).text(object.label));
-						observer.attr('disabled', false);
+						observer.prop('disabled', false);
 					});
 				});
+			}
+			// if there are no options after the change event, disable the component
+			if ($(observer).options === undefined){
+				observer.prop('disabled', true);
 			}
 		});
 	});

--- a/app/assets/javascripts/etd_save_work_control.es6
+++ b/app/assets/javascripts/etd_save_work_control.es6
@@ -63,6 +63,9 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
 
       this.laneyEmbargoDurations = '<option value=""></option><option value="6 months">6 months</option><option value="1 year">1 year</option><option value="2 years">2 years</option><option value="6 years">6 years</option>';
 
+      this.departments_with_subfields = ['Business', 'Executive Masters of Public Health - MPH', 'Biostatistics and Bioinformatics', 'Biostatistics', 'Biological and Biomedical Sciences', 'Environmental Studies', 'Epidemiology', 'Psychology', 'Religion', 'Religion and Anthropology', 'Religion and Classical Civilization', 'Religion and History', 'Religion and Sociology']
+
+
       this.preventSubmit()
       this.fileDeleted()
       this.supplementalFilesListener()
@@ -71,6 +74,10 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
       this.setCommitteeMembersContentListener()
       this.setAgreementListener()
       this.setTinyListener()
+      this.setPartneringAgencyListener()
+      this.setSchoolListener()
+      this.setDepartmentListener()
+      this.setSubfieldListener()
       this.supplementalMetadataListener()
 
       // Check if the form is already valid. (e.g. If the user is editing an existing record, the form should be valid immediately.)
@@ -100,6 +107,46 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
     setTinyListener(){
       var form = this
       $(document).bind('laevigata:tinymce:change', null, (e) => form.formStateChanged('.about-my-etd'));
+    }
+    // dynamically added fields need to explicitly trigger validation
+    setPartneringAgencyListener(){
+      var form = this
+      $('#etd_partnering_agency').on('change', function(){
+        // if we should add subfield for validating, do so
+        if (form.departments_with_subfields.includes($('#etd_department').val())){
+          form.requiredAboutMeFields.reload('.about-me', true)
+        } else {
+          form.requiredAboutMeFields.reload('.about-me')
+        }
+        form.formStateChanged('.about-me');
+      });
+    }
+
+    setSchoolListener(){
+      var form = this
+      $('#etd_school').on('change', function(){
+        $("#etd_subfield").val("").change().prop('disabled', true)
+        form.requiredAboutMeFields.reload('.about-me')
+      });
+    }
+
+    setDepartmentListener(){
+      var form = this
+      $('#etd_department').on('change', function(){
+        // call reload if subfield has content, based upon array of department names that contain subfields
+          if (form.departments_with_subfields.includes($(this).val())){
+            form.requiredAboutMeFields.reload('.about-me', true)
+          } else {
+            form.requiredAboutMeFields.reload('.about-me')
+          }
+      });
+    }
+
+    setSubfieldListener(){
+      var form = this
+      $('#etd_subfield').on('change', function(){
+        form.requiredAboutMeFields.reload('.about-me', true)
+      });
     }
 
     setAgreementListener(){
@@ -355,9 +402,6 @@ export default class EtdSaveWorkControl extends SaveWorkControl {
     }
 
     validateMeAndMyProgram() {
-      // TODO: make sure email format is valid
-      // red border around input might suffice for invalid
-
       // if Rollins is school, partnering agency is required, otherwise not
       if ($('#etd_school').val() != "Rollins School of Public Health"){
         this.requiredAboutMeFields.requiredFields = $(this.requiredAboutMeFields.requiredFields).not("#etd_partnering_agency")

--- a/app/assets/javascripts/required_fields.es6
+++ b/app/assets/javascripts/required_fields.es6
@@ -25,16 +25,27 @@ export class ETDRequiredFields extends RequiredFields {
   }
 
   /* We need to call this reload method any time we have changed the required fields on the form, for example when we add/remove a field or enable/disable a field. */
-  reload(selector) {
+  reload(selector, subfields_enabled) {
     // All inputs are required, except inputs that are
     // hidden, disabled, or optional.
     // ":input" matches all input, select or textarea
     // fields, but we want to exclude buttons.
+
+    // if selector == ".about-me", add department, which is disabled when this function is called by the change of school that enables it; in the situation where a specific value for department means a subdepartment is required, handle that case as well.
+
     this.requiredFields = $(selector).find(":input")
-      .filter(":not([type=hidden])")
-      .filter(":not([disabled])")
-      .filter(":not([class~=optional])")
-      .filter(":not(button)")
+     .filter(":not([type=hidden])")
+     .filter(":not([disabled])")
+     .filter(":not([class~=optional])")
+     .filter(":not(button)")
+
+    if (selector === '.about-me'){
+      this.requiredFields = $(this.requiredFields).add($("#etd_department"));
+    }
+
+    if (subfields_enabled != undefined){
+      this.requiredFields = $(this.requiredFields).add($("#etd_subfield"));
+    }
 
     this.requiredFields.change(this.callback)
   }

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class EtdForm < Hyrax::Forms::WorkForm
     include SingleValuedForm
     self.model_class = ::Etd
-    # placeholder about me terms
+    # about me terms
     self.terms += [:graduation_date]
     self.terms += [:post_graduation_email]
     self.terms += [:resource_type]
@@ -14,10 +14,10 @@ module Hyrax
     self.terms += [:degree]
     self.terms += [:partnering_agency]
     self.terms += [:submitting_type]
-    # placeholder about my program fields
+
     self.terms += [:committee_chair]
     self.terms += [:committee_members]
-    # removing these for About me demo
+
     self.terms -= [:rights]
 
     # about my etd terms
@@ -81,6 +81,13 @@ module Hyrax
     # Both String and boolean 'true' should count as true.
     def true_string?(field)
       field == 'true' || field == true
+    end
+
+    # we need to pass a nil to Hyrax in order to remove a subfield
+    # from an existing ETD, because the absence of the parameter won't
+    def self.sanitize_params(form_params)
+      form_params["subfield"] = nil unless form_params.include?("subfield")
+      super
     end
 
     # Select the correct affiliation type for committee member

--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -63,39 +63,14 @@ module EtdHelper
     private
 
       def departments(school)
-        return unless school
-        if school.include? 'Emory'
-          Hyrax::EmoryService.new.select_active_options
-        elsif school.include? 'Laney'
-          Hyrax::LaneyService.new.select_active_options
-        elsif school.include? 'Candler'
-          Hyrax::CandlerService.new.select_active_options
-        elsif school.include? 'Rollins'
-          Hyrax::RollinsService.new.select_active_options
-        else
-          []
-        end
+        service = Hyrax::LaevigataAuthorityService.for(school: school)
+
+        service&.select_active_options || []
       end
 
       def subfields(department)
-        if department == 'Biological and Biomedical Sciences'
-          Hyrax::BiologicalService.new.select_active_options
-        elsif department == 'Business'
-          Hyrax::BusinessService.new.select_active_options
-        elsif department == 'Executive Masters of Public Health - MPH'
-          Hyrax::EmphService.new.select_active_options
-        elsif department == 'Biostatistics and Bioinformatics'
-          Hyrax::BiostatisticsService.new.select_active_options
-        elsif department == 'Environmental Health'
-          Hyrax::EnvironmentService.new.select_active_options
-        elsif department == 'Epidemiology'
-          Hyrax::EpidemiologyService.new.select_active_options
-        elsif department == 'Psychology'
-          Hyrax::PsychologyService.new.select_active_options
-        elsif department.include? 'Religion'
-          Hyrax::ReligionService.new.select_active_options
-        else
-          []
-        end
+        service = Hyrax::LaevigataAuthorityService.for(department: department)
+
+        service&.select_active_options || []
       end
 end

--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -2,7 +2,7 @@ module EtdHelper
   def school_determined_departments(f)
     # if you are in a 'new' state, collection will be supplied by js so disable field, nothing selected
     if curation_concern.id.nil?
-      f.input :department, as: :select, include_blank: true, input_html: {
+      f.input :department, as: :select, include_blank: true, required: true, input_html: {
         class: 'form-control',
         'data-option-dependent' => true,
         'data-option-observed' => 'etd_school',
@@ -48,7 +48,7 @@ module EtdHelper
         disabled: true
       }, label: "Sub Field"
     else
-      f.input :subfield, as: :select, collection: subfields(curation_concern[:department].first), selected: curation_concern[:subfield].first, include_blank: true, input_html: {
+      f.input :subfield, as: :select, collection: subfields(curation_concern[:department].first), selected: curation_concern[:subfield].first, include_blank: true, required: true, input_html: {
         class: 'form-control',
         "data-option-dependent" => true,
         "data-option-observed" => "etd_department",
@@ -70,7 +70,6 @@ module EtdHelper
 
       def subfields(department)
         service = Hyrax::LaevigataAuthorityService.for(department: department)
-
         service&.select_active_options || []
       end
 end

--- a/app/services/hyrax/laevigata_authority_service.rb
+++ b/app/services/hyrax/laevigata_authority_service.rb
@@ -7,6 +7,70 @@ module Hyrax
   #
   # @see https://github.com/samvera/questioning_authority/#list-of-id-and-term-keys-and-optionally-active-key
   class LaevigataAuthorityService < Hyrax::QaSelectService
+    class << self
+      ##
+      # Builds an authority service for a given school or department.
+      #
+      # Given a school, a deparmental authority service is returned with the
+      # appropriate deparments within that school. Given a department, a
+      # subfield authority service is returned representing the subfields
+      # within the department.
+      #
+      # If both are given, an argument error is raised.
+      #
+      # @overload for(school:)
+      #   @param [#=~] school
+      #   @return [LaevigataAuthorityService] a departmental authority service
+      # @overload for(departement:)
+      #   @param [#=~] department
+      #   @return [LaevigataAuthorityService] a subfield authority service
+      #
+      # @raise [ArgumentError] when both a school and department are given.
+      def for(school: nil, department: nil)
+        return for_school(school)         if school     && !department
+        return for_department(department) if department && !school
+
+        raise(ArgumentError,
+              "Expected one of school or department. Got school: #{school}; department: #{department}")
+      end
+
+      ##
+      # @api private
+      def for_school(school)
+        case school
+        when /Emory/
+          Hyrax::EmoryService.new
+        when /Laney/
+          Hyrax::LaneyService.new
+        when /Candler/
+          Hyrax::CandlerService.new
+        when /Rollins/
+          Hyrax::RollinsService.new
+        end
+      end
+
+      ##
+      # @api private
+      def for_department(department)
+        case department
+        when 'Business'
+          Hyrax::BusinessService.new
+        when 'Executive Masters of Public Health - MPH'
+          Hyrax::ExecutiveService.new
+        when 'Biostatistics and Bioinformatics'
+          Hyrax::BiostatisticsService.new
+        when 'Environmental Health'
+          Hyrax::EnvironmentalService.new
+        when 'Epidemiology'
+          Hyrax::EpidemiologyService.new
+        when 'Psychology'
+          Hyrax::PsychologyService.new
+        when /Religion/
+          Hyrax::ReligionService.new
+        end
+      end
+    end
+
     def active?(id)
       authority.find(id).fetch('active', true)
     end

--- a/app/services/hyrax/laevigata_authority_service.rb
+++ b/app/services/hyrax/laevigata_authority_service.rb
@@ -57,10 +57,18 @@ module Hyrax
           Hyrax::BusinessService.new
         when 'Executive Masters of Public Health - MPH'
           Hyrax::ExecutiveService.new
+
+        # both Biostatistics programs have same sub-fields,
+        # returned by the same service
+        when 'Biostatistics'
+          Hyrax::BiostatisticsService.new
         when 'Biostatistics and Bioinformatics'
           Hyrax::BiostatisticsService.new
-        when 'Environmental Health'
+        when 'Biological and Biomedical Sciences'
+          Hyrax::BiologicalService.new
+        when 'Environmental Studies'
           Hyrax::EnvironmentalService.new
+        # both Laney and Rollins have Epidemiology departments with same set of sub-fields, returned by the service
         when 'Epidemiology'
           Hyrax::EpidemiologyService.new
         when 'Psychology'

--- a/spec/features/create_etd_about_me_spec.rb
+++ b/spec/features/create_etd_about_me_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Create an Etd' do
       expect(page).to have_css('#about_me select#etd_partnering_agency')
     end
 
-    scenario "validates 'about me and my program'", js: true unless continuous_integration? do
+    scenario "validates 'about me and my program'", js: true do
       fill_in 'Student Name', with: 'Eun, Dongwon'
       select("Spring 2018", from: "Graduation Date")
       fill_in "Post Graduation Email", with: "graduate@done.com"
@@ -42,11 +42,11 @@ RSpec.feature 'Create an Etd' do
       select("Religion", from: "Department")
       select("Ethics and Society", from: "Sub Field")
       select('MS', from: "Degree")
-      select("Honors Thesis", from: "Submission Type")
-      fill_in "Committee Chair/Thesis Advisor", with: "Diane Arbus"
+
+      fill_in "etd[committee_chair_attributes][0][name][]", with: "Diane Arbus"
 
       fill_in "etd[committee_members_attributes][0][name][]", with: "Joan Didion"
-
+      select("Honors Thesis", from: "Submission Type")
       expect(page).to have_css('li#required-about-me.complete')
     end
 
@@ -142,6 +142,46 @@ RSpec.feature 'Create an Etd' do
       fill_in "etd[committee_members_attributes][0][name][]", with: "Joan Didion"
 
       expect(page).not_to have_css('li#required-about-me.complete')
+    end
+
+    scenario "requires departments", js: true do
+      visit("/concern/etds/new")
+
+      fill_in 'Student Name', with: 'Eun, Dongwon'
+      select("Spring 2018", from: "Graduation Date")
+      fill_in "Post Graduation Email", with: "graduate@done.com"
+      select("Emory College", from: "School")
+
+      select('MS', from: "Degree")
+      select("Honors Thesis", from: "Submission Type")
+      fill_in "etd[committee_chair_attributes][0][name][]", with: "Diane Arbus"
+
+      fill_in "etd[committee_members_attributes][0][name][]", with: "Joan Didion"
+      expect(page).not_to have_css('li#required-about-me.complete')
+
+      select("English and History", from: "Department")
+
+      expect(page).to have_css('li#required-about-me.complete')
+    end
+
+    scenario "departments with subfields require them", js: true do
+      visit("/concern/etds/new")
+
+      fill_in 'Student Name', with: 'Eun, Dongwon'
+      select("Spring 2018", from: "Graduation Date")
+      fill_in "Post Graduation Email", with: "graduate@done.com"
+      select("Emory College", from: "School")
+      select("Environmental Studies", from: "Department")
+      select('MS', from: "Degree")
+      select("Honors Thesis", from: "Submission Type")
+      fill_in "etd[committee_chair_attributes][0][name][]", with: "Diane Arbus"
+
+      fill_in "etd[committee_members_attributes][0][name][]", with: "Joan Didion"
+
+      expect(page).not_to have_css('li#required-about-me.complete')
+      select("Environmental Health - MPH", from: "Sub Field")
+
+      expect(page).to have_css('li#required-about-me.complete')
     end
   end
 end

--- a/spec/features/create_etd_review_spec.rb
+++ b/spec/features/create_etd_review_spec.rb
@@ -29,6 +29,8 @@ RSpec.feature 'Create an Etd' do
       fill_in 'Post Graduation Email', with: 'frodo@example.com'
       select("Rollins School of Public Health", from: "School")
       select("Epidemiology", from: "Department")
+      # corrected laevigata program names means a subfield is required with Epidemiology
+      select("Epidemiology - MPH & MSPH", from: "Sub Field")
 
       expect(page).to have_select('Partnering Agency')
       select('CDC', from: 'Partnering Agency')
@@ -273,6 +275,8 @@ RSpec.feature 'Create an Etd' do
       fill_in 'Post Graduation Email', with: 'frodo@example.com'
       select("Rollins School of Public Health", from: "School")
       select("Epidemiology", from: "Department")
+      # corrected laevigata program names means a subfield is required with Epidemiology
+      select("Epidemiology - MPH & MSPH", from: "Sub Field")
 
       select('CDC', from: 'Partnering Agency')
       select 'PhD', from: 'Degree'

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -132,7 +132,6 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs do
       let(:dept) { 'Biological and Biomedical Sciences' }
       let(:subfield) { ['Genetics and Molecular Biology'] }
       let(:attach_supp_files) { true }
-
       let(:embargo_attrs) do
         {
           files_embargoed: true,
@@ -145,7 +144,7 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs do
       scenario "edit a field", js: true do
         visit hyrax_etd_path(etd)
         click_on('Edit')
-
+        sleep(5)
         # Verify existing data in About Me tab
         expect(find_field('Student Name').value).to eq attrs[:creator].first
         expect(find_field('Student Name')).not_to be_disabled
@@ -157,6 +156,7 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs do
         expect(find_field('School')).not_to be_disabled
         expect(find_field('Department').value).to eq attrs[:department].first
         expect(find_field('Department')).not_to be_disabled
+
         expect(find_field('Sub Field').value).to eq attrs[:subfield].first
         expect(find_field('Sub Field')).not_to be_disabled
         expect(find_field('Degree').value).to eq attrs[:degree].first
@@ -269,7 +269,7 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs do
         click_on('About Me')
         select 'Chemistry', from: 'Department'
         # Subfield should change according to department
-        expect(find_field('Sub Field').value).to eq ''
+        expect(find_field('Sub Field', disabled: true)).to be_disabled
 
         # Edit a committee member
         fill_in 'etd[committee_members_attributes][0]_name', with: 'Betty'

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Hyrax::EtdForm do
     its(:terms) { is_expected.to include(:submitting_type) }
   end
 
+  describe "editing an ETD" do
+    context 'when removing a subfield' do
+      let(:form_params) { { "creator" => ['Joey'] } }
+      let(:sanitized_params) { { "creator" => ['Joey'], "subfield" => nil } }
+      it "gives Hyrax what it needs to execute the removal" do
+        allow(Hyrax::Forms::WorkForm).to receive(:sanitize_params).with(form_params)
+
+        described_class.sanitize_params(form_params)
+
+        expect(form_params).to eq(sanitized_params)
+      end
+    end
+  end
+
   describe "#primary_pdf_name" do
     subject { form.primary_pdf_name }
 

--- a/spec/services/hyrax/laevigata_authority_service_spec.rb
+++ b/spec/services/hyrax/laevigata_authority_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hyrax::LaevigataAuthorityService do
 
     describe 'regression tests' do
       it 'has an enviornmental service' do
-        expect(described_class.for(department: 'Environmental Health'))
+        expect(described_class.for(department: 'Environmental Studies'))
           .to be_a Hyrax::EnvironmentalService
       end
 

--- a/spec/services/hyrax/laevigata_authority_service_spec.rb
+++ b/spec/services/hyrax/laevigata_authority_service_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Hyrax::LaevigataAuthorityService do
+  describe '.for' do
+    it 'raises an error if no arguments are passed' do
+      expect { described_class.for }.to raise_error ArgumentError
+    end
+
+    it 'raises an error if both a school and department are passed' do
+      expect { described_class.for(school: 'Moomin College', department: 'Moomin Studies') }
+        .to raise_error ArgumentError
+    end
+
+    it 'gives a department service when a school is given' do
+      expect(described_class.for(school: 'Emory'))
+        .to be_a Hyrax::EmoryService
+    end
+
+    it 'gives a different department service when another school is given' do
+      expect(described_class.for(school: 'Laney School'))
+        .to be_a Hyrax::LaneyService
+    end
+
+    it 'is nil an invalid school is given' do
+      expect(described_class.for(school: 'Moomin College')).to be_nil
+    end
+
+    it 'gives a subfield service when a department is given' do
+      expect(described_class.for(department: 'Business'))
+        .to be_a Hyrax::BusinessService
+    end
+
+    it 'gives a different subfield service when another department is given' do
+      expect(described_class.for(department: 'Religion or something'))
+        .to be_a Hyrax::ReligionService
+    end
+
+    it 'is nil an invalid department is given' do
+      expect(described_class.for(school: 'Moomin Studies')).to be_nil
+    end
+
+    describe 'regression tests' do
+      it 'has an enviornmental service' do
+        expect(described_class.for(department: 'Environmental Health'))
+          .to be_a Hyrax::EnvironmentalService
+      end
+
+      it 'has an EMPH service' do
+        expect(described_class.for(department: 'Executive Masters of Public Health - MPH'))
+          .to be_a Hyrax::ExecutiveService
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needs review, particularly for accuracy and internal alignment of department and subfield names, and needs thorough user acceptance testing for school, department and subfield validation. One known issue is storing department names in the js, which creates an extra maintenance burden and a point of potential failure. Some of the feature tests could probably benefit from filling fields out of the sequential order they appear in on the page, additionally, there is a 5-second sleep added to the edit spec solving a timing issue that could possibly be better addressed. Refactoring the front end validation, which has grown complicated due to multiple dynamic and interdependent interactions, might be a good idea. 