### PR TITLE
Support inactive QA terms

### DIFF
--- a/app/services/hyrax/laevigata_authority_service.rb
+++ b/app/services/hyrax/laevigata_authority_service.rb
@@ -80,11 +80,23 @@ module Hyrax
     end
 
     def active?(id)
-      authority.find(id).fetch('active', true)
+      authority.find(id)&.fetch('active', true)
     end
 
     def active_elements
       authority.all.select { |e| e.fetch('active', true) }
+    end
+
+    def include_current_value(value, _index, render_options, html_options)
+      warn "#{self.class}##{__method__} has been implemented in Hyrax and can be removed." if
+        method(__method__).super_method
+
+      unless active?(value)
+        html_options[:class] << ' force-select'
+        render_options += [[label(value) { value }, value]]
+      end
+
+      [render_options, html_options]
     end
   end
 end

--- a/app/views/records/edit_fields/_degree.html.erb
+++ b/app/views/records/edit_fields/_degree.html.erb
@@ -1,5 +1,6 @@
 <% degree_service = Hyrax::DegreeService.new %>
 <%= f.input :degree, as: :select,
-    collection: degree_service.select_all_options,
+    collection: degree_service.select_active_options,
     include_blank: true, required: true,
+    item_helper: degree_service.method(:include_current_value),
     input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_graduation_date.html.erb
+++ b/app/views/records/edit_fields/_graduation_date.html.erb
@@ -1,5 +1,6 @@
-<% graduationdate_service = GraduationdateService.new %>
+<% graduation_date_service = GraduationdateService.new %>
 <%= f.input :graduation_date, label: "Graduation Date",
   as: :select, required: true,
-  collection: graduationdate_service.select_all_options,
+  collection: graduation_date_service.select_active_options,
+  item_helper: graduation_date_service.method(:include_current_value),
   input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,5 +1,6 @@
 <% language_service = Hyrax::LanguageService.new %>
 <%= f.input :language, as: :select, hint: false,
-    collection: language_service.select_all_options,
+    collection: language_service.select_active_options,
     include_blank: true, required: true,
+    item_helper: language_service.method(:include_current_value),
     input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_research_field.html.erb
+++ b/app/views/records/edit_fields/_research_field.html.erb
@@ -3,5 +3,6 @@
     collection: research_field_service.select_active_ids,
     label: 'Research Field', hint: 'Select at least one, but no more than three, research fields that best describe your work. List your primary field first. If you do not see your exact field, pick the closest option.',
     input_html: { class: 'form-control' },
+    item_helper: research_field_service.method(:include_current_value),
     include_blank: true, required: true
 %>

--- a/app/views/records/edit_fields/_school.html.erb
+++ b/app/views/records/edit_fields/_school.html.erb
@@ -1,5 +1,6 @@
 <% school_service = Hyrax::SchoolService.new %>
 <%= f.input :school, as: :select,
-    collection: school_service.select_all_options,
+    collection: school_service.select_active_options,
     include_blank: true, required: true,
+    item_helper: school_service.method(:include_current_value),
     input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_submitting_type.html.erb
+++ b/app/views/records/edit_fields/_submitting_type.html.erb
@@ -1,6 +1,7 @@
 <% submitting_service = SubmittingService.new %>
 <%= f.input :submitting_type, as: :select,
-    collection: submitting_service.select_all_options,
+    collection: submitting_service.select_active_options,
     include_blank: true, required: true,
     input_html: { class: 'form-control' },
+    item_helper: submitting_service.method(:include_current_value),
     label: "Submission Type" %>

--- a/spec/services/hyrax/laevigata_authority_service_spec.rb
+++ b/spec/services/hyrax/laevigata_authority_service_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::LaevigataAuthorityService do
+  subject(:select_service) { described_class.new('graduation_dates') }
+
   describe '.for' do
     it 'raises an error if no arguments are passed' do
       expect { described_class.for }.to raise_error ArgumentError
@@ -49,6 +51,26 @@ RSpec.describe Hyrax::LaevigataAuthorityService do
         expect(described_class.for(department: 'Executive Masters of Public Health - MPH'))
           .to be_a Hyrax::ExecutiveService
       end
+    end
+  end
+
+  describe '#include_current_value' do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it 'adds an inactive current value' do
+      expect(select_service.include_current_value('2009', :idx, render_opts, html_opts))
+        .to eq [[['2009', '2009']], { class: 'moomin force-select' }]
+    end
+
+    it 'does not add an empty/missing value' do
+      expect(select_service.include_current_value('', :idx, render_opts, html_opts))
+        .to eq [render_opts, html_opts]
+    end
+
+    it 'does not add an active current value' do
+      expect(select_service.include_current_value('Spring 2019', :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
     end
   end
 end


### PR DESCRIPTION
Add a helper that can be used when creating form select fields from QA authorities. This is implemented upstream in samvera/hyrax#3122, so a guard is included to flag removal upon a future upgrade.

Use the helper when building form fields; change the existing forms to use active terms only.

Connected to #1094.