### PR TITLE
add table for in-progress-etds to rails db

### DIFF
--- a/db/migrate/20180606164027_create_in_progress_etds.rb
+++ b/db/migrate/20180606164027_create_in_progress_etds.rb
@@ -1,0 +1,12 @@
+class CreateInProgressEtds < ActiveRecord::Migration[5.0]
+  def change
+    create_table :in_progress_etds do |t|
+      t.string :name
+      t.string :email
+      t.string :graduation_date
+      t.string :submission_type
+      t.string :user_ppid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180524202322) do
+ActiveRecord::Schema.define(version: 20180606164027) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -141,6 +141,16 @@ ActiveRecord::Schema.define(version: 20180524202322) do
     t.boolean  "enabled",    default: false, null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+  end
+
+  create_table "in_progress_etds", force: :cascade do |t|
+    t.string   "name"
+    t.string   "email"
+    t.string   "graduation_date"
+    t.string   "submission_type"
+    t.string   "user_ppid"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|


### PR DESCRIPTION
This commit adds a table to the Rails db, for persisting in-progress-etds. The table contains all of the ETD properties and the user's ppid. The addition of a user id in this table enables a very simple mechanism for enforcing one in-progress-etd per user, and editing with partial saves (find_or_create_by(:user_ppid) in InProgressEtds#new). Addresses #1080 and #1081.