### PR TITLE
Adds support for legacy graduation dates using inactive QA terms

### DIFF
--- a/app/inputs/controlled_select_input.rb
+++ b/app/inputs/controlled_select_input.rb
@@ -1,0 +1,19 @@
+class ControlledSelectInput < SimpleForm::Inputs::CollectionSelectInput
+  def input(wrapper_options = nil)
+    existing_values = Array(object.send(attribute_name))
+
+    return super if existing_values.empty?
+
+    if existing_values.length > 1
+      logger.warn("Editing a work with multiple values in #{attribute_name}, " \
+                  'but using a single valued form field. Values were: ' \
+                  "#{existing_values}")
+    end
+
+    @collection, wrapper_options =
+      options[:item_helper]
+        &.call(existing_values.first, 1, collection, wrapper_options)
+
+    super
+  end
+end

--- a/app/views/records/edit_fields/_graduation_date.html.erb
+++ b/app/views/records/edit_fields/_graduation_date.html.erb
@@ -1,6 +1,6 @@
 <% graduation_date_service = GraduationdateService.new %>
 <%= f.input :graduation_date, label: "Graduation Date",
-  as: :select, required: true,
+  as: :controlled_select, required: true,
   collection: graduation_date_service.select_active_options,
   item_helper: graduation_date_service.method(:include_current_value),
   input_html: { class: 'form-control' } %>

--- a/spec/features/controlled_vocabulary_spec.rb
+++ b/spec/features/controlled_vocabulary_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+RSpec.feature 'Using Controlled Vocabularies', :workflow do
+  let(:admin) { create(:admin) }
+  let(:user)  { create(:user) }
+
+  let(:etd) do
+    actor_create(:etd,
+                 title: ['Another great thesis by Frodo'],
+                 creator: ['Johnson, Frodo'],
+                 graduation_date: ['2013'],
+                 post_graduation_email: ['frodo@example.com'],
+                 school: ['Emory College'],
+                 department: ['Religion'],
+                 degree: ['Ph.D.'],
+                 submitting_type: ['Dissertation'],
+                 language: ['English'],
+                 abstract: ['<p>Literature from the US</p>'],
+                 table_of_contents: ['<h1>Chapter One</h1>'],
+                 research_field: ['Aeronomy'],
+                 keyword: ['key1'],
+                 copyright_question_one: false,
+                 copyright_question_two: true,
+                 copyright_question_three: false,
+                 files_embargoed: false,
+                 abstract_embargoed: false,
+                 toc_embargoed: false,
+                 embargo_length: nil,
+                 user: user)
+  end
+
+  before { login_as admin }
+
+  scenario 'has existing value selected' do
+    visit edit_hyrax_etd_path(etd)
+
+    expect(page).to have_select('etd_graduation_date', selected: '2013')
+  end
+end


### PR DESCRIPTION
A new input type is added to handle addition of values using the vocabulary helper method supplied in #1095 (see also: samvera/hyrax#3122). Using this input on a field-by-field basis allows single-value select inputs to support inactive terms.

This closes #1094, with the caveat that there are currently only inactive terms for `graduation_date`. When other inactive terms are added, action is needed to change the `simple_form` input type for the relevant fields.