### PR TITLE
institute a flag for new UI development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 language: ruby
-# cache: bundler
+
 sudo: false
 services:
   - redis-server
@@ -20,7 +20,11 @@ script:
   - bundle exec rubocop
   - xvfb-run -a bundle exec rake ci
 env:
-  - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+  global:
+    - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
+  matrix:
+    - NEW_UI_ENABLED=false
+    - NEW_UI_ENABLED=true
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Laevigata depends on certain environment variables being set. In development mod
 * `PROQUEST_SFTP_PASSWORD`
 * `PROQUEST_NOTIFICATION_EMAIL`
 * `REGISTRAR_DATA_PATH` - the file from which to load registrar data (e.g., for graduation status and dates)
+* `NEW_UI_ENABLED` (should be set to default to false in all .env files)
 
 ## Cron jobs in production
 

--- a/config/new_ui.yml
+++ b/config/new_ui.yml
@@ -1,0 +1,6 @@
+development:
+  enabled: <%= ENV.fetch("NEW_UI_ENABLED", false) %>
+test:
+  enabled: <%= ENV.fetch("NEW_UI_ENABLED", false) %>
+production:
+  enabled: <%= ENV.fetch("NEW_UI_ENABLED", false) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,14 @@ Rails.application.routes.draw do
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
+  # While we work on new UI architecture, keep it accessible only when new_ui is true (see config/new_ui.yml).
+
+  if Rails.application.config_for('new_ui').fetch('enabled', false)
+    resources :in_progress_etds
+  end
+
   curation_concerns_basic_routes
+
   curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 


### PR DESCRIPTION
This commit creates a flag which determines whether the work creating a new UI and partial-save feature is enabled or not. The flag is available via Rails.application.config_for('new_ui') and defaults to false. It is now employed in the routes file and our .travis.yml, in which we have a build for each flag value. Addresses #1065 