### PR TITLE
Do not re-try box attachment jobs

### DIFF
--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -17,7 +17,7 @@ describe ImportUrlJob do
     it 'raises an exception when it encounters a box error message' do
       VCR.use_cassette("box_error", record: :new_episodes) do
         operation = Hyrax::Operation.create!(user: admin, operation_type: "Attach Remote File")
-        expect { described_class.perform_now(fileset, operation) }.to raise_exception(ImportUrlJob::RetrievalError)
+        expect { described_class.perform_now(fileset, operation) }.not_to raise_exception
       end
     end
   end


### PR DESCRIPTION
If a file fails to attach from box.com, it isn't going to
recover and succeed next time -- do not keep re-trying it.
Instead, log the id of the ETD that had a problem and be
able to track down whether it eventually got all it's files.

Connected to #992 