### PR TITLE
Fallback admin set

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -68,6 +68,10 @@ class Etd < ActiveFedora::Base
     return department.first if valid_admin_sets.include?(department.first)
     return subfield.first if valid_admin_sets.include?(subfield.first)
 
+    Honeybadger.notify("No AdminSet was found for school: #{school}; " \
+                       "department: #{department}; subfield: #{subfield}.\n" \
+                       "Assigned to #{FALLBACK_ADMIN_SET_ID}.\n#{inspect}")
+
     FALLBACK_ADMIN_SET_ID
   end
 

--- a/spec/controllers/hyrax/etds_controller_office_document_bug_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_office_document_bug_spec.rb
@@ -2,7 +2,7 @@
 #  `rails generate hyrax:work Etd`
 require 'rails_helper'
 
-RSpec.describe Hyrax::EtdsController, :perform_jobs do
+RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
   let(:params) do
     eval(File.read("#{fixture_path}/form_submission_params/office_document_bug.rb")) # rubocop:disable Security/Eval
   end
@@ -13,7 +13,6 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs do
     describe "POST create" do
       it "doesn't crash when it receives massive office document input" do
         allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-        ActiveFedora::Cleaner.clean!
         w.setup
         allow(request.env['warden']).to receive(:authenticate!).and_return(user)
         allow(controller).to receive(:current_user).and_return(user)

--- a/spec/features/embargo_show_spec.rb
+++ b/spec/features/embargo_show_spec.rb
@@ -4,7 +4,7 @@ require 'workflow_setup'
 require 'etd_factory'
 include Warden::Test::Helpers
 
-RSpec.feature 'Display an ETD with embargoed content' do
+RSpec.feature 'Display an ETD with embargoed content', :clean do
   let(:etd) do
     etd = FactoryBot.create(:sample_data_with_everything_embargoed, school: ["Candler School of Theology"])
     etd_factory = EtdFactory.new
@@ -19,7 +19,6 @@ RSpec.feature 'Display an ETD with embargoed content' do
   let(:depositor) { User.where(ppid: etd.depositor).first }
   let(:approver) { User.where(ppid: 'candleradmin').first }
   before do
-    ActiveFedora::Cleaner.clean!
     w.setup
     allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
   end

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -5,7 +5,7 @@ require 'active_fedora/cleaner'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Laney Graduate School two step approval workflow', :perform_jobs do
+RSpec.feature 'Laney Graduate School two step approval workflow', :perform_jobs, :clean do
   let(:depositing_user) { User.where(ppid: etd.depositor).first }
   let(:approving_user) { User.where(uid: "laneyadmin").first }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }
@@ -13,7 +13,6 @@ RSpec.feature 'Laney Graduate School two step approval workflow', :perform_jobs 
   context 'a logged in user' do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      ActiveFedora::Cleaner.clean!
       w.setup
       actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
       actor.create({})

--- a/spec/features/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/features/undergrad_honors_workflow_etd_spec.rb
@@ -5,7 +5,7 @@ require 'active_fedora/cleaner'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Emory College approval workflow', :perform_jobs do
+RSpec.feature 'Emory College approval workflow', :perform_jobs, :clean do
   let(:depositing_user) { User.where(ppid: etd.depositor).first }
   let(:approving_user) { User.where(uid: "ecadmin").first }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
@@ -13,7 +13,6 @@ RSpec.feature 'Emory College approval workflow', :perform_jobs do
   context 'a logged in user' do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      ActiveFedora::Cleaner.clean!
       w.setup
       actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
       actor.create({})

--- a/spec/jobs/proquest_job_spec.rb
+++ b/spec/jobs/proquest_job_spec.rb
@@ -3,7 +3,7 @@ require 'active_fedora/cleaner'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-describe ProquestJob do
+describe ProquestJob, :clean do
   context "Laney PhD" do
     let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }
     let(:etd) { FactoryBot.create(:ready_for_proquest_submission_phd) }
@@ -32,7 +32,6 @@ describe ProquestJob do
     let(:approving_user) { User.where(ppid: 'laneyadmin').first }
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      ActiveFedora::Cleaner.clean!
       w.setup
       actor.create(attributes_for_actor)
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,11 @@ RSpec.configure do |config|
     ActiveFedora::Cleaner.clean!
   end
 
+  config.before clean: true do
+    DatabaseCleaner.clean
+    ActiveFedora::Cleaner.clean!
+  end
+
   config.before do
     DatabaseCleaner.strategy = :transaction
   end

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -3,7 +3,7 @@ require 'active_fedora/cleaner'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-describe GraduationService do
+describe GraduationService, :clean do
   let(:graduated_user) { FactoryBot.create(:graduated_user) }
   let(:nongraduated_user) { FactoryBot.create(:nongraduated_user) }
   let(:approving_user) { User.where(uid: "candleradmin").first }
@@ -11,7 +11,6 @@ describe GraduationService do
   let(:graduated_etd) { FactoryBot.create(:sample_data) }
   let(:nongraduated_etd) { FactoryBot.create(:sample_data) }
   before do
-    ActiveFedora::Cleaner.clean!
     w.setup
     # Create and approve the graduated ETD
     actor = Hyrax::CurationConcern.actor(graduated_etd, ::Ability.new(graduated_user))


### PR DESCRIPTION
The unassigned `AdminSet` is introduced as a catch-all for submitted ETDs that
couldn't be automatically assigned to another AdminSet. It has a generic
one-step approval process.

The purpose of this change is to avoid raising user facing errors when complex
internal admin set logic fails. Ideally, no items would ever be assigned to this
set; when they are, however, they can be triaged and repaired by
administrators. This avoids letting issues impact students at submission time.

Related to #924.