### PR TITLE
Filenames must match when retrieving uploaded file metadata

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -127,7 +127,7 @@ module Hyrax
     # @return [Hash]
     def get_supplemental_file_metadata(filename, params)
       supplemental_file_metadata = params["etd"]["supplemental_file_metadata"].values
-      supplemental_file_metadata.select { |a| a["filename"] == filename }.first
+      supplemental_file_metadata.select { |a| a["filename"].tr(' ', '_') == filename.tr(' ', '_') }.first
     end
 
     def get_filename_for_uploaded_file(uploaded_file, params)


### PR DESCRIPTION
The file uploader re-names uploaded files to replace spaces
with underscores. We need to do the same replacement when
matching on uploaded_file_metadata, otherwise it won't retrieve
the metadata.

Fixes #976 