### PR TITLE
Stop create duplicate grants on workflow setup

### DIFF
--- a/lib/tasks/permission_template_access_dedup.rake
+++ b/lib/tasks/permission_template_access_dedup.rake
@@ -1,0 +1,17 @@
+namespace :emory do
+  desc 'Deduplicate PermissionTemplateAccesses'
+  task :deduplicate_permission_template_accesses do
+    ActiveRecord::Base.transaction do
+      AdminSet.all.each do |admin_set|
+        access_grants = Hyrax::PermissionTemplateAccess
+                          .where(permission_template_id: admin_set.permission_template.id,
+                                 agent_id:   'registered',
+                                 access:     'deposit',
+                                 agent_type: 'group').to_a
+
+        access_grants.pop
+        access_grants.each(&:destroy)
+      end
+    end
+  end
+end

--- a/lib/workflow_setup.rb
+++ b/lib/workflow_setup.rb
@@ -156,6 +156,12 @@ class WorkflowSetup
   # Allow anyone with a registered account to deposit into any of the AdminSets
   def everyone_can_deposit_everywhere
     AdminSet.all.each do |admin_set|
+      next if Hyrax::PermissionTemplateAccess
+                .find_by(permission_template_id: admin_set.permission_template.id,
+                         agent_id:   'registered',
+                         access:     'deposit',
+                         agent_type: 'group')
+
       admin_set.permission_template.access_grants.create(agent_type: 'group', agent_id: 'registered', access: 'deposit')
       deposit = Sipity::Role.find_by!(name: 'depositing')
       admin_set.permission_template.available_workflows.each do |workflow|


### PR DESCRIPTION
We used to create a new grant for deposit access to 'registered' on each workflow setup (i.e. every deploy). These duplicate entries are no longer allowed in Hyrax 2.0 breaking deployment. We also introduce a one-time rake task to clean up the duplicates.