### PR TITLE
Adds URLs to ETD show page, and degree awarded notification.

### DIFF
--- a/app/services/hyrax/workflow/degree_awarded_notification.rb
+++ b/app/services/hyrax/workflow/degree_awarded_notification.rb
@@ -12,7 +12,7 @@ module Hyrax
       end
 
       def message
-        "The degree associated with #{title} (#{link_to work_id, document_url}) has been awarded."
+        "The degree associated with #{title} (#{link_to document_url, document_url}) has been awarded."
       end
     end
   end

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -5,7 +5,9 @@
       <%= render 'work_title', presenter: @presenter %>
     </header>
 
+    <span>Permanent URL: <%= main_app.hyrax_etd_url(@presenter.id) %></span>
     <% unless @presenter.workflow.state_label == 'Approved' %>
+      <br />
       <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
     <% end %>
   </div>


### PR DESCRIPTION
No tests, as these are in views, although I'm happy to add them.

Here's a before:
![before](https://user-images.githubusercontent.com/638392/38335399-27f346be-382c-11e8-9935-2fc7bd1b3538.JPG)

And after:
![after](https://user-images.githubusercontent.com/638392/38335445-50df5612-382c-11e8-99b2-33845919091b.JPG)

