### PR TITLE
Return a 404 for unmatched routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,4 +34,8 @@ class ApplicationController < ActionController::Base
   def user_root_path
     new_hyrax_etd_path
   end
+
+  rescue_from ActionController::RoutingError do |exception|
+    render plain: '404 Not found', status: 404
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,6 +5,12 @@ class CatalogController < ApplicationController
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 
+  # If a requested url doesn't match any routes, send it here and raise a
+  # RoutingError, which gets caught by the ApplicationController
+  def catch_404
+    raise ActionController::RoutingError, params[:path]
+  end
+
   def self.uploaded_field
     solr_name('system_create', :stored_sortable, type: :date)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,4 +58,6 @@ Rails.application.routes.draw do
   authenticate :user, ->(u) { u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end
+
+  match "*path", to: "catalog#catch_404", via: :all
 end


### PR DESCRIPTION
Currently we create an error message and a stack trace every
time someone requests an unknown route. Since we're getting
crawled by search engines and security scans, this happens
a lot and it makes our log files less useful than they might be.

When we get a request for an unrecognized route, just return a 404
and move on.

Connected to https://github.com/curationexperts/laevigata/issues/987