### PR TITLE
Log all scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ Laevigata depends on certain environment variables being set. In development mod
 * `PROQUEST_NOTIFICATION_EMAIL`
 * `REGISTRAR_DATA_PATH` - the file from which to load registrar data (e.g., for graduation status and dates)
 
+## Cron jobs in production 
+
+There are certain cron jobs that are expected to run in production. These include graduation job, 
+fixity audit, embargo expiration, and others. We use the `whenever` gem to manage these.
+If you need to make changes to the scheduled jobs, please update `config/schedule.rb` and the new crontab should be installed via capistrano when the code is deployed.
+
+Please note that in order to run as expected, the PATH must be defined: run `crontab -e` as the `deploy` user and
+ensure these lines are at the top of your cron file:
+```
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+```
+
+**Please ensure that any scheduled jobs write to the rails log file so we can track whether they are
+running as expected.**
+
 ## Developer Setup
 
 1. Change to your working directory for new development projects   

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,9 +19,6 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Email output to Bess, for now
-env 'MAILTO', 'bess@curationexperts.com'
-
 # Weekly, check whether students have graduated and kick off
 # graduation jobs if so
 every :monday, at: '12:20am' do

--- a/lib/tasks/embargo_notifications.rake
+++ b/lib/tasks/embargo_notifications.rake
@@ -1,6 +1,7 @@
 namespace :emory do
   desc "Remove expired embargoes and send notifications. Pass date YYYY-MM-DD. Defaults to today."
   task :embargo_expiration, [:date] => [:environment] do |_t, args|
+    Rails.logger.warn "Running EmbargoExpirationService"
     EmbargoExpirationService.run(args[:date])
   end
 end

--- a/lib/tasks/fixity.rake
+++ b/lib/tasks/fixity.rake
@@ -1,6 +1,7 @@
 namespace :emory do
   desc "Whole repository fixity check"
   task :fixity do
+    Rails.logger.warn "Running Hyrax::RepositoryAuditService"
     Hyrax::RepositoryAuditService.audit_everything
   end
 end

--- a/lib/tasks/graduation.rake
+++ b/lib/tasks/graduation.rake
@@ -1,7 +1,7 @@
 namespace :emory do
   desc "Check for new graduates."
   task :graduation do
-    puts "Running GraduationService with file #{ENV['REGISTRAR_DATA_PATH']}"
+    Rails.logger.warn "Running GraduationService with file #{ENV['REGISTRAR_DATA_PATH']}"
     GraduationService.run
   end
 end

--- a/lib/tasks/proquest_export.rake
+++ b/lib/tasks/proquest_export.rake
@@ -1,7 +1,7 @@
 namespace :emory do
   desc "Export and optionally send a specific ProQuest package"
   task :proquest_export, [:id] => [:environment] do |_t, args|
-    puts "Running ProquestJob for id #{args[:id]}"
+    Rails.logger.warn "Running ProquestJob for id #{args[:id]}"
     ProquestJob.perform_now(args[:id], transmit: false, cleanup: false, retransmit: true)
   end
 end

--- a/lib/tasks/proquest_notifications.rake
+++ b/lib/tasks/proquest_notifications.rake
@@ -1,7 +1,7 @@
 namespace :emory do
   desc "Send notifications about proquest submissions -- Pass date YYYY-MM-DD -- Defaults to today."
   task :proquest_notifications, [:date] => [:environment] do |_t, args|
-    puts "Running ProquestNotificationService"
+    Rails.logger.warn "Running ProquestNotificationService"
     ProquestNotificationService.run(args[:date])
   end
 end

--- a/lib/tasks/read_only.rake
+++ b/lib/tasks/read_only.rake
@@ -2,7 +2,9 @@ namespace :emory do
   namespace :read_only do
     desc "Put the system in read-only mode to enable consistent backups"
     task :on do
-      puts "Going into read-only mode to enable backups."
+      message = "Going into read-only mode to enable backups."
+      Rails.logger.warn message
+      puts message
       read_only_feature = Hyrax::Feature.find_by_key("read_only")
       read_only_feature.enabled = true
       read_only_feature.save
@@ -12,7 +14,9 @@ namespace :emory do
 
     desc "Turn off read-only mode: restore normal operations."
     task :off do
-      puts "Restoring normal operations."
+      message = "Restoring normal operations -- turning off read only mode."
+      Rails.logger.warn message
+      puts message
       read_only_feature = Hyrax::Feature.find_by_key("read_only")
       read_only_feature.enabled = false
       read_only_feature.save


### PR DESCRIPTION
It appears that some of our scheduled jobs stopped running
as expected at some point and we didn't notice.

Going forward, we should ensure that all scheduled jobs leave
a record of their having run in the log file, which we should
be able to track in splunk.

Connected to #997 