### PR TITLE
enabling partnering agency in editing

### DIFF
--- a/app/assets/javascripts/about_me_and_my_program.es6
+++ b/app/assets/javascripts/about_me_and_my_program.es6
@@ -6,17 +6,23 @@ export default class AboutMeAndMyProgram {
     this.attach_add_committee_listeners('chair')
     this.attach_add_committee_listeners('member')
     this.attach_school_listener()
+    this.display_partnering_agencies()
   }
 
-  // Partnering Agencies are not shown unless the Rollins School is selected (or derived from the student's netId, potentially.)
+  // Partnering Agencies are not shown unless the Rollins School is selected during the creation of an ETD, or is the existing ETD's school during editing of an ETD
+
+  display_partnering_agencies(){
+    if($('#etd_school').val() === "Rollins School of Public Health"){
+      $('#rollins_partnering_agencies').show()
+    } else {
+      $('#rollins_partnering_agencies').hide();
+    }
+  }
 
   attach_school_listener(){
+    var form = this
     $('#etd_school').on('change', function(){
-      if ($(this).val() === "Rollins School of Public Health"){
-        $('#rollins_partnering_agencies').show();
-      } else {
-        $('#rollins_partnering_agencies').hide();
-      }
+      form.display_partnering_agencies();
     });
   }
 

--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -1,62 +1,32 @@
 module EtdHelper
   def school_determined_departments(f)
     # if you are in a 'new' state, collection will be supplied by js so disable field, nothing selected
-    if curation_concern.id.nil?
-      f.input :department, as: :select, include_blank: true, required: true, input_html: {
-        class: 'form-control',
-        'data-option-dependent' => true,
-        'data-option-observed' => 'etd_school',
-        'data-option-url' => '/authorities/terms/local/:etd_school:',
-        'data-option-key-method' => :id,
-        'data-option-value-method' => :name, disabled: true
-      }, label: 'Department'
+    if curation_concern.new_record?
+      f.input :department, department_form_opts(disabled: true)
     else
-      # if you are in an 'edit' state
-      f.input :department, as: :select, collection: departments(curation_concern[:school].first), selected: curation_concern[:department].first, include_blank: true, required: true, input_html: {
-        class: 'form-control',
-        'data-option-dependent' => true,
-        'data-option-observed' => 'etd_school',
-        'data-option-url' => '/authorities/terms/local/:etd_school:',
-        'data-option-key-method' => :id,
-        'data-option-value-method' => :name, disabled: false
-      }, label: 'Department'
+      f.input :department, department_form_opts(disabled: false).merge(collection: departments(curation_concern[:school].first), selected: curation_concern[:department].first)
     end
   end
 
   def department_determined_subfields(f)
     # a 'new' state, nothing is selected and disable subfields
-    if curation_concern.id.nil?
-      f.input :subfield, as: :select, include_blank: true, input_html: {
-        class: 'form-control',
-        "data-option-dependent" => true,
-        "data-option-observed" => "etd_department",
-        "data-option-url" => "/authorities/terms/local/:etd_department:",
-        "data-option-key-method" => :id,
-        "data-option-value-method" => :name,
-        disabled: true
-      }, label: "Sub Field"
-    # either new or department without subfields,
-    # in either case collection will be supplied by js, disable fields and nothing selected
-    elsif curation_concern['subfield'].empty?
-      f.input :subfield, as: :select, include_blank: true, input_html: {
-        class: 'form-control',
-        "data-option-dependent" => true,
-        "data-option-observed" => "etd_department",
-        "data-option-url" => "/authorities/terms/local/:etd_department:",
-        "data-option-key-method" => :id,
-        "data-option-value-method" => :name,
-        disabled: true
-      }, label: "Sub Field"
+    if curation_concern.new_record? || curation_concern['subfield'].empty?
+
+      f.input :subfield, subfield_form_opts(disabled: true)
+
     else
