### PR TITLE
Actor deprecations

### DIFF
--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -10,25 +10,13 @@ module Hyrax
     class DefaultAdminSetActor < Hyrax::Actors::AbstractActor
       attr_accessor :curation_concern
 
-      def create(attributes)
-        if attributes.is_a? Hyrax::Actors::Environment
-          env                   = attributes
-          attributes            = env.attributes
-          self.curation_concern = env.curation_concern
-        end
-
-        ensure_admin_set_attribute!(attributes)
+      def create(env)
+        ensure_admin_set_attribute!(env.attributes)
         next_actor.create(env)
       end
 
-      def update(attributes)
-        if attributes.is_a? Hyrax::Actors::Environment
-          env                   = attributes
-          attributes            = env.attributes
-          self.curation_concern = env.curation_concern
-        end
-
-        ensure_admin_set_attribute!(attributes)
+      def update(env)
+        ensure_admin_set_attribute!(env.attributes)
         next_actor.update(env)
       end
 

--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -5,26 +5,18 @@ module Hyrax
     class InterpretVisibilityActor < AbstractActor
       attr_accessor :curation_concern
 
-      def create(attributes)
-        if attributes.is_a? Hyrax::Actors::Environment
-          env                   = attributes
-          attributes            = env.attributes
-          self.curation_concern = env.curation_concern
-        end
+      def create(env)
+        @attributes           = env.attributes
+        self.curation_concern = env.curation_concern
 
-        @attributes = attributes
         save_embargo_and_visibility_data
         next_actor.create(env)
       end
 
-      def update(attributes)
-        if attributes.is_a? Hyrax::Actors::Environment
-          env                   = attributes
-          attributes            = env.attributes
-          self.curation_concern = env.curation_concern
-        end
+      def update(env)
+        @attributes           = env.attributes
+        self.curation_concern = env.curation_concern
 
-        @attributes = attributes
         save_embargo_and_visibility_data
         next_actor.update(env)
       end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -201,21 +201,6 @@ Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 
-Hyrax::CurationConcern.class_eval do
-  def self.actor(*args)
-    @work_middleware_stack ||= actor_factory.build(Hyrax::Actors::Terminator.new)
-    return @work_middleware_stack if args.empty?
-
-    warn "[DEPRECATION] calling `CurationConcern.actor` with arguments is " \
-         "deprecated and removed from Hyrax 2.0.0. Pass a " \
-         "`Hyrax::Actors::Environment` to `#create`, `#update` or `#delete` " \
-         "instead.\nCalled from #{Gem.location_of_caller.join(':')}"
-
-    concern, ability = args.take(2)
-    Hyrax::Actors::ActorStack.new(concern, ability, @work_middleware_stack)
-  end
-end
-
 module Hyrax
   module Actors
     class ActorStack

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -89,9 +89,11 @@ namespace :sample_data do
         upload2 = File.open(file2_path) do |file2|
           Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
         end
-        actor = Hyrax::CurationConcern.actor(etd, ability)
-        attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-        actor.create(attributes_for_actor)
+
+        attributes = { uploaded_files: [upload1.id, upload2.id] }
+        env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+
+        Hyrax::CurationConcern.actor.create(env)
         puts "Created #{etd.id}"
       end
     end
@@ -131,9 +133,11 @@ namespace :sample_data do
     file2 = File.open("#{::Rails.root}/spec/fixtures/miranda/image.tif")
     upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
     upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    attributes_for_actor = { embargo_length: etd.embargo_length, uploaded_files: [upload1.id, upload2.id] }
-    actor.create(attributes_for_actor)
+
+    attributes = { embargo_length: etd.embargo_length, uploaded_files: [upload1.id, upload2.id] }
+    env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+
     approving_user = User.where(ppid: 'candleradmin').first
     subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
@@ -160,9 +164,11 @@ namespace :sample_data do
         file_type: 'Image'
       )
     }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-    actor.create(attributes_for_actor)
+
+    attributes = { uploaded_files: [upload1.id, upload2.id] }
+    env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+
     approving_user = User.where(ppid: 'tezprox').first
     subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
@@ -208,9 +214,11 @@ namespace :sample_data do
         file_type: 'Software'
       )
     }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-    actor.create(attributes_for_actor)
+
+    attributes = { uploaded_files: [upload1.id, upload2.id] }
+    env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+    Hyrax::CurationConcern.actor.create(env)
+
     etd
   end
 
@@ -236,9 +244,11 @@ namespace :sample_data do
       file2 = File.open("#{::Rails.root}/spec/fixtures/miranda/image.tif")
       upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
       upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
