### PR TITLE
mvc for new ui

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -1,0 +1,35 @@
+class InProgressEtdsController < ApplicationController
+  def new
+    @in_progress_etd = InProgressEtd.find_or_create_by(user_ppid: current_user.id)
+  end
+
+  def create
+    @in_progress_etd = InProgressEtd.new(in_progress_etd_params)
+    @in_progress_etd.save
+    redirect_to @in_progress_etd
+  end
+
+  def edit
+    @in_progress_etd = InProgressEtd.find(params[:id])
+  end
+
+  def update
+    @in_progress_etd = InProgressEtd.find(params[:id])
+
+    if @in_progress_etd.update(in_progress_etd_params)
+      redirect_to @in_progress_etd
+    else
+      render 'edit'
+    end
+  end
+
+  def show
+    @in_progress_etd = InProgressEtd.find(params[:id])
+  end
+
+  private
+
+    def in_progress_etd_params
+      params.require(:in_progress_etd).permit(:name, :email, :graduation_date, :submission_type)
+    end
+end

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -1,0 +1,2 @@
+class InProgressEtd < ApplicationRecord
+end

--- a/app/views/in_progress_etds/_form.html.erb
+++ b/app/views/in_progress_etds/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_for @in_progress_etd do |form| %>
+  <ul class='basic_list'>
+    <li>
+      <%= form.label(:name) %>
+      <%= form.text_field(:name) %>
+    </li>
+    <li>
+      <%= form.label(:email) %>
+      <%= form.text_field(:email) %>
+    </li>
+    <li>
+      <!-- TODO: capitalize appropriately -->
+      <%= form.label(:graduation_date) %>
+      <%= form.text_field(:graduation_date) %>
+    </li>
+    <li>
+      <%= form.label(:submission_type) %>
+      <%= form.text_field(:submission_type) %>
+    </li>
+    <li>
+      <%= form.submit('Save') %>
+    </li>
+  </ul>
+<% end %>

--- a/app/views/in_progress_etds/edit.html.erb
+++ b/app/views/in_progress_etds/edit.html.erb
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <%= render 'form' %>
+  </body>
+</html>

--- a/app/views/in_progress_etds/new.html.erb
+++ b/app/views/in_progress_etds/new.html.erb
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <%= render 'form' %>
+  </body>
+</html>

--- a/app/views/in_progress_etds/show.html.erb
+++ b/app/views/in_progress_etds/show.html.erb
@@ -1,0 +1,21 @@
+<html>
+  <head></head>
+  <body>
+    <h1>Your In-Progress ETD</h1>
+    <ul class='basic_list'>
+      <li>
+        Name <%= @in_progress_etd.name %>
+      </li>
+      <li>
+        Email <%= @in_progress_etd.email %>
+      </li>
+      <li>
+        Graduation Date <%= @in_progress_etd.graduation_date %>
+      </li>
+      <li>
+        Submission Type <%= @in_progress_etd.submission_type %>
+      </li>
+    </ul>
+    <%= link_to('Edit', edit_in_progress_etd_path(@in_progress_etd)) %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,10 @@ Rails.application.routes.draw do
   # While we work on new UI architecture, keep it accessible only when new_ui is true (see config/new_ui.yml).
 
   if Rails.application.config_for('new_ui').fetch('enabled', false)
+    get '/concern/etds/new', to: 'in_progress_etds#new'
     resources :in_progress_etds
+  else
+    get '/concern/etds/new', to: 'hyrax/etds#new'
   end
 
   curation_concerns_basic_routes