-      f.input :subfield, as: :select, collection: subfields(curation_concern[:department].first), selected: curation_concern[:subfield].first, include_blank: true, required: true, input_html: {
-        class: 'form-control',
-        "data-option-dependent" => true,
-        "data-option-observed" => "etd_department",
-        "data-option-url" => "/authorities/terms/local/:etd_department:",
-        "data-option-key-method" => :id,
-        "data-option-value-method" => :name,
-        disabled: false
-      }, label: "Sub Field"
+      f.input :subfield, subfield_form_opts(disabled: false).merge(collection: subfields(curation_concern[:department].first), selected: curation_concern[:subfield].first)
+    end
+  end
+
+  def partnering_agency(f)
+    if curation_concern.new_record?
+      f.input :partnering_agency,
+              partnering_agency_form_opts
+    else
+      f.input :partnering_agency, partnering_agency_form_opts.merge(
+        selected: curation_concern[:partnering_agency].first
+      )
     end
   end
 
@@ -71,5 +41,35 @@ module EtdHelper
       def subfields(department)
         service = Hyrax::LaevigataAuthorityService.for(department: department)
         service&.select_active_options || []
+      end
+
+      def partnering_agency_form_opts
+        partnering_service = PartnersService.new
+        { as: :etd_multi_value_select,
+          include_blank: true, label: "Partnering Agency", collection: partnering_service.select_all_options,
+          input_html: { class: 'form-control' } }
+      end
+
+      def subfield_form_opts(disabled:)
+        { as: :select, include_blank: true, input_html: {
+          class: 'form-control',
+          "data-option-dependent" => true,
+          "data-option-observed" => "etd_department",
+          "data-option-url" => "/authorities/terms/local/:etd_department:",
+          "data-option-key-method" => :id,
+          "data-option-value-method" => :name,
+          disabled: disabled
+        }, label: "Sub Field" }
+      end
+
+      def department_form_opts(disabled:)
+        { as: :select, include_blank: true, required: true, input_html: {
+          class: 'form-control',
+          'data-option-dependent' => true,
+          'data-option-observed' => 'etd_school',
+          'data-option-url' => '/authorities/terms/local/:etd_school:',
+          'data-option-key-method' => :id,
+          'data-option-value-method' => :name, disabled: disabled
+        }, label: 'Department' }
       end
 end

--- a/app/views/records/edit_fields/_partnering_agency.html.erb
+++ b/app/views/records/edit_fields/_partnering_agency.html.erb
@@ -3,8 +3,6 @@
   <% partnering_service = PartnersService.new %>
   <h3>Partnering Agency</h3>
   <div class="form-instructions">Select a maximum of three partnering agencies you worked with or used as a resource. If you used data from an agency, include them in this section. Otherwise, select "Does not apply (no collaborating organization)."</div>
-  <%= f.input :partnering_agency, as: :etd_multi_value_select,
-    collection: partnering_service.select_all_options,
-    include_blank: true, label: "Partnering Agency",
-    input_html: { class: 'form-control' } %>
+  
+  <%= partnering_agency(f) %>
 </div>

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs do
       scenario "on the edit form", js: true do
         visit hyrax_etd_path(etd)
         click_on('Edit')
-
+        sleep(5)
         # Verify correct Department is selected and not disabled, Sub Fields is disabled
         expect(find('#etd_department').value).to eq dept
         expect(find('#etd_department')).not_to be_disabled
@@ -125,6 +125,10 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs do
         expect(find_by_id('embargo_school')).to be_disabled
         expect(find_by_id('etd_embargo_length')).to be_disabled
         expect(page).to have_css('li#required-embargoes.complete')
+
+        # A Laney student should not see the Partnering Agency content
+        expect(page).not_to have_content('Partnering Agency')
+        expect(page).not_to have_css('#etd_partnering_agency')
       end
     end
 