-      actor = Hyrax::CurationConcern.actor(etd, ability)
-      attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-      actor.create(attributes_for_actor)
+
+      attributes = { uploaded_files: [upload1.id, upload2.id] }
+      env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+      Hyrax::CurationConcern.actor.create(env)
+
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
       sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
       Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Preapproved")

--- a/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/default_admin_set_actor_spec.rb
@@ -2,31 +2,26 @@ libdir = File.expand_path('../../../../', __FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
 
-RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
-  before :all do
-    ActiveFedora::Cleaner.clean!
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean
-  end
+RSpec.describe Hyrax::Actors::DefaultAdminSetActor, :clean do
+  subject(:actor)  { described_class.new(next_actor) }
   let(:next_actor) { double('next actor', create: true) }
-  let(:actor) do
-    Hyrax::Actors::ActorStack.new(etd, depositor_ability, [described_class])
-  end
+
   let(:depositor) { create(:user) }
   let(:depositor_ability) { ::Ability.new(depositor) }
+  let(:env) { Hyrax::Actors::Environment.new(etd, depositor_ability, attributes) }
   let(:etd) { FactoryBot.create(:sample_data, admin_set: nil, school: ["Laney Graduate School"]) }
   let(:admin_set) { FactoryBot.create(:admin_set, title: ["Laney Graduate School"], id: "f1881k888") }
 
   describe "create" do
     before do
-      allow(Hyrax::Actors::Terminator).to receive(:new).and_return(next_actor)
       allow(next_actor).to receive(:create).with(admin_set_id: admin_set.id).and_return(true)
     end
 
     context "when there is no admin_set assigned" do
       let(:attributes) { { admin_set_id: '' } }
       it "assigns the admin_set and admin_set id" do
-        actor.create(attributes)
+        actor.create(env)
+
         expect(next_actor)
           .to have_received(:create)
           .with(have_attributes(attributes: { admin_set_id: admin_set.id }))
@@ -37,7 +32,8 @@ RSpec.describe Hyrax::Actors::DefaultAdminSetActor do
       let(:attributes) { { admin_set_id: admin_set.id } }
 
       it "keeps the admin_set id" do
-        actor.create(attributes)
+        actor.create(env)
+
         expect(next_actor)
           .to have_received(:create)
           .with(have_attributes(attributes: attributes))

--- a/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/interpret_visibility_actor_spec.rb
@@ -1,22 +1,26 @@
 libdir = File.expand_path('../../../../', __FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
+
 describe Hyrax::Actors::InterpretVisibilityActor do
+  subject(:actor)  { described_class.new(next_actor) }
+  let(:next_actor) { Hyrax::Actors::EtdActor.new(root_actor) }
+  let(:root_actor) { Hyrax::Actors::Terminator.new }
+
   let(:user) { create(:user) }
+  let(:env) { Hyrax::Actors::Environment.new(etd, Ability.new(user), attributes) }
   let(:etd) { FactoryBot.create(:etd) }
-  let(:actor) do
-    Hyrax::Actors::ActorStack.new(etd,
-                                  ::Ability.new(user),
-                                  [described_class,
-                                   Hyrax::Actors::EtdActor])
-  end
   let(:six_years_from_today) { Time.zone.today + 6.years }
   let(:date) { Time.zone.today + 2 }
 
   describe 'the next actor' do
     let(:root_actor) { double }
+
     before do
-      allow(Hyrax::Actors::Terminator).to receive(:new).and_return(root_actor)
+      allow(root_actor)
+        .to receive(:create)
+        .with(an_instance_of(Hyrax::Actors::Environment))
+
       allow(etd).to receive(:save).and_return(true)
     end
 
@@ -27,15 +31,11 @@ describe Hyrax::Actors::InterpretVisibilityActor do
       end
 
       it 'removes embargo_release_date from attributes' do
-        allow(root_actor)
-          .to receive(:create)
-          .with(an_instance_of(Hyrax::Actors::Environment))
-
-        actor.create(attributes)
+        actor.create(env)
 
         expect(root_actor)
           .to have_received(:create)
-          .with(an_instance_of(Hyrax::Actors::Environment))
+          .with(have_attributes(attributes: attributes.except(:embargo_length).stringify_keys))
       end
     end
   end
@@ -61,15 +61,15 @@ describe Hyrax::Actors::InterpretVisibilityActor do
       context 'with an embargo length' do
         let(:date) { Time.zone.today + 2 }
         it 'sets a temporary embargo release of date six years from today' do
-          actor.create(attributes)
+          actor.create(env)
           expect(etd.embargo.embargo_release_date).to eq six_years_from_today
         end
         it "saves the embargo length" do
-          actor.create(attributes)
+          actor.create(env)
           expect(etd.embargo_length).to eq "6 months"
         end
         it "sets the visibility to open" do
-          actor.create(attributes)
+          actor.create(env)
           expect(etd.visibility).to eq "open"
         end
       end
@@ -92,7 +92,7 @@ describe Hyrax::Actors::InterpretVisibilityActor do
     end
     context 'without an embargo length' do
       it "does not create an embargo" do
-        actor.create(attributes)
+        actor.create(env)
         expect(etd.embargo).to eq nil
         expect(etd.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       end

--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
       end
 
       # Create the ETD record
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(user))
       attributes_for_actor ||= {}
-      actor.create(attributes_for_actor)
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(user), attributes_for_actor)
+      Hyrax::CurationConcern.actor.create(env)
 
       # Approver requests changes, so student will be able to edit the ETD
       change_workflow_status(etd, "request_changes", approver)

--- a/spec/features/candler_workflow_etd_spec.rb
+++ b/spec/features/candler_workflow_etd_spec.rb
@@ -16,8 +16,8 @@ RSpec.feature 'Candler approval workflow', :perform_jobs, :clean do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      actor.create({})
+      env = Hyrax::Actors::Environment.new(etd, Ability.new(depositing_user), {})
+      Hyrax::CurationConcern.actor.create(env)
     end
     scenario "a school approver approves a work" do
       # Check the ETD was assigned the right workflow

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -71,9 +71,9 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
       file_ids << uploaded_supp.id
     end
 
-    actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(student))
-    attributes_for_actor = { uploaded_files: file_ids }
-    actor.create(attributes_for_actor)
+    attributes = { uploaded_files: file_ids }
+    env        = Hyrax::Actors::Environment.new(etd, ::Ability.new(student), attributes)
+    Hyrax::CurationConcern.actor.create(env)
 
     # Approver requests changes, so student will be able to edit the ETD
     change_workflow_status(etd, "request_changes", approver)

