### PR TITLE
Fully clean data when testing embargo expiration service

### DIFF
--- a/spec/services/embargo_expiration_service_spec.rb
+++ b/spec/services/embargo_expiration_service_spec.rb
@@ -2,10 +2,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-describe EmbargoExpirationService do
-  before do
-    Etd.delete_all
-  end
+describe EmbargoExpirationService, :clean do
   context "rake task" do
     let(:expiration_service_instance) { instance_double(described_class) }
     it "sets the default date to today if no value is passed" do


### PR DESCRIPTION
There had been intermittent tombstone issues in these tests. Cleaning the database fully instead of deleting the ETDs is more stable.