### PR TITLE
Return empty metadata instead of `nil`

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -114,7 +114,14 @@ module Hyrax
         uploaded_file.save
         return true
       end
+
       supplemental_file_metadata = get_supplemental_file_metadata(filename, params)
+
+      if supplemental_file_metadata.empty?
+        Honeybadger.notify "No metadata was assigned for #{filename} on #{params['etd']['title']}\n" \
+                           "The uploaded file was: #{uploaded_file.id};\nThe params were: #{params}."
+      end
+
       uploaded_file.title = supplemental_file_metadata["title"]
       uploaded_file.description = supplemental_file_metadata["description"]
       uploaded_file.file_type = supplemental_file_metadata["file_type"]
@@ -126,8 +133,8 @@ module Hyrax
     # @param [Hash] params
     # @return [Hash]
     def get_supplemental_file_metadata(filename, params)
-      supplemental_file_metadata = params["etd"]["supplemental_file_metadata"].values
-      supplemental_file_metadata.select { |a| a["filename"] == filename }.first
+      supplemental_file_metadata = params["etd"]["supplemental_file_metadata"]&.values || {}
+      supplemental_file_metadata.find { |a| a["filename"] == filename } || {}
     end
 
     def get_filename_for_uploaded_file(uploaded_file, params)

--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -344,6 +344,12 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs do
       expect(metadata["description"]).to eq "Super Great"
       expect(metadata["file_type"]).to eq "Image"
     end
+    it "gets supplemental file metadata for fake filename" do
+      metadata = described_class.new.get_supplemental_file_metadata("nil.png", params)
+      expect(metadata["title"]).to be_nil
+      expect(metadata["description"]).to be_nil
+      expect(metadata["file_type"]).to be_nil
+    end
     it "creates an UploadedFile object for each entry in the uploaded_files array" do
       described_class.new.apply_file_metadata(params)
       params["uploaded_files"].each do |be_upload_url|


### PR DESCRIPTION
Some submissions fail at the `EtdsController` due to missing supplemental file
metadata. The reason this is missing coming from the form is currently unknown,
but there's no reason the submission needs to fail in this case.

Instead, we return an empty metadata set and save the uploaded file. We notify
Honeybadger of the error with relevant metadata.

Resolves https://app.honeybadger.io/projects/54219/faults/37338090