### PR TITLE
Clarify developer setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ add the email address to the list in `config/emory/do_not_send.yml`
     `cd laevigata`
 1. Use set your ruby version to **2.3.4** and the gemset of your choice  
     eg. `rvm use --create 2.3.4@laevigata`
+1. Install gem dependencies  
+    `bundle install`
 1. Start redis  
     `redis-server &`  
     *note:* use ` &` to start in the background, or run redis in a new terminal session  


### PR DESCRIPTION
It's obvious once you get the error, but if you're following the developer setup instructions verbatim, they ask you to run the server without installing dependencies