### PR TITLE
Set visibility when expiring an embargo

### DIFF
--- a/app/services/embargo_expiration_service.rb
+++ b/app/services/embargo_expiration_service.rb
@@ -90,6 +90,7 @@ class EmbargoExpirationService
     expirations = find_expirations(0)
     expirations.each do |expiration|
       Rails.logger.warn "ETD #{expiration.id}: Expiring embargo"
+      expiration.visibility = expiration.visibility_after_embargo if expiration.visibility_after_embargo
       expiration.deactivate_embargo!
       expiration.embargo.save
       expiration.save


### PR DESCRIPTION
We were relying on `#deactivate_embargo!` to do this work, but it
explictly *does not* affect visibility. We set the visibility to the
`#visibility_after_embargo` explictly, since we are already filtering by the
date passed into the task.

Related to #977. See also: https://github.com/samvera/hyrax/issues/2657