### PR TITLE
Add an error class for admin set errors

### DIFF
--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -32,13 +32,29 @@ module Hyrax
         next_actor.update(env)
       end
 
+      class ResolutionError < ArgumentError
+        attr_reader :school, :department, :work
+
+        def initialize(msg = "Could not assign admin_set.",
+                       work = nil,
+                       school = nil,
+                       department = nil)
+          @department = department
+          @school     = school
+          @work       = work
+
+          super(msg + "\n\tSchool: #{school}; Department: #{department}; Work ID: #{work.id}")
+        end
+      end
+
       private
 
         def ensure_admin_set_attribute!(attributes)
           school = attributes["school"] ? attributes["school"] : curation_concern.school
           department = attributes["department"] ? attributes["department"] : curation_concern.department
           curation_concern.assign_admin_set(school, department)
-          raise "Could not assign admin_set for #{curation_concern.id}" if curation_concern.admin_set.nil?
+          raise ResolutionError.new("Could not assign admin_set for: ", curation_concern, school.to_a, department.to_a) if
+            curation_concern.admin_set.nil?
           attributes[:admin_set_id] = curation_concern.admin_set.id
         end
     end


### PR DESCRIPTION
The AdminSetActor provided a mostly unhelpful and hard to trace error message
when an admin set could not be assigned. This provides a namespaced error and
a structured message to improve handling.