### PR TITLE
Set visibility when expiring an embargo

### DIFF
--- a/app/services/embargo_expiration_service.rb
+++ b/app/services/embargo_expiration_service.rb
@@ -90,6 +90,7 @@ class EmbargoExpirationService
     expirations = find_expirations(0)
     expirations.each do |expiration|
       Rails.logger.warn "ETD #{expiration.id}: Expiring embargo"
+      expiration.visibility = expiration.visibility_after_embargo if expiration.visibility_after_embargo
       expiration.deactivate_embargo!
       expiration.embargo.save
       expiration.save

--- a/spec/services/embargo_expiration_service_spec.rb
+++ b/spec/services/embargo_expiration_service_spec.rb
@@ -82,6 +82,9 @@ describe EmbargoExpirationService do
   context "#expire_embargoes" do
     let(:etd) { FactoryBot.create(:tomorrow_expiration) }
     let(:service) { described_class.new(Time.zone.tomorrow) }
+
+    before { etd.embargo_visibility! }
+
     it "removes the embargo for each object whose expiration date has been reached" do
       expect(etd.embargo_release_date).to eq(Time.zone.tomorrow)
       expect(etd.under_embargo?).to eq true
@@ -93,6 +96,25 @@ describe EmbargoExpirationService do
       # Visibility during embargo was authenticated and intended visibility after embargo was open"
       expect(etd.embargo_history.last).to match(/deactivated/)
       expect(etd.under_embargo?).to eq false
+    end
+
+    it "changes the embargo permissions" do
+      expect { service.expire_embargoes }
+        .to change { etd.reload.visibility }
+        .from(etd.visibility_during_embargo)
+        .to(etd.visibility_after_embargo)
+    end
+
+    context "when the embargo is not expired" do
+      let(:service) { described_class.new(Time.zone.now + 2.days) }
+
+      it 'does not deactivate embargo' do
+        expect { service.expire_embargoes }
+          .not_to change { etd.visibility }
+          .from(etd.visibility_during_embargo)
+
+        expect(etd.under_embargo?).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
We were relying on `#deactivate_embargo!` to do this work, but it
explictly *does not* affect visibility. We set the visibility to the
`#visibility_after_embargo` explictly, since we are already filtering by the
date passed into the task.

Related to #977. See also: https://github.com/samvera/hyrax/issues/2657

This is a backport of #1122 