### PR TITLE
Do not run the Hyrax Audit Service

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,10 +31,6 @@ every :day, at: '11:55pm' do
   rake "emory:proquest_notifications"
 end
 
-every :saturday, at: '1:20am' do
-  rake "emory:fixity"
-end
-
 every :day, at: '2:20am' do
   rake "emory:embargo_expiration"
 end

--- a/lib/tasks/fixity.rake
+++ b/lib/tasks/fixity.rake
@@ -1,7 +1,0 @@
-namespace :emory do
-  desc "Whole repository fixity check"
-  task :fixity do
-    Rails.logger.warn "Running Hyrax::RepositoryAuditService"
-    Hyrax::RepositoryAuditService.audit_everything
-  end
-end


### PR DESCRIPTION
It emails the depositor of any work found to have a
fixity issue. This is not the behavior we want.