### PR TITLE
Remove deprecated `curation_concerns_embargo_management` routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,8 +34,6 @@ Rails.application.routes.draw do
   end
 
   curation_concerns_basic_routes
-
-  curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
This command is now a no-op and raises deprecation warnings. Removing it leaves all the current behavior intact.