### PR TITLE
Catch any places where we can't update post-graduation email

### DIFF
--- a/spec/jobs/graduation_job_spec.rb
+++ b/spec/jobs/graduation_job_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-describe GraduationJob do
+describe GraduationJob, :clean do
   context "calculating embargo_release_date", :clean do
     it "can interpret a length of '6 months'" do
       e = described_class.embargo_length_to_embargo_release_date(Time.zone.today, "6 months")


### PR DESCRIPTION
Make these errors more actionable.
Often they are caused by fake (testing) data, but we can't
just throw them away in case there's ever a real problem.
This should make it obvious whether it's a real problem for
a real student.

Connected to #985 