### PR TITLE
Update bcrypt gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'bcrypt', '>= 3.1.12'
 gem 'clamby', '>= 1.2.5'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       execjs (~> 2.0)
     bcp47 (0.3.3)
       i18n
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     bindex (0.5.0)
     bixby (0.3.1)
       rubocop (~> 0.49, <= 0.50.0)
@@ -897,6 +897,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (>= 3.1.12)
   bixby
   byebug
   capistrano
@@ -966,4 +967,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
On Fedora 28 (the Linux distro) the bcrypt gem
is broken until the fix introduced in 3.1.12. This changes the Gemfile so that we have at least that version of bcrypt. This came up because @little9
uses Fedora on desktops.

See codahale/bcrypt-ruby#170