### PR TITLE
 Improve embargo management UX and remove "Deactivate Embargo" button 

### DIFF
--- a/app/views/hyrax/embargoes/edit.html.erb
+++ b/app/views/hyrax/embargoes/edit.html.erb
@@ -1,0 +1,57 @@
+<% cc_type = curation_concern.human_readable_type %>
+
+<% provide :page_header do %>
+  <h1><%= t('.manage_embargoes_html', cc: curation_concern, cc_type: cc_type) %></h1>
+<% end %>
+
+<div class="panel panel-default tabs">
+  <div class="panel-heading">
+    <h2 class="panel-title"><%= t('.header.current') %></h2>
+  </div>
+  <div class="panel-body">
+    <%= simple_form_for [main_app, curation_concern] do |f| %>
+      <fieldset class="set-access-controls">
+        <section class="help-block">
+          <p>
+            <% if curation_concern.embargo_release_date %>
+              <%= t('.embargo_true_html',  cc: cc_type) %>
+            <% else %>
+              <%= t('.embargo_false_html', cc: cc_type) %>
+            <% end %>
+          </p>
+        </section>
+
+        <div class="form-group">
+          <input type="hidden" name="<%= f.object_name %>[visibility]" value="<%= Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>" />
+          <%= render 'hyrax/base/form_permission_embargo', curation_concern: curation_concern, f: f  %>
+        </div>
+      </fieldset>
+
+      <div class="row">
+        <div class="col-md-12 form-actions">
+          <% if curation_concern.embargo_release_date %>
+            <%= f.submit t('.embargo_update'), class: 'btn btn-primary' %>
+            <%= link_to t('.embargo_deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
+          <% else %>
+            <%= f.submit t('.embargo_apply'), class: 'btn btn-primary' %>
+          <% end %>
+          <%= link_to t('.embargo_cancel'), embargoes_path, class: 'btn btn-default' %>
+          <%= link_to t('.embargo_return', cc: cc_type), edit_polymorphic_path([main_app, curation_concern]), class: 'btn btn-default' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="panel panel-default tabs">
+  <div class="panel-heading">
+    <h2 class="panel-title"><%= t('.header.past') %></h2>
+  </div>
+  <div class="panel-body">
+    <% if curation_concern.embargo_history.empty? %>
+      <%= t('.history_empty', cc: cc_type) %>
+    <% else %>
+      <%= render partial: "embargo_history", object: curation_concern.embargo_history %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hyrax/embargoes/edit.html.erb
+++ b/app/views/hyrax/embargoes/edit.html.erb
@@ -31,7 +31,6 @@
         <div class="col-md-12 form-actions">
           <% if curation_concern.embargo_release_date %>
             <%= f.submit t('.embargo_update'), class: 'btn btn-primary' %>
-            <%= link_to t('.embargo_deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
           <% else %>
             <%= f.submit t('.embargo_apply'), class: 'btn btn-primary' %>
           <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -20,6 +20,8 @@ en:
       service_html: A service of <a href="https://emory.edu/" class="navbar-link" target="_blank">Emory University</a>.
     active_consent_to_agreement: "I hereby grant to Emory University and its agents the non-exclusive license to archive, make accessible, and display, subject to any embargo restrictions I have specified above, my thesis or dissertation in whole or in part in all forms of media, now or hereafter known, including the display of the thesis or dissertation on the world wide web. I retain all ownership rights to the copyright of the thesis or dissertation. I also retain the right to use in future works (such as articles or books) all or part of this thesis or dissertation. I certify that my electronic submission is the version of my thesis/dissertation that was approved by my committee."
     base:
+      form_permission_under_embargo:
+        help_html: "<strong>This work is under embargo.</strong> You can change the settings of the embargo here, or visit the %{edit_link}."
       form_progress:
         required_about_me: "About Me"
         required_my_etd: "My ETD"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -7,6 +7,14 @@ en:
     account_name:           "455000"
     directory:
       suffix:               "@emory.edu"
+    embargoes:
+      edit:
+        embargo_cancel: Manage Embargoes
+        embargo_return: Edit %{cc}
+      list_expired_active_embargoes:
+        deactivate: Release Embargo
+        deactivate_selected: Release Selected Embargoes
+        missing: There are no expired embargoes currently awaiting release.
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Emory University</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="https://emory.edu/" class="navbar-link" target="_blank">Emory University</a>.


### PR DESCRIPTION
The terminology in embargo management pages is frequently overly wordy and unclear out of the box. Particularly, "deactivate" is overloaded: meaning "release"/"lift" when the embargo release date is past, and meaning "reset item permissions to embargoed and mark the embargo inactive" otherwise. In
`list_expired_active_embargos`, the former is always the case, so we say "Release" to reduce confusion ("Release", rather than "lift", is the terminology used elsewhere).

While we're here, we tighten up some other values to avoid overly wordy and vague text, (e.g. "Cancel and manage all embargoes" becomes "Manage Embargoes").

The counter-intuitive "Deactivate Embargo" button is also removed.

Related to curationexperts/nurax#205 & samvera/hyrax#3058.

Closes #1108.