### PR TITLE
Restart sidekiq with systemctl in production

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,6 +34,26 @@ append :linked_files, "config/redis.yml"
 append :linked_files, "config/secrets.yml"
 append :linked_files, "config/solr.yml"
 
+# We have to re-define capistrano-sidekiq's tasks to work with
+# systemctl in production
+namespace :sidekiq do
+  task :stop do
+    on roles(:app) do
+      execute :sudo, :systemctl, :stop, :sidekiq
+    end
+  end
+  task :stop do
+    on roles(:app) do
+      execute :sudo, :systemctl, :start, :sidekiq
+    end
+  end
+  task :restart do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :sidekiq
+    end
+  end
+end
+
 namespace :deploy do
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -7,9 +7,12 @@ namespace :sidekiq do
   desc "Sidekiq stop"
   task :stop do
     puts "--- Trying to stop Sidekiq Now ---"
-    if File.exist?(sidekiq_pid_file)
+    if Rails.env == 'development' && File.exist?(sidekiq_pid_file)
       puts "Stopping sidekiq now #PID-#{File.readlines(sidekiq_pid_file).first}..."
       system "sidekiqctl stop #{sidekiq_pid_file}" # stops sidekiq process here
+    elsif Rails.env == 'production'
+      system "sudo /bin/systemctl stop sidekiq" # stops sidekiq process here
+      puts "--- Stopping sidekiq with systemctl ---"
     else
       puts "--- Sidekiq Not Running ---"
     end
@@ -18,9 +21,14 @@ namespace :sidekiq do
   desc "Sidekiq start"
   task :start do
     puts "Starting Sidekiq..."
-    system "bundle exec sidekiq -e#{Rails.env} -C config/sidekiq.yml -P #{sidekiq_pid_file} -d -L #{sidekiq_log_file}" # starts sidekiq process here
-    sleep(2)
-    puts "Sidekiq started #PID-#{File.readlines(sidekiq_pid_file).first}."
+    if Rails.env == 'development'
+      system "bundle exec sidekiq -e#{Rails.env} -C config/sidekiq.yml -P #{sidekiq_pid_file} -d -L #{sidekiq_log_file}" # starts sidekiq process here
+      sleep(2)
+      puts "Sidekiq started #PID-#{File.readlines(sidekiq_pid_file).first}."
+    elsif Rails.env == 'production'
+      system "sudo /bin/systemctl stop sidekiq" # stops sidekiq process here
+      puts "--- Starting sidekiq with systemctl ---"
+    end
   end
 
   desc "Sidekiq restart"


### PR DESCRIPTION
We need to ensure that sidekiq is always running in production.
That means we need to make it a managed system service, so
it will start running again if the system reboots or something
unexpected like a crash happens.

See https://thomasroest.com/2017/03/04/properly-setting-up-redis-and-sidekiq-in-production-ubuntu-16-04.html for more details