--- a/spec/controllers/in_progress_etds_controller_spec.rb
+++ b/spec/controllers/in_progress_etds_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe InProgressEtdsController do
+  render_views
+  if Rails.application.config_for('new_ui').fetch('enabled', false)
+    describe 'POST create' do
+      it 'persists a new InProgressEtd' do
+        post :create, params: { in_progress_etd: { name: 'Maud Gonne' } }
+
+        expect(InProgressEtd.all.count).to eq 1
+      end
+
+      it 'persists a new InProgressEtd with all of its attributes' do
+        post :create, params: { in_progress_etd: { name: 'Maud Gonne', email: 'maud@sinnfein.org', graduation_date: '1916', submission_type: 'Honors Thesis' } }
+
+        expect(InProgressEtd.last.name).to eq('Maud Gonne')
+        expect(InProgressEtd.last.email).to eq('maud@sinnfein.org')
+        expect(InProgressEtd.last.graduation_date).to eq('1916')
+        expect(InProgressEtd.last.submission_type).to eq('Honors Thesis')
+      end
+    end
+
+    describe 'GET Show' do
+      let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+      it 'shows an InProgressEtd' do
+        get :show, params: { id: in_progress_etd.id }
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    describe 'GET Edit' do
+      let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+
+      it 'displays the in_progress_etd edit form' do
+        get :edit, params: { id: in_progress_etd.id }
+      end
+    end
+
+    describe 'PUT #Create - Updates' do
+      it 'updates the in_progress_etd attributes' do
+        put :create, params: { in_progress_etd: { name: 'Frida Kahlo', email: 'frida@blue_house.mx', graduation_date: '1936', submission_type: 'PhD' } }
+
+        expect(InProgressEtd.last.name).to eq('Frida Kahlo')
+        expect(InProgressEtd.last.email).to eq('frida@blue_house.mx')
+        expect(InProgressEtd.last.graduation_date).to eq('1936')
+        expect(InProgressEtd.last.submission_type).to eq('PhD')
+      end
+    end
+
+    describe 'PATCH #Update - Updates' do
+      let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+      it 'updates the in_progress_etd attributes' do
+        patch :update, params: { id: in_progress_etd.id, in_progress_etd: { name: 'Tina Modetti', email: 'tina@blue_house.mx', graduation_date: '1926', submission_type: 'Never' } }
+
+        expect(InProgressEtd.last.name).to eq('Tina Modetti')
+        expect(InProgressEtd.last.email).to eq('tina@blue_house.mx')
+        expect(InProgressEtd.last.graduation_date).to eq('1926')
+        expect(InProgressEtd.last.submission_type).to eq('Never')
+      end
+    end
+  end
+end

--- a/spec/factories/in_progress_etds.rb
+++ b/spec/factories/in_progress_etds.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :in_progress_etd do
+    name "Miranda"
+    email "miranda@graduated.net"
+    graduation_date "Summer 2020"
+    submission_type "Master's Thesis"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -126,6 +126,15 @@ RSpec.configure do |config|
   #   describe "problem test", verify_partial_doubles: false do
   #     ...
   #   end
+
+  config.around(:each, type: :feature) do
+    ENV["NEW_UI_ENABLED"] = 'false'
+  end
+
+  config.before(:all, type: :view) do
+    skip("View tests run only when NEW_UI_ENABLED") if ENV["NEW_UI_ENABLED"] == 'false'
+  end
+
   config.before do |example|
     config.mock_with :rspec do |mocks|
       mocks.verify_partial_doubles = example.metadata.fetch(:verify_partial_doubles, true)

--- a/spec/views/in_progress_etds/_form.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/_form.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'in_progress_etds/_form.html.erb', type: :view do
+  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+  before do
+    assign(:in_progress_etd, in_progress_etd)
+    render
+  end
+
+  it 'the form has a name input' do
+    expect(rendered).to have_selector("input#in_progress_etd_name")
+  end
+
+  it 'the form has an email input' do
+    expect(rendered).to have_selector("input#in_progress_etd_email")
+  end
+
+  it 'the form has a graduation_date input' do
+    expect(rendered).to have_selector("input#in_progress_etd_graduation_date")
+  end
+
+  it 'the form has a submission_type input' do
+    expect(rendered).to have_selector("input#in_progress_etd_submission_type")
+  end
+end

--- a/spec/views/in_progress_etds/edit.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/edit.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'in_progress_etds/edit.html.erb', type: :view do
+  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+
+  before do
+    assign(:in_progress_etd, in_progress_etd)
+    render
+  end
+
+  it 'contains a form to edit an in_progress_etd' do
+    expect(rendered).to have_selector("form[action='/in_progress_etds/1']")
+  end
+end

--- a/spec/views/in_progress_etds/new.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/new.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'in_progress_etds/new.html.erb', type: :view do
+  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+
+  before do
+    assign(:in_progress_etd, in_progress_etd)
+    render
+  end
+
+  it 'contains a form to create a new in_progress_etd' do
+    expect(rendered).to have_selector("form[action='/in_progress_etds/1']")
+  end
+end

--- a/spec/views/in_progress_etds/show.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/show.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'in_progress_etds/show.html.erb', type: :view do
+  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+  before do
+    assign(:in_progress_etd, in_progress_etd)
+    render
+  end
+
+  it 'contains name' do
+    expect(rendered).to have_content('Miranda')
+  end
+
+  it 'contains email' do
+    expect(rendered).to have_content('miranda@graduated.net')
+  end
+
+  it 'contains graduation date' do
+    expect(rendered).to have_content('Summer 2020')
+  end
+
+  it 'contains submission type' do
+    expect(rendered).to have_content("Master's Thesis")
+  end
+end


### PR DESCRIPTION
This commit builds a new controller and some very minimal views for a very simple InProgressEtd model, behind the new_ui_enabled flag. It adds an RSpec config to set this flag to false for feature tests. The new controller allows for find_or_create_by a user_ppid property, which addresses the need for partial saves and one in_progress_etd per student. It currently requires a db migration, which will be added in a subsequent PR. Addresses #1072 and #1067 