### PR TITLE
Use themed layout for workflows controller

### DIFF
--- a/app/controllers/hyrax/admin/workflows_controller.rb
+++ b/app/controllers/hyrax/admin/workflows_controller.rb
@@ -5,7 +5,7 @@ module Hyrax
   # Presents a list of works in workflow
   class Admin::WorkflowsController < ApplicationController
     before_action :ensure_authorized!
-    layout 'dashboard'
+    with_themed_layout 'dashboard'
     class_attribute :deposited_workflow_state_name
 
     self.deposited_workflow_state_name = 'published'


### PR DESCRIPTION
The older code made its way in with #1054, which worked for Hyrax 2.0, but was
merged concurrently with #1055 (Hyrax 2.1). In Hyrax 2.1, we need to use
`with_themed_layout` to correctly find the dashboard layout.