### PR TITLE
Check that the do_not_send.yml file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ running as expected.**
 ## Suppressing email for bouncing addresses
 
 If an email address is bouncing, or if someone prefers not to receive email notifications,
-add the email address to the list in `app/lib/email_intercept.rb`
+add the email address to the list in `config/emory/do_not_send.yml`
 
 ## Developer Setup
 

--- a/app/lib/email_intercept.rb
+++ b/app/lib/email_intercept.rb
@@ -2,7 +2,12 @@ require 'yaml'
 
 class EmailIntercept
   def self.delivering_email(message)
-    do_not_send = YAML.load_file(Rails.root.join('config', 'emory', 'do_not_send.yml'))
+    do_not_send_file = Rails.root.join('config', 'emory', 'do_not_send.yml')
+    unless File.file? do_not_send_file
+      Rails.logger.error "Missing config file: #{do_not_send_file}"
+      return
+    end
+    do_not_send = YAML.load_file(do_not_send_file)
     message.to.each do |recipient|
       message.perform_deliveries = false if do_not_send.include? recipient
     end


### PR DESCRIPTION
Just in case the file isn't on a server where this is
deployed, don't raise an exception.
Log an error message if the config file is missing.