### PR TITLE
Display the EtdForm object on a single page

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -1,10 +1,15 @@
 class InProgressEtdsController < ApplicationController
   def new
     @in_progress_etd = InProgressEtd.find_or_create_by(user_ppid: current_user.id)
+    @form = Hyrax::EtdForm.new(Etd.new, current_user.ability, Hyrax::EtdsController)
+    @curation_concern = Etd.new
+
+    # Showing the form that we get from Hyrax::EtdForm
   end
 
   def create
-    @in_progress_etd = InProgressEtd.new(in_progress_etd_params)
+    @in_progress_etd = InProgressEtd.new
+    @in_progress_etd.data = params['etd'].to_json
     @in_progress_etd.save
     redirect_to @in_progress_etd
   end
@@ -30,6 +35,6 @@ class InProgressEtdsController < ApplicationController
   private
 
     def in_progress_etd_params
-      params.require(:in_progress_etd).permit(:name, :email, :graduation_date, :submission_type, :department)
+      params.permit(Hyrax::EtdForm.terms)
     end
 end

--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -1,31 +1,34 @@
 module EtdHelper
+  mattr_accessor :curation_concern
+  self.curation_concern = @curation_concern ||= curation_concern
+
   def school_determined_departments(f)
     # if you are in a 'new' state, collection will be supplied by js so disable field, nothing selected
-    if curation_concern.new_record?
+    if @curation_concern.new_record?
       f.input :department, department_form_opts(disabled: true)
     else
-      f.input :department, department_form_opts(disabled: false).merge(collection: departments(curation_concern[:school].first), selected: curation_concern[:department].first)
+      f.input :department, department_form_opts(disabled: false).merge(collection: departments(@curation_concern[:school].first), selected: @curation_concern[:department].first)
     end
   end
 
   def department_determined_subfields(f)
     # a 'new' state, nothing is selected and disable subfields
-    if curation_concern.new_record? || curation_concern['subfield'].empty?
+    if @curation_concern.new_record? || curation_concern['subfield'].empty?
 
       f.input :subfield, subfield_form_opts(disabled: true)
 
     else
-      f.input :subfield, subfield_form_opts(disabled: false).merge(collection: subfields(curation_concern[:department].first), selected: curation_concern[:subfield].first)
+      f.input :subfield, subfield_form_opts(disabled: false).merge(collection: subfields(@curation_concern[:department].first), selected: @curation_concern[:subfield].first)
     end
   end
 
   def partnering_agency(f)
-    if curation_concern.new_record?
+    if @curation_concern.new_record?
       f.input :partnering_agency,
               partnering_agency_form_opts
     else
       f.input :partnering_agency, partnering_agency_form_opts.merge(
-        selected: curation_concern[:partnering_agency].first
+        selected: @curation_concern[:partnering_agency].first
       )
     end
   end

--- a/app/views/in_progress_etds/_form.html.erb
+++ b/app/views/in_progress_etds/_form.html.erb
@@ -1,13 +1,19 @@
-<%= form_tag("/in_progress_etds", method: "post") do %>
-  <ul class='basic_list'>
-    <% Hyrax::EtdForm.terms.each do |term| %>
-      <li>
-        <%= label_tag(term) %>
-        <%= text_field_tag(term) %>
-      </li>
-    <% end %>
-    <li>
-      <%= submit_tag('Save') %>
-    </li>
-  </ul>
+<%= simple_form_for @form, html: { class: 'editor' }, url: url_for(:controller => 'in_progress_etds', :action => 'create') do |f| %>
+  <% curation_concern = @curation_concern %>
+  <div id="descriptions_display">
+	  <%= render 'records/form_header' %>
+    <div class="well">
+      <% f.object.terms.each do |term| %>
+        <%= render_edit_field_partial(term, f: f, curation_concern: @curation_concern) %>
+      <% end %>
+    </div> <!-- /well -->
+  </div>
+  <%= hidden_field_tag :type, params[:type] %>
+
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= f.submit 'Save', class: 'btn btn-primary' %>
+      <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
+    </div>
+  </div>
 <% end %>

--- a/spec/views/in_progress_etds/_form.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/_form.html.erb_spec.rb
@@ -1,10 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'in_progress_etds/_form.html.erb', type: :view do
-  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:etd) { Etd.new }
+  let(:form) { Hyrax::EtdForm.new(etd, ::Ability.new(user), Hyrax::EtdsController) }
   let(:inputs) { Hyrax::EtdForm.terms }
   before do
-    assign(:in_progress_etd, in_progress_etd)
+    assign(:form, form)
+    assign(:curation_concern, etd)
     render
   end
 

--- a/spec/views/in_progress_etds/edit.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/edit.html.erb_spec.rb
@@ -1,15 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'in_progress_etds/edit.html.erb', type: :view do
-  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
-
+  let(:user) { FactoryBot.create(:user) }
+  let(:etd) { Etd.new }
+  let(:form) { Hyrax::EtdForm.new(etd, ::Ability.new(user), Hyrax::EtdsController) }
   before do
-    assign(:in_progress_etd, in_progress_etd)
+    assign(:form, form)
+    assign(:curation_concern, etd)
     render
   end
 
   it 'contains a form to edit an in_progress_etd' do
-    pending
-    expect(rendered).to have_selector("form[action='/in_progress_etds/1']")
+    expect(rendered).to have_selector("form[action='/in_progress_etds']")
+
+    expect(rendered).to have_selector("form[id='new_etd']")
   end
 end

--- a/spec/views/in_progress_etds/new.html.erb_spec.rb
+++ b/spec/views/in_progress_etds/new.html.erb_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'in_progress_etds/new.html.erb', type: :view do
-  let(:in_progress_etd) { FactoryBot.create(:in_progress_etd) }
-
+  let(:user) { FactoryBot.create(:user) }
+  let(:etd) { Etd.new }
+  let(:form) { Hyrax::EtdForm.new(etd, ::Ability.new(user), Hyrax::EtdsController) }
   before do
-    assign(:in_progress_etd, in_progress_etd)
+    assign(:form, form)
+    assign(:curation_concern, etd)
     render
   end
 
   it 'contains a form to create a new in_progress_etd' do
-    pending
-    expect(rendered).to have_selector("form[action='/in_progress_etds/1']")
+    expect(rendered).to have_selector("form[action='/in_progress_etds']")
   end
 end


### PR DESCRIPTION
This changes the InProgressEtd form to display the
complete EtdFrom object using `simple_form`. When this
form is submitted the results are saved as JSON in the
the InProgressEtd.data field.