### PR TITLE
Clear capistrano tasks before re-defining them

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,13 +36,16 @@ append :linked_files, "config/solr.yml"
 
 # We have to re-define capistrano-sidekiq's tasks to work with
 # systemctl in production
+Rake::Task["sidekiq:stop"].clear_actions
+Rake::Task["sidekiq:start"].clear_actions
+Rake::Task["sidekiq:restart"].clear_actions
 namespace :sidekiq do
   task :stop do
     on roles(:app) do
       execute :sudo, :systemctl, :stop, :sidekiq
     end
   end
-  task :stop do
+  task :start do
     on roles(:app) do
       execute :sudo, :systemctl, :start, :sidekiq
     end
@@ -50,17 +53,6 @@ namespace :sidekiq do
   task :restart do
     on roles(:app) do
       execute :sudo, :systemctl, :restart, :sidekiq
-    end
-  end
-end
-
-namespace :deploy do
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
     end
   end
 end


### PR DESCRIPTION
Otherwise they run twice and we end up with extra
copies of sidekiq running.

Also, fix a typo and remove unused cap task.