--- a/spec/features/edit_rollins_spec.rb
+++ b/spec/features/edit_rollins_spec.rb
@@ -66,9 +66,10 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
     uploaded_etd = File.open(primary_pdf_file) { |file| Hyrax::UploadedFile.create(user: student, file: file, pcdm_use: 'primary') }
     file_ids = [uploaded_etd.id]
 
-    actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(student))
-    attributes_for_actor = { uploaded_files: file_ids }
-    actor.create(attributes_for_actor)
+    attributes = { uploaded_files: file_ids }
+    env        = Hyrax::Actors::Environment.new(etd, ::Ability.new(student), attributes)
+
+    Hyrax::CurationConcern.actor.create(env)
 
     # Approver requests changes, so student will be able to edit the ETD
     change_workflow_status(etd, "request_changes", approver)

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -13,9 +13,12 @@ RSpec.feature 'Laney Graduate School two step approval workflow', :perform_jobs,
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      actor.create({})
+
+      Hyrax::CurationConcern
+        .actor
+        .create(Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), {}))
     end
+
     scenario "an approver reviews and approves a work" do
       expect(etd.active_workflow.name).to eq "laney_graduate_school"
       expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_review"

--- a/spec/features/rollins_workflow_etd_spec.rb
+++ b/spec/features/rollins_workflow_etd_spec.rb
@@ -20,8 +20,9 @@ RSpec.feature 'Create a Rollins ETD', :perform_jobs, :clean, :js do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      actor.create({})
+
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), {})
+      Hyrax::CurationConcern.actor.create(env)
     end
     scenario "Miranda submits a thesis and an approver approves it", js: true do
       expect(etd.active_workflow.name).to eq "emory_one_step_approval"

--- a/spec/features/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/features/undergrad_honors_workflow_etd_spec.rb
@@ -13,8 +13,9 @@ RSpec.feature 'Emory College approval workflow', :perform_jobs, :clean, :js do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      actor.create({})
+
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), {})
+      Hyrax::CurationConcern.actor.create(env)
     end
     scenario "a school approver approves a work" do
       expect(etd.active_workflow.name).to eq "emory_one_step_approval"

--- a/spec/features/virus_workflow_etd_spec.rb
+++ b/spec/features/virus_workflow_etd_spec.rb
@@ -22,9 +22,10 @@ RSpec.feature 'Virus checking', :perform_jobs, :clean, :js do
       class_double("Clamby").as_stubbed_const
       allow(Clamby).to receive(:virus?).and_return(true)
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      attributes_for_actor = { uploaded_files: [upload1.id] }
-      actor.create(attributes_for_actor)
+
+      attributes = { uploaded_files: [upload1.id] }
+      env        = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), attributes)
+      Hyrax::CurationConcern.actor.create(env)
     end
     scenario "supplemental file with virus" do
       # Check the ETD was assigned the right workflow

