### PR TITLE
Story 1029: Display config for schools

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,11 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: false
 
+Rails/Delegate:
+  Exclude:
+    - 'app/models/schools/department.rb'
+    - 'app/models/schools/subfield.rb'
+
 Rails/FindBy:
   Enabled: false
 
@@ -110,6 +115,10 @@ RSpec/InstanceVariable:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/javascripts/jasmine_spec.rb'
+
+RSpec/LetSetup:
+  Exclude:
+    - "spec/models/schools/*.rb"
 
 RSpec/NestedGroups:
   Enabled: false

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,7 @@
  *= require hyrax
  *= require openseadragon 
  *= require etd
+ *= require schools
  *= require_tree ./emory/ 
  *= require_self
  */

--- a/app/assets/stylesheets/schools.scss
+++ b/app/assets/stylesheets/schools.scss
@@ -1,0 +1,27 @@
+// Schools views
+
+#school-config {
+  table.admin_set {
+    margin-top: 0.3em;
+    margin-bottom: 1em;
+    margin-left: 3em;
+
+    th, td {
+      padding: 0.25em 0.75em;
+    }
+  }
+
+  .department {
+    margin-top: 1em;
+  }
+
+  .subfield {
+    padding-left: 3em;
+  }
+
+  .org-label {
+    font-weight: bold;
+    padding-right: 0.8em;
+  }
+}
+

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SchoolsController < ApplicationController
+  before_action :auth
+
+  def index
+    @school_terms = Schools::School.active_elements
+  end
+
+  def show
+    @school = Schools::School.new(params[:id])
+  end
+
+  private
+
+    def auth
+      authorize! :read, Schools::School
+    end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,7 @@ class Ability
     return unless admin?
     can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
     can [:destroy], ActiveFedora::Base
+    can [:read], Schools::School
   end
 
   ##

--- a/app/models/approver.rb
+++ b/app/models/approver.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Approver
+  # For a given AdminSet, which Users are approvers for the active workflow.
+  def self.for_admin_set(admin_set)
+    workflow = admin_set.active_workflow
+    approving_role = Sipity::Role.where(name: "approving").first
+    wf_role = Sipity::WorkflowRole.find_by(workflow: workflow, role_id: approving_role)
+    resp = wf_role.workflow_responsibilities
+    agents = Sipity::Agent.where(id: resp.pluck(:agent_id), proxy_for_type: 'User')
+    user_ids = agents.pluck('proxy_for_id')
+
+    User.find user_ids
+  end
+end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -216,12 +216,9 @@ class Etd < ActiveFedora::Base
   # department it belongs to
   # @return [String] the name of an admin set
   def determine_admin_set(school = self.school, department = self.department, subfield = self.subfield)
-    valid_admin_sets = YAML.safe_load(File.read(WorkflowSetup::DEFAULT_ADMIN_SETS_CONFIG)).keys
-    admin_set_determined_by_school = ["Laney Graduate School", "Candler School of Theology", "Emory College"]
-    return school.first if admin_set_determined_by_school.include?(school.first) && valid_admin_sets.include?(school.first)
-    return department.first if valid_admin_sets.include?(department.first)
-    return subfield.first if valid_admin_sets.include?(subfield.first)
-    raise "Cannot find admin set config where school = #{school.first} and department = #{department.first} and subfield = #{subfield.first}"
+    as_name = AdminSetChooser.new.determine_admin_set(school, department, subfield)
+    raise "Cannot find admin set config where school = #{school.first} and department = #{department.first} and subfield = #{subfield.first}" unless as_name
+    as_name
   end
 
   # Assign an admin_set based on what is returned by #determine_admin_set

