### PR TITLE
Never display permission badges for `FileSet`

### DIFF
--- a/app/presenters/file_set_presenter.rb
+++ b/app/presenters/file_set_presenter.rb
@@ -12,4 +12,13 @@ class FileSetPresenter < Hyrax::FileSetPresenter
     return true if solr_document["pcdm_use_tesim"] == "supplementary"
     false
   end
+
+  ##
+  # @note we never display permission badges for `FileSet` objects, embargo
+  #   status depends on the parent `Etd`
+  #
+  # @return [String] sanitized HTML for the permission badge
+  def permission_badge
+    ''
+  end
 end

--- a/spec/presenters/file_set_presenter_spec.rb
+++ b/spec/presenters/file_set_presenter_spec.rb
@@ -17,5 +17,11 @@ describe FileSetPresenter do
     # If the fields require no addition logic for display, you can simply delegate
     # them to the solr document
     it { is_expected.to delegate_method(:pcdm_use).to(:solr_document) }
+
+    describe '#permission_badge' do
+      it 'has no permission badge' do
+        expect(presenter.permission_badge).to eq ''
+      end
+    end
   end
 end


### PR DESCRIPTION
Embargo status for `FileSet` depends on the `#files_embargoed` flag as well as
the embargo set on the parent `Etd`. We don't want to display the permission
badge using the usual logic that ignores this information. The presenter overide
ensures we always display `''` as the badge.