--- a/spec/features/workflow_approval_spec.rb
+++ b/spec/features/workflow_approval_spec.rb
@@ -18,7 +18,8 @@ RSpec.feature 'Dashboard workflow', :clean do
 
   scenario 'approver can approve submitted etd', :perform_jobs do
     allow(CharacterizeJob).to receive(:perform_later) # don't run fits
-    Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user)).create({})
+    env = Hyrax::Actors::Environment.new(etd, Ability.new(depositing_user), {})
+    Hyrax::CurationConcern.actor.create(env)
 
     expect(etd.active_workflow.name).to eq 'emory_one_step_approval'
     expect(etd.to_sipity_entity.reload.workflow_state_name).to eq 'pending_approval'

--- a/spec/jobs/graduation_job_spec.rb
+++ b/spec/jobs/graduation_job_spec.rb
@@ -58,8 +58,9 @@ describe GraduationJob, :clean do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      actor.create({})
+
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), {})
+      Hyrax::CurationConcern.actor.create(env)
 
       # The approving user approves the ETD before graduation
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)

--- a/spec/models/proquest_behaviors_etd_spec.rb
+++ b/spec/models/proquest_behaviors_etd_spec.rb
@@ -29,13 +29,15 @@ RSpec.describe Etd, :perform_jobs, :clean do
         )
       end
     end
-    let(:actor) { Hyrax::CurationConcern.actor(etd, ability) }
+    let(:actor) { Hyrax::CurationConcern.actor }
     let(:attributes_for_actor) { { uploaded_files: [upload1.id, upload2.id] } }
     let(:approving_user) { User.where(ppid: 'laneyadmin').first }
+    let(:env) { Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor) }
+
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
       w.setup
-      actor.create(attributes_for_actor)
+      actor.create(env)
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
       sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
       Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Preapproved")

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -11,16 +11,20 @@ describe GraduationService, :clean do
   let(:nongraduated_etd) { FactoryBot.create(:sample_data) }
   before do
     w.setup
+
     # Create and approve the graduated ETD
-    actor = Hyrax::CurationConcern.actor(graduated_etd, ::Ability.new(graduated_user))
-    actor.create({})
+    env = Hyrax::Actors::Environment.new(graduated_etd, ::Ability.new(graduated_user), {})
+    Hyrax::CurationConcern.actor.create(env)
+
     subject = Hyrax::WorkflowActionInfo.new(graduated_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
     expect(graduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
+
     # Create and approve the nongraduated ETD
-    actor = Hyrax::CurationConcern.actor(nongraduated_etd, ::Ability.new(nongraduated_user))
-    actor.create({})
+    env = Hyrax::Actors::Environment.new(nongraduated_etd, ::Ability.new(nongraduated_user), {})
+    Hyrax::CurationConcern.actor.create(env)
+
     subject = Hyrax::WorkflowActionInfo.new(nongraduated_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = { admin_set_id: etd.admin_set.id }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    attributes = { admin_set_id: etd.admin_set.id }
+    env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+
+    Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/comment_notification_spec.rb
+++ b/spec/services/hyrax/workflow/comment_notification_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe Hyrax::Workflow::CommentNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, {})
+    Hyrax::CurationConcern.actor.create(env)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/degree_awarded_notification_spec.rb
+++ b/spec/services/hyrax/workflow/degree_awarded_notification_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe Hyrax::Workflow::DegreeAwardedNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = { admin_set_id: etd.admin_set.id }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    attributes = { admin_set_id: etd.admin_set.id }
+    env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+
+    Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/hidden_notification_spec.rb
+++ b/spec/services/hyrax/workflow/hidden_notification_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Hyrax::Workflow::HiddenNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, {})
+    Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/pending_approval_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_approval_notification_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Hyrax::Workflow::PendingApprovalNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, {})
+    Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/pending_review_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_review_notification_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, {})
+    Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/reviewed_notification_spec.rb
+++ b/spec/services/hyrax/workflow/reviewed_notification_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Hyrax::Workflow::ReviewedNotification, :clean do
   let(:notification) do
     env = Hyrax::Actors::Environment.new(etd, ability, {})
     Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/virus_encountered_notification_spec.rb
+++ b/spec/services/hyrax/workflow/virus_encountered_notification_spec.rb
@@ -15,9 +15,11 @@ RSpec.describe Hyrax::Workflow::VirusEncounteredNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = { admin_set_id: etd.admin_set.id }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
+    attributes = { admin_set_id: etd.admin_set.id }
+    env        = Hyrax::Actors::Environment.new(etd, ability, attributes)
+
+    Hyrax::CurationConcern.actor.create(env)
+
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)


### PR DESCRIPTION
When we upgraded to Hyrax 2.0, we shimmed in support for old style calls and added deprecation warnings. This removes the old actor stack calls in favor of the new Hyrax 2.0 syntax, then removes the deprecated code.