### PR TITLE
Use common solr & fedora installers for all projects

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,5 +1,6 @@
 # Place any default configuration for solr_wrapper here
 port: 8984
 version: 4.7.5
+download_dir: /var/tmp
 enable_jms: false
 fcrepo_home_dir: tmp/fcrepo4-development-data

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,6 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
 version: 6.6.2
+download_dir: /var/tmp
 instance_dir: tmp/solr-development
 collection:
   persist: true


### PR DESCRIPTION
I run multiple projects and often end up wiping out my stale development
environment entirely.  At present, each project re-downloads the same
solr and fedora installers to local temp directories, even if I already
have a copy on my system.  I'd rather just download the installers once
for any project that needs them.

Using the download_dir: option in the wrapper config files allows
multiple projects to use the same installer to install local versions
of the services for each app.