### PR TITLE
Update sprockets-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     daemons (1.2.6)
     database_cleaner (1.6.2)
     declarative (0.0.10)
@@ -409,7 +409,7 @@ GEM
       simple_form (~> 3.2, <= 3.5.0)
       tinymce-rails (~> 4.1)
       tinymce-rails-imageupload (~> 4.0.17.beta)
-    i18n (0.9.4)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inflecto (0.0.2)
@@ -549,7 +549,7 @@ GEM
     net-ssh (4.2.0)
     nio4r (2.2.0)
     noid (0.9.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -591,7 +591,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
       rdf
-    rack (2.0.4)
+    rack (2.0.5)
     rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
@@ -819,7 +819,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.2)
@@ -960,7 +960,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.3.4p301
+   ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
This is in response to critical security issue CVE-2018-3760.

Backports #1132.