### PR TITLE
Add ENV['BRANCH'] option to deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,7 +16,7 @@ set :assets_prefix, "#{shared_path}/public/assets"
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
 # Default branch is :master
-set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || 'master'
+set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || ENV['BRANCH'] || 'master'
 
 append :linked_dirs, "config/emory"
 append :linked_dirs, "public/assets"


### PR DESCRIPTION
Laevigata uses `BRANCH_NAME` to deploy a specific branch, but `BRANCH` is the variable used in `ansible-samvera`. 

This will let you change the branch when deploying with `ansible-samvera`.