### PR TITLE
Update WorkflowsController to fix Review Submissions page

### DIFF
--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -4,12 +4,15 @@
 module Hyrax
   # Presents a list of works in workflow
   class Admin::WorkflowsController < ApplicationController
-    before_action :ensure_admin!
-    layout 'admin'
+    before_action :ensure_authorized!
+    layout 'dashboard'
+    class_attribute :deposited_workflow_state_name
+
+    self.deposited_workflow_state_name = 'published'
 
     def index
       add_breadcrumb t(:'hyrax.controls.home'), root_path
-      add_breadcrumb t(:'hyrax.toolbar.admin.menu'), hyrax.admin_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
       add_breadcrumb t(:'hyrax.admin.sidebar.tasks'), '#'
       add_breadcrumb t(:'hyrax.admin.sidebar.workflow_review'), request.path
       @status_list = Hyrax::Workflow::StatusListService.new(self, "-workflow_state_name_ssim:#{deposited_workflow_state_name}")
@@ -18,14 +21,8 @@ module Hyrax
 
     private
 
-      def ensure_admin!
-        # Even though the user can view this admin set, they may not be able to view
-        # it on the admin page.
-        authorize! :read, :admin_dashboard
-      end
-
-      def deposited_workflow_state_name
-        'published'
+      def ensure_authorized!
+        authorize! :review, :submissions
       end
   end
 end

--- a/spec/features/workflow_approval_spec.rb
+++ b/spec/features/workflow_approval_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+require 'workflow_setup'
+include Warden::Test::Helpers
+
+RSpec.feature 'Dashboard workflow', :clean do
+  let(:approving_user)  { User.find_by(uid: "candleradmin") }
+  let(:depositing_user) { User.find_by(ppid: etd.depositor) }
+  let(:etd)             { create(:sample_data, school: ["Candler School of Theology"]) }
+
+  before do
+    WorkflowSetup
+      .new("#{fixture_path}/config/emory/superusers.yml",
+           "#{fixture_path}/config/emory/candler_admin_sets.yml",
+           "/dev/null")
+      .setup
+    login_as approving_user
+  end
+
+  scenario 'approver can approve submitted etd', :perform_jobs do
+    allow(CharacterizeJob).to receive(:perform_later) # don't run fits
+    Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user)).create({})
+
+    expect(etd.active_workflow.name).to eq 'emory_one_step_approval'
+    expect(etd.to_sipity_entity.reload.workflow_state_name).to eq 'pending_approval'
+
+    visit '/dashboard'
+    click_on 'Review Submissions'
+
+    expect(page).to have_content etd.title.first
+    expect(page).to have_content depositing_user.user_key
+    expect(page).to have_content 'pending_approval'
+  end
+end


### PR DESCRIPTION
The WorkflowsController has changed in Hyrax 2.0, breaking our local overrides. This updates the controller to contain the current code. We keep the local workflow state name as "published".

A feature test is included to catch regressions.