--- a/spec/features/edit_rollins_spec.rb
+++ b/spec/features/edit_rollins_spec.rb
@@ -1,0 +1,96 @@
+# Generated via `rails generate hyrax:work Etd`
+require 'rails_helper'
+require 'active_fedora/cleaner'
+require 'workflow_setup'
+include Warden::Test::Helpers
+
+RSpec.feature 'Edit an existing ETD', :perform_jobs do
+  let(:approver) { User.where(uid: "epidemiology_admin").first }
+  let(:student) { create :user }
+
+  let(:etd) { FactoryBot.build(:etd, attrs) }
+  let(:primary_pdf_file) { File.join(fixture_path, "joey/joey_thesis.pdf") }
+
+  let(:attrs) do
+    {
+      depositor: student.user_key,
+      title: ['A Rollins thesis by Joey'],
+      creator: ['Johnson, Joey'],
+      graduation_date: ['Spring 2018'],
+      post_graduation_email: ['frodo@example.com'],
+      school: ['Rollins School of Public Health'],
+      department: ['Epidemiology'],
+      subfield: ['Epidemiology - MPH & MSPH'],
+      degree: ['Ph.D.'],
+      submitting_type: ['Dissertation'],
+      partnering_agency: ['CDC'],
+      committee_chair_attributes: cc_attrs,
+      committee_members_attributes: cm_attrs,
+      language: ['English'],
+      abstract: ['<p>Literature from the US</p>'],
+      table_of_contents: ['<h1>Chapter One</h1>'],
+      research_field: ['Aeronomy'],
+      keyword: ['key1'],
+      copyright_question_one: false,
+      copyright_question_two: true,
+      copyright_question_three: false,
+      files_embargoed: embargo_attrs[:files_embargoed],
+      abstract_embargoed: embargo_attrs[:abstract_embargoed],
+      toc_embargoed: embargo_attrs[:toc_embargoed],
+      embargo_length: embargo_attrs[:embargo_length]
+    }
+  end
+
+  let(:embargo_attrs) do
+    {
+      files_embargoed: false,
+      abstract_embargoed: false,
+      toc_embargoed: false,
+      embargo_length: nil
+    }
+  end
+
+  let(:cc_attrs) { [{ name: 'Fred' }] }
+  let(:cm_attrs) { [{ name: 'Barney' }] }
+
+  let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/epidemiology_admin_sets.yml", "/dev/null") }
+
+  before do
+    ActiveFedora::Cleaner.clean!
+
+    # Create AdminSet and Workflow
+    workflow_setup.setup
+
+    # Don't characterize the file during specs
+    allow(CharacterizeJob).to receive_messages(perform_later: nil, perform_now: nil)
+
+    # Create ETD & attach PDF file
+    etd.assign_admin_set
+    uploaded_etd = File.open(primary_pdf_file) { |file| Hyrax::UploadedFile.create(user: student, file: file, pcdm_use: 'primary') }
+    file_ids = [uploaded_etd.id]
+
+    actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(student))
+    attributes_for_actor = { uploaded_files: file_ids }
+    actor.create(attributes_for_actor)
+
+    # Approver requests changes, so student will be able to edit the ETD
+    change_workflow_status(etd, "request_changes", approver)
+
+    # Don't run background jobs during the spec
+    allow(ActiveJob::Base).to receive_messages(perform_later: nil, perform_now: nil)
+  end
+
+  context 'a logged in Rollins student edits their ETD', js: true do
+    before { login_as student }
+
+    scenario "and Partnering Agency is displayed" do
+      visit hyrax_etd_path(etd)
+      click_on('Edit')
+      sleep(5)
+
+      expect(page).to have_content('Partnering Agency')
+      expect(page).to have_css('#etd_partnering_agency')
+      expect(page).to have_css('li#required-about-me.complete')
+    end
+  end
+end


### PR DESCRIPTION
This commit makes the partnering agency inputs load when the edit form loads, rather than only upon selecting Rollins from the school select. There is also some minor js refactoring, a new Rollins edit spec, a check for correct partnering display in the create spec, and re-naming a few scenarios in specs for better clarity.