--- a/app/models/schools/department.rb
+++ b/app/models/schools/department.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# This class is not meant to be used to edit or set
+# any of the config values.  It is for display only.
+# See the School class for more info.
+
+module Schools
+  class Department
+    # @param school [Schools::School]: The school this department belongs to.
+    # @param id [String]: The ID for the department (as defined in config/authorities/<school>_programs.yml)
+    def initialize(school, id)
+      @school = school
+      @id = id
+    end
+    attr_reader :school, :id
+
+    def label
+      return @label if @label
+      qa_terms = school_service.active_elements.find { |dept| dept['id'] == id } || {}
+      @label = qa_terms[:label]
+    end
+
+    def school_service
+      school.service
+    end
+
+    def service
+      @service ||= Hyrax::LaevigataAuthorityService.for(department: id)
+    end
+
+    def subfield_ids
+      return [] unless service
+      qa_terms = service.authority.all
+      qa_terms.map { |terms| terms[:id] }
+    end
+
+    # The subfields that belong to this department
+    def subfields
+      @subfields ||= subfield_ids.map do |id|
+        Schools::Subfield.new(school, self, id)
+      end
+    end
+
+    delegate :all_admin_sets, to: :school
+    delegate :as_chooser, to: :school
+
+    # @return [AdminSet] The AdminSet for this department (if it has one)
+    def admin_set
+      # Some AdminSets are determined by school, not department.
+      return nil if school.admin_set
+
+      return @admin_set if @admin_set
+      as_name = as_chooser.determine_admin_set([], [id], [])
+      return nil unless as_name
+      @admin_set = all_admin_sets.find { |as| as.title.include?(as_name) }
+    end
+  end
+end

--- a/app/models/schools/school.rb
+++ b/app/models/schools/school.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# This class collects the config information about a
+# school into one place so that it can easily be
+# displayed.
+#
+# This class is not meant to be used to edit or set
+# any of the config values.  It is for display only.
+
+module Schools
+  class School
+    # Find the QA terms for all active schools.
+    def self.active_elements
+      ss = Hyrax::SchoolService.new
+      ss.active_elements
+    end
+
+    # @param id [String]: The ID for the school (as defined in config/authorities/school.yml)
+    def initialize(id)
+      @id = id
+    end
+    attr_reader :id
+
+    def label
+      return @label if @label
+      ss = Hyrax::SchoolService.new
+      qa_terms = ss.active_elements.find { |school| school['id'] == id } || {}
+      @label = qa_terms[:label]
+    end
+
+    def service
+      @service ||= Hyrax::LaevigataAuthorityService.for(school: id)
+    end
+
+    def department_ids
+      return [] unless service
+      qa_terms = service.authority.all
+      qa_terms.map { |terms| terms[:id] }
+    end
+
+    # @return [Array<Schools::Department>] The departments for this school.
+    def departments
+      @departments ||= department_ids.map do |dept_id|
+        Schools::Department.new(self, dept_id)
+      end
+    end
+
+    def as_chooser
+      @as_chooser ||= ::AdminSetChooser.new
+    end
+
+    # @return [Array<AdminSet>] All AdminSet records.
+    #
+    # Fetch all the AdminSet records so they will be
+    # available for this school's departments and
+    # sub-fields without having to do multiple queries
+    def all_admin_sets
+      @all_admin_sets ||= AdminSet.all.to_a
+    end
+
+    # @return [AdminSet] The AdminSet for this school (if it has one)
+    def admin_set
+      return @admin_set if @admin_set
+      as_name = as_chooser.determine_admin_set([id], [], [])
+      return nil unless as_name
+      @admin_set = all_admin_sets.find { |as| as.title.include?(as_name) }
+    end
+  end
+end

--- a/app/models/schools/subfield.rb
+++ b/app/models/schools/subfield.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This class is not meant to be used to edit or set
+# any of the config values.  It is for display only.
+# See the School class for more info.
+
+module Schools
+  class Subfield
+    # @param school [Schools::School]: The school this subfield belongs to.
+    # @param department [Schools::Department]: The department this subfield belongs to.
+    # @param id [String]: The ID for the subfield (as defined in config/authorities/<department>_programs.yml)
+    def initialize(school, department, id)
+      @school = school
+      @department = department
+      @id = id
+    end
+    attr_reader :school, :department, :id
+
+    def department_service
+      department.service
+    end
+
+    def label
+      return @label if @label
+      qa_terms = department_service.active_elements.find { |subfield| subfield['id'] == id } || {}
+      @label = qa_terms[:label]
+    end
+
+    delegate :all_admin_sets, to: :school
+    delegate :as_chooser, to: :school
+
+    # @return [AdminSet] The AdminSet for this subfield (if it has one)
+    def admin_set
+      # Some AdminSets are determined by school or
+      # department, not subfield.
+      return nil if school.admin_set
+      return nil if department.admin_set
+
+      return @admin_set if @admin_set
+      as_name = as_chooser.determine_admin_set([], [], [id])
+      return nil unless as_name
+      @admin_set = all_admin_sets.find { |as| as.title.include?(as_name) }
+    end
+  end
+end

--- a/app/services/admin_set_chooser.rb
+++ b/app/services/admin_set_chooser.rb
@@ -1,0 +1,16 @@
+class AdminSetChooser
+  # Determine what admin set an ETD should belong to,
+  # based on what school and department it belongs to.
+  #
+  # @return [String] the name of an admin set
+  def determine_admin_set(school, department, subfield)
+    admin_set_determined_by_school = ["Laney Graduate School", "Candler School of Theology", "Emory College"]
+    return school.first if admin_set_determined_by_school.include?(school.first) && valid_admin_sets.include?(school.first)
+    return department.first if valid_admin_sets.include?(department.first)
+    return subfield.first if valid_admin_sets.include?(subfield.first)
+  end
+
+  def valid_admin_sets
+    @valid_admin_sets ||= YAML.safe_load(File.read(WorkflowSetup::DEFAULT_ADMIN_SETS_CONFIG)).keys
+  end
+end

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -1,0 +1,44 @@
+  <% if menu.show_configuration? %>
+    <li class="h5"><%= t('hyrax.admin.sidebar.configuration') %></li>
+    <li>
+      <%= menu.collapsable_section t('hyrax.admin.sidebar.settings'),
+                                   icon_class: "fa fa-cog",
+                                   id: 'collapseSettings',
+                                   open: menu.settings_section? do %>
+        <% if can?(:update, :appearance) %>
+          <%= menu.nav_link(hyrax.admin_appearance_path) do %>
+            <span class="fa fa-paint-brush"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.appearance') %></span>
+          <% end %>
+        <% end %>
+        <% if can?(:manage, :collection_types) %>
+          <%= menu.nav_link(hyrax.admin_collection_types_path) do %>
+            <span class="fa fa-folder-open"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collection_types') %></span>
+          <% end %>
+        <% end %>
+        <% if can?(:manage, Hyrax::Feature) %>
+          <%= menu.nav_link(hyrax.edit_pages_path) do %>
+            <span class="fa fa-file-text-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.pages') %></span>
+          <% end %>
+          <%= menu.nav_link(hyrax.edit_content_blocks_path) do %>
+            <span class="fa fa-square-o"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.content_blocks') %></span>
+          <% end %>
+          <%= menu.nav_link(hyrax.admin_features_path) do %>
+            <span class="fa fa-wrench"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.technical') %></span>
+          <% end %>
+        <% end %>
+      <% end %>
+    </li>
+
+    <% if can?(:manage, Sipity::WorkflowResponsibility) %>
+      <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
+        <span class="fa fa-users"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
+      <% end %>
+    <% end # end of configuration block %>
+
+      <% if can?(:read, Schools::School) %>
+        <%= menu.nav_link(main_app.schools_path) do %>
+          <span class="fa fa-cog"></span>
+          <span class="sidebar-action-text">Schools</span>
+        <% end %>
+      <% end %>
+  <% end %>

--- a/app/views/schools/_admin_set.html.erb
+++ b/app/views/schools/_admin_set.html.erb
@@ -1,0 +1,16 @@
+<table class='admin_set'>
+  <tr>
+    <th> Admin Set </th>
+    <td> <%= admin_set.title.join(', ') %> </td>
+  </tr>
+
+  <tr>
+    <th> Workflow </th>
+    <td> <%= admin_set.active_workflow.name %> </td>
+  </tr>
+
+  <tr>
+    <th> Approvers </th>
+    <td> <%= Approver.for_admin_set(admin_set).join(', ') %> </td>
+  </tr>
+</table>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -1,0 +1,5 @@
+<h1>Schools</h1>
+
+<% @school_terms.each do |school| %>
+  <p> <%= link_to school[:label], school_path(school[:id]) %> </p>
+<% end %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,0 +1,31 @@
+<div id='school-config'>
+  School Configuration:
+  <h1><%= @school.label %></h1>
+
+  <% if @school.admin_set %>
+    <%= render partial: 'admin_set', locals: { admin_set: @school.admin_set } %>
+  <% end %>
+
+  <% @school.departments.each do |dept| %>
+    <div class='department'>
+      <span class='org-label'> Department </span>
+      <%= dept.label %>
+
+      <% if dept.admin_set %>
+        <%= render partial: 'admin_set', locals: { admin_set: dept.admin_set } %>
+      <% end %>
+
+      <% dept.subfields.each do |subfield| %>
+        <div class='subfield'>
+          <span class='org-label'> Subfield </span>
+          <%= subfield.label %>
+
+          <% if subfield.admin_set %>
+            <%= render partial: 'admin_set', locals: { admin_set: subfield.admin_set } %>
+          <% end %>
+        </div>
+      <% end %>
+
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,5 +67,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
+  resources :schools, only: [:index, :show]
+
   match "*path", to: "catalog#catch_404", via: :all
 end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SchoolsController, type: :controller do
+  context 'logged in as an admin user' do
+    let!(:admin) { FactoryBot.create(:admin) }
+    before { sign_in admin }
+
+    describe 'GET #index' do
+      it 'returns index page' do
+        get :index
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+        expect(assigns(:school_terms).map { |school| school[:label] }).to eq ['Candler School of Theology', 'Emory College', 'Laney Graduate School', 'Rollins School of Public Health']
+      end
+    end
+
+    describe 'GET #show' do
+      let(:id) { 'Laney Graduate School' }
+
+      it 'returns show page' do
+        get :show, params: { id: id }
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:show)
+        expect(assigns(:school).label).to eq 'Laney Graduate School'
+      end
+    end
+  end
+
+  context 'logged in as a student' do
+    let!(:student) { FactoryBot.create(:user) }
+    before { sign_in student }
+
+    describe 'GET #index' do
+      it 'denies access' do
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash.alert).to match(/You are not authorized/)
+      end
+    end
+
+    describe 'GET #show' do
+      let(:id) { 'Laney Graduate School' }
+
+      it 'denies access' do
+        get :show, params: { id: id }
+        expect(response).to redirect_to(root_path)
+        expect(flash.alert).to match(/You are not authorized/)
+      end
+    end
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -23,6 +23,12 @@ FactoryBot.define do
 
     factory :admin do
       groups ['admin']
+
+      after(:create) do |user, evaluator|
+        role = Role.find_or_create_by(name: 'admin')
+        role.users << user
+        role.save
+      end
     end
 
     factory :ateer do

--- a/spec/fixtures/config/emory/admin_sets_small.yml
+++ b/spec/fixtures/config/emory/admin_sets_small.yml
@@ -1,0 +1,23 @@
+Laney Graduate School:
+  workflow:
+   - laney_graduate_school
+  approving:
+   - laneyadmin
+   - laneyadmin2
+Emory College:
+  approving:
+   - ecadmin
+   - ecadmin2
+Candler School of Theology:
+  approving:
+   - candleradmin
+   - candleradmin2
+Applied Epidemiology:
+  approving:
+   - applied_epidemiology_admin
+Biostatistics:
+  approving:
+   - biostatistics_admin
+Epidemiology:
+  approving:
+   - epidemiology_admin

--- a/spec/models/approver_spec.rb
+++ b/spec/models/approver_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Approver, type: :model do
+  # Change "/dev/null" to STDOUT to see all logging output
+  let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/admin_sets_small.yml", "/dev/null") }
+
+  let(:superusers) { ['admin_set_owner', 'superman001', 'wonderwoman001', 'tezprox'] }
+
+  before do
+    # Create AdminSet and Workflow records
+    workflow_setup.setup
+  end
+
+  describe '::for_admin_set' do
+    let(:laney) { AdminSet.where(title_sim: 'Laney Graduate School').first }
+    let(:candler) { AdminSet.where(title_sim: 'Candler School of Theology').first }
+    let(:epi) { AdminSet.where(title_sim: 'Epidemiology').first }
+
+    let(:laney_approvers) { Approver.for_admin_set(laney) }
+    let(:candler_approvers) { Approver.for_admin_set(candler) }
+    let(:epi_approvers) { Approver.for_admin_set(epi) }
+
+    it 'finds the users who are approvers for this admin set' do
+      expect(laney_approvers.map(&:uid)).to contain_exactly(*superusers, 'laneyadmin', 'laneyadmin2')
+      expect(candler_approvers.map(&:uid)).to contain_exactly(*superusers, 'candleradmin', 'candleradmin2')
+      expect(epi_approvers.map(&:uid)).to contain_exactly(*superusers, 'epidemiology_admin')
+    end
+  end
+end

--- a/spec/models/schools/department_spec.rb
+++ b/spec/models/schools/department_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schools::Department, type: :model do
+  let(:school_id) { 'Rollins School of Public Health' }
+  let(:school) { Schools::School.new(school_id) }
+
+  let(:dept_id) { 'Biostatistics' }
+  let(:dept) { described_class.new(school, dept_id) }
+
+  describe 'init' do
+    it 'creates a department associated with that school' do
+      expect(dept.school).to eq school
+      expect(dept.label).to eq 'Biostatistics and Bioinformatics'
+    end
+
+    context 'with a bad id' do
+      let(:dept_id) { 'not a real dept id' }
+
+      it 'doesnt raise an error' do
+        expect(dept.school).to eq school
+        expect(dept.label).to eq nil
+      end
+    end
+  end
+
+  describe '#admin_set' do
+    let(:rollins) { Schools::School.new('Rollins School of Public Health') }
+
+    let(:id_behav) { 'Behavioral Sciences and Health Education' }
+    let(:id_envir) { 'Environmental Health' }
+    let(:behav) { described_class.new(rollins, id_behav) }
+    let(:envir) { described_class.new(rollins, id_envir) }
+
+    before { AdminSet.delete_all }
+    let!(:as_behav) { FactoryBot.create(:admin_set, title: [id_behav]) }
+
+    # The 'Behavioral Sciences and Health Education'
+    # department has a matching AdminSet, but for the
+    # 'Environmental Health' department, the AdminSet
+    # will be determined by the subfield, rather than
+    # by department.
+    it 'returns an AdminSet if there is one at the department level' do
+      expect(AdminSet.count).to eq 1
+      expect(behav.admin_set.title).to eq [id_behav]
+      expect(envir.admin_set).to eq nil
+    end
+
+    context 'when department name matches an existing AdminSet record, but AdminSet is determined by school, not department' do
+      let(:id_laney) { 'Laney Graduate School' }
+      let(:laney) { Schools::School.new(id_laney) }
+      let(:id_bio) { 'Biostatistics' }
+      let(:bio) { described_class.new(laney, id_bio) }
+
+      before { AdminSet.delete_all }
+      let!(:as_laney) { FactoryBot.create(:admin_set, title: [id_laney]) }
+      let!(:as_bio) { FactoryBot.create(:admin_set, title: [id_bio]) }
+
+      it 'returns no AdminSet for the department because the AdminSet is determined by the school instead' do
+        expect(AdminSet.count).to eq 2
+        expect(bio.school.admin_set.title).to eq [id_laney]
+        expect(bio.admin_set).to eq nil
+      end
+    end
+  end
+
+  describe '#subfields' do
+    subject(:subfields) { dept.subfields }
+
+    context 'a department with subfields' do
+      it 'returns the subfields for this department' do
+        expect(subfields.map(&:label)).to contain_exactly('Biostatistics - MPH & MSPH', 'Public Health Informatics - MSPH')
+      end
+    end
+
+    context 'a department without subfields' do
+      let(:school) { Schools::School.new('Candler School of Theology') }
+      let(:dept) { described_class.new(school, 'Divinity') }
+
+      it 'returns empty' do
+        expect(subfields).to eq []
+      end
+    end
+  end
+end

--- a/spec/models/schools/school_spec.rb
+++ b/spec/models/schools/school_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schools::School, type: :model do
+  let(:school) { described_class.new(id) }
+  let(:id) { 'Candler School of Theology' }
+
+  describe '::active_elements' do
+    subject { described_class.active_elements }
+    let(:school_labels) { subject.map { |school| school[:label] } }
+
+    it 'finds the QA terms for all the active schools' do
+      expect(school_labels).to eq ['Candler School of Theology', 'Emory College', 'Laney Graduate School', 'Rollins School of Public Health']
+    end
+  end
+
+  describe 'init' do
+    it 'loads the correct school' do
+      expect(school.label).to eq 'Candler School of Theology'
+    end
+
+    context 'with a bad id' do
+      let(:id) { 'not a real school id' }
+
+      it 'doesnt raise an error' do
+        expect(school.label).to eq nil
+        expect(school.departments).to eq []
+      end
+    end
+  end
+
+  describe '#departments' do
+    subject(:depts) { school.departments }
+
+    let(:id) { 'Rollins School of Public Health' }
+    let(:dept_id) { 'Biostatistics' }
+    let(:bio_dept) { depts.select { |dept| dept.id == dept_id }.first }
+
+    it 'returns the departments for this school' do
+      expect(depts.length).to eq 7
+      expect(bio_dept.label).to eq 'Biostatistics and Bioinformatics'
+    end
+  end
+
+  describe '#admin_set' do
+    let(:id_candler) { 'Candler School of Theology' }
+    let(:id_rollins) { 'Rollins School of Public Health' }
+    let(:candler) { described_class.new(id_candler) }
+    let(:rollins) { described_class.new(id_rollins) }
+
+    before { AdminSet.delete_all }
+    let!(:as_candler) { FactoryBot.create(:admin_set, title: [id_candler]) }
+    let!(:as_other) { FactoryBot.create(:admin_set, title: ['some other admin set']) }
+
+    # Candler has an associated AdminSet, but Rollins
+    # doesn't because AdminSets for Rollins are
+    # determined by department/sub-field rather than
+    # by school.
+    it 'returns an AdminSet if there is one at the school level' do
+      expect(AdminSet.count).to eq 2
+      expect(candler.admin_set.title).to eq [id_candler]
+      expect(rollins.admin_set).to eq nil
+    end
+  end
+end

--- a/spec/models/schools/subfield_spec.rb
+++ b/spec/models/schools/subfield_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Schools::Subfield, type: :model do
+  let(:school) { Schools::School.new('Rollins School of Public Health') }
+  let(:dept) { Schools::Department.new(school, 'Epidemiology') }
+  let(:subfield_id) { 'Global Epidemiology - MPH & MSPH' }
+  let(:subfield) { described_class.new(school, dept, subfield_id) }
+
+  describe 'init' do
+    it 'creates a subfield associated with a department and school' do
+      expect(subfield.school).to eq school
+      expect(subfield.department).to eq dept
+      expect(subfield.label).to eq 'Global Epidemiology - MPH & MSPH'
+    end
+
+    context 'with a bad id' do
+      let(:subfield_id) { 'not a real subfield id' }
+
+      it 'doesnt raise an error' do
+        expect(subfield.school).to eq school
+        expect(subfield.department).to eq dept
+        expect(subfield.label).to eq nil
+      end
+    end
+  end
+
+  describe '#admin_set' do
+    context 'when admin set is determined at school level' do
+      let(:school_id) { 'Laney Graduate School' }
+      let(:school) { Schools::School.new(school_id) }
+      let(:dept) { Schools::Department.new(school, 'Biostatistics') }
+      let(:subfield_id) { 'Global Environmental Health - MPH' }
+
+      before { AdminSet.delete_all }
+      let!(:as_laney) { FactoryBot.create(:admin_set, title: [school_id]) }
+      let!(:as_other) { FactoryBot.create(:admin_set, title: [subfield_id]) }
+
+      it 'returns nil' do
+        expect(AdminSet.count).to eq 2
+        expect(school.admin_set.title).to eq [school.id]
+        expect(subfield.admin_set).to eq nil
+      end
+    end
+
+    context 'when admin set is determined at department level' do
+      let(:dept) { Schools::Department.new(school, 'Biostatistics') }
+      let(:subfield_id) { 'Public Health Informatics' }
+
+      before { AdminSet.delete_all }
+      let!(:as_dept) { FactoryBot.create(:admin_set, title: [dept.id]) }
+      let!(:as_sub) { FactoryBot.create(:admin_set, title: [subfield_id]) }
+
+      it 'returns nil' do
+        expect(AdminSet.count).to eq 2
+        expect(dept.admin_set.title).to eq [dept.id]
+        expect(subfield.admin_set).to eq nil
+      end
+    end
+
+    context 'when admin set is determined at subfield level' do
+      let(:subfield_id) { 'Global Environmental Health - MPH' }
+
+      before { AdminSet.delete_all }
+      let!(:as_subfield) { FactoryBot.create(:admin_set, title: [subfield_id]) }
+      let!(:as_other) { FactoryBot.create(:admin_set, title: ['some other admin set']) }
+
+      it 'returns the AdminSet for this subfield' do
+        expect(AdminSet.count).to eq 2
+        expect(school.admin_set).to eq nil
+        expect(dept.admin_set).to eq nil
+        expect(subfield.admin_set.title).to eq [subfield_id]
+      end
+    end
+  end
+end


### PR DESCRIPTION
The configured relationships between schools, departments, subfields,
admin sets, approving users, and workflows is complicated.  That
information is spread across a dozen yaml files and 5 or 10 database
tables.  It's really hard to understand the current configuration for a
running app.

This code attempts to make it easier to understand the config by
displaying the full config on a single web page for each school.

Some things to note:

* I made a SchoolsController to display the config info for each school,
which is only accessible by admin users.

* I pulled the logic for choosing the correct AdminSet into a new class
AdminSetChooser, so that I could share that logic between the Etd class
and the School and Department classes.

* I copied app/views/hyrax/dashboard/sidebar/_configuration.html.erb over
from hyrax so that I could insert the nav link for the schools config
page.

Connected to #1029