### PR TITLE
Remove several deprecated calls from tests

### DIFF
--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -89,9 +89,11 @@ namespace :sample_data do
         upload2 = File.open(file2_path) do |file2|
           Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
         end
-        actor = Hyrax::CurationConcern.actor(etd, ability)
+
         attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-        actor.create(attributes_for_actor)
+        env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
+        Hyrax::CurationConcern.actor.create(env)
+
         puts "Created #{etd.id}"
       end
     end
@@ -131,9 +133,11 @@ namespace :sample_data do
     file2 = File.open("#{::Rails.root}/spec/fixtures/miranda/image.tif")
     upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
     upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
-    actor = Hyrax::CurationConcern.actor(etd, ability)
+
     attributes_for_actor = { embargo_length: etd.embargo_length, uploaded_files: [upload1.id, upload2.id] }
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
+    Hyrax::CurationConcern.actor.create(env)
+
     approving_user = User.where(ppid: 'candleradmin').first
     subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
@@ -160,9 +164,11 @@ namespace :sample_data do
         file_type: 'Image'
       )
     }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
+
     attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
+    Hyrax::CurationConcern.actor.create(env)
+
     approving_user = User.where(ppid: 'tezprox').first
     subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
@@ -208,9 +214,11 @@ namespace :sample_data do
         file_type: 'Software'
       )
     }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
+
     attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
+    Hyrax::CurationConcern.actor.create(env)
+
     etd
   end
 
@@ -236,9 +244,11 @@ namespace :sample_data do
       file2 = File.open("#{::Rails.root}/spec/fixtures/miranda/image.tif")
       upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
       upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
-      actor = Hyrax::CurationConcern.actor(etd, ability)
+
       attributes_for_actor = { uploaded_files: [upload1.id, upload2.id] }
-      actor.create(attributes_for_actor)
+      env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
+      Hyrax::CurationConcern.actor.create(env)
+
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
       sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
       Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: "Preapproved")

--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -53,9 +53,8 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
       end
 
       # Create the ETD record
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(user))
-      attributes_for_actor ||= {}
-      actor.create(attributes_for_actor)
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(user), attributes_for_actor || {})
+      Hyrax::CurationConcern.actor.create(env)
 
       # Approver requests changes, so student will be able to edit the ETD
       change_workflow_status(etd, "request_changes", approver)

--- a/spec/features/candler_workflow_etd_spec.rb
+++ b/spec/features/candler_workflow_etd_spec.rb
@@ -5,20 +5,16 @@ require 'workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.feature 'Candler approval workflow', :perform_jobs, :clean do
-  let(:depositing_user) { User.where(ppid: etd.depositor).first }
+  let(:depositing_user) { FactoryBot.create(:user) }
   let(:approving_user) { User.where(uid: "candleradmin").first }
   let(:admin_superuser) { User.where(uid: "tezprox").first } # uid from superuser.yml
 
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null") }
 
-  let(:etd) { FactoryBot.create(:sample_data, school: ["Candler School of Theology"]) }
+  let(:etd) { FactoryBot.actor_create(:sample_data, school: ["Candler School of Theology"], user: depositing_user) }
   context 'a logged in user' do
-    before do
-      allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
-      actor.create({})
-    end
+    before { w.setup }
+
     scenario "a school approver approves a work" do
       # Check the ETD was assigned the right workflow
       expect(etd.active_workflow.name).to eq "emory_one_step_approval"

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -71,9 +71,9 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
       file_ids << uploaded_supp.id
     end
 
-    actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(student))
     attributes_for_actor = { uploaded_files: file_ids }
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ::Ability.new(student), attributes_for_actor)
+    Hyrax::CurationConcern.actor.create(env)
 
     # Approver requests changes, so student will be able to edit the ETD
     change_workflow_status(etd, "request_changes", approver)

--- a/spec/features/edit_rollins_spec.rb
+++ b/spec/features/edit_rollins_spec.rb
@@ -66,9 +66,8 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
     uploaded_etd = File.open(primary_pdf_file) { |file| Hyrax::UploadedFile.create(user: student, file: file, pcdm_use: 'primary') }
     file_ids = [uploaded_etd.id]
 
-    actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(student))
-    attributes_for_actor = { uploaded_files: file_ids }
-    actor.create(attributes_for_actor)
+    env = Hyrax::Actors::Environment.new(etd, ::Ability.new(student), uploaded_files: file_ids)
+    Hyrax::CurationConcern.actor.create(env)
 
     # Approver requests changes, so student will be able to edit the ETD
     change_workflow_status(etd, "request_changes", approver)

--- a/spec/features/virus_workflow_etd_spec.rb
+++ b/spec/features/virus_workflow_etd_spec.rb
@@ -22,10 +22,12 @@ RSpec.feature 'Virus checking', :perform_jobs, :clean, :js do
       class_double("Clamby").as_stubbed_const
       allow(Clamby).to receive(:virus?).and_return(true)
       w.setup
-      actor = Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user))
+
       attributes_for_actor = { uploaded_files: [upload1.id] }
-      actor.create(attributes_for_actor)
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), attributes_for_actor)
+      Hyrax::CurationConcern.actor.create(env)
     end
+
     scenario "supplemental file with virus" do
       # Check the ETD was assigned the right workflow
       expect(etd.active_workflow.name).to eq "emory_one_step_approval"

--- a/spec/features/workflow_approval_spec.rb
+++ b/spec/features/workflow_approval_spec.rb
@@ -4,8 +4,11 @@ include Warden::Test::Helpers
 
 RSpec.feature 'Dashboard workflow', :clean do
   let(:approving_user)  { User.find_by(uid: "candleradmin") }
-  let(:depositing_user) { User.find_by(ppid: etd.depositor) }
-  let(:etd)             { create(:sample_data, school: ["Candler School of Theology"]) }
+  let(:depositing_user) { FactoryBot.create(:user) }
+
+  let(:etd) do
+    FactoryBot.actor_create(:sample_data, school: ["Candler School of Theology"], user: depositing_user)
+  end
 
   before do
     WorkflowSetup
@@ -17,9 +20,6 @@ RSpec.feature 'Dashboard workflow', :clean do
   end
 
   scenario 'approver can approve submitted etd', :perform_jobs do
-    allow(CharacterizeJob).to receive(:perform_later) # don't run fits
-    Hyrax::CurationConcern.actor(etd, ::Ability.new(depositing_user)).create({})
-
     expect(etd.active_workflow.name).to eq 'emory_one_step_approval'
     expect(etd.to_sipity_entity.reload.workflow_state_name).to eq 'pending_approval'
 

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -7,25 +7,23 @@ describe GraduationService, :clean do
   let(:nongraduated_user) { FactoryBot.create(:nongraduated_user) }
   let(:approving_user) { User.where(uid: "candleradmin").first }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null") }
-  let(:graduated_etd) { FactoryBot.create(:sample_data) }
-  let(:nongraduated_etd) { FactoryBot.create(:sample_data) }
+  let(:graduated_etd) { FactoryBot.actor_create(:sample_data, user: graduated_user) }
+  let(:nongraduated_etd) { FactoryBot.actor_create(:sample_data, user: nongraduated_user) }
+
   before do
     w.setup
     # Create and approve the graduated ETD
-    actor = Hyrax::CurationConcern.actor(graduated_etd, ::Ability.new(graduated_user))
-    actor.create({})
     subject = Hyrax::WorkflowActionInfo.new(graduated_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
     expect(graduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
     # Create and approve the nongraduated ETD
-    actor = Hyrax::CurationConcern.actor(nongraduated_etd, ::Ability.new(nongraduated_user))
-    actor.create({})
     subject = Hyrax::WorkflowActionInfo.new(nongraduated_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
     expect(nongraduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
   end
+
   describe "#run" do
     it "finds all works in an approved state that do not yet have a degree_awarded value" do
       described_class.load_data('./spec/fixtures/registrar_sample.json')

--- a/spec/services/hyrax/workflow/approved_notification_spec.rb
+++ b/spec/services/hyrax/workflow/approved_notification_spec.rb
@@ -12,14 +12,17 @@ RSpec.describe Hyrax::Workflow::ApprovedNotification, :clean do
   end
 
   let(:user) { FactoryBot.create(:user) }
-  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
   let(:ability) { ::Ability.new(user) }
+
+  let(:etd) do
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"], user: user)
+  end
+
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
+
   let(:notification) do
-    env = Hyrax::Actors::Environment.new(etd, ability, admin_set_id: etd.admin_set.id)
-    Hyrax::CurationConcern.actor.create(env)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -8,20 +8,24 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification, :clean do
     w = WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null")
     w.setup
   end
+
   let(:user) { FactoryBot.create(:user) }
-  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
   let(:ability) { ::Ability.new(user) }
+
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
+
+  let(:etd) do
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"], user: user)
+  end
+
   let(:notification) do
-    attributes_for_actor = { admin_set_id: etd.admin_set.id }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)
   end
+
   it "can instantiate" do
     expect(notification).to be_instance_of(described_class)
   end

--- a/spec/services/hyrax/workflow/comment_notification_spec.rb
+++ b/spec/services/hyrax/workflow/comment_notification_spec.rb
@@ -9,15 +9,14 @@ RSpec.describe Hyrax::Workflow::CommentNotification, :clean do
     w.setup
   end
   let(:user) { FactoryBot.create(:user) }
-  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
+  let(:etd) do
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"], user: user)
+  end
   let(:ability) { ::Ability.new(user) }
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/degree_awarded_notification_spec.rb
+++ b/spec/services/hyrax/workflow/degree_awarded_notification_spec.rb
@@ -8,16 +8,18 @@ RSpec.describe Hyrax::Workflow::DegreeAwardedNotification, :clean do
     w = WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null")
     w.setup
   end
+
   let(:user) { FactoryBot.create(:user) }
-  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
   let(:ability) { ::Ability.new(user) }
+
+  let(:etd) do
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"], user: user)
+  end
+
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = { admin_set_id: etd.admin_set.id }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/hidden_notification_spec.rb
+++ b/spec/services/hyrax/workflow/hidden_notification_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe Hyrax::Workflow::HiddenNotification, :clean do
     w.setup
   end
   let(:user) { FactoryBot.create(:user) }
-  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
   let(:ability) { ::Ability.new(user) }
+
+  let(:etd) do
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"], user: user)
+  end
+
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
+
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/pending_approval_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_approval_notification_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe Hyrax::Workflow::PendingApprovalNotification, :clean do
   end
   let(:user) { FactoryBot.create(:user) }
   let(:etd) do
-    FactoryBot.create(
+    FactoryBot.actor_create(
       :sample_data,
       title: ["Grant Proposal for a socio-ecological approach, using community-based engagement principles and green infrastructure, to reduce magnitude and improve quality of storm water runoff entering storm drains in the Sandtown-Winchester/Harlem Park neighborhood, Baltimore City, Maryland"],
       depositor: user.user_key,
-      school: ["Candler School of Theology"]
+      school: ["Candler School of Theology"],
+      user: user
     )
   end
   let(:ability) { ::Ability.new(user) }
@@ -22,9 +23,6 @@ RSpec.describe Hyrax::Workflow::PendingApprovalNotification, :clean do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/pending_review_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_review_notification_spec.rb
@@ -10,16 +10,13 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification, :clean do
   end
   let(:user) { FactoryBot.create(:user) }
   let(:etd) do
-    FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Laney Graduate School"])
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Laney Graduate School"], user: user)
   end
   let(:ability) { ::Ability.new(user) }
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = {}
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/reviewed_notification_spec.rb
+++ b/spec/services/hyrax/workflow/reviewed_notification_spec.rb
@@ -10,15 +10,13 @@ RSpec.describe Hyrax::Workflow::ReviewedNotification, :clean do
   end
   let(:user) { FactoryBot.create(:user) }
   let(:etd) do
-    FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Laney Graduate School"])
+    FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Laney Graduate School"], user: user)
   end
   let(:ability) { ::Ability.new(user) }
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    env = Hyrax::Actors::Environment.new(etd, ability, {})
-    Hyrax::CurationConcern.actor.create(env)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)

--- a/spec/services/hyrax/workflow/virus_encountered_notification_spec.rb
+++ b/spec/services/hyrax/workflow/virus_encountered_notification_spec.rb
@@ -9,15 +9,12 @@ RSpec.describe Hyrax::Workflow::VirusEncounteredNotification, :clean do
     w.setup
   end
   let(:user) { FactoryBot.create(:user) }
-  let(:etd) { FactoryBot.create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"]) }
+  let(:etd) { FactoryBot.actor_create(:sample_data, depositor: user.user_key, school: ["Candler School of Theology"], user: user) }
   let(:ability) { ::Ability.new(user) }
   let(:recipients) do
     { 'to' => [FactoryBot.create(:user), FactoryBot.create(:user)] }
   end
   let(:notification) do
-    attributes_for_actor = { admin_set_id: etd.admin_set.id }
-    actor = Hyrax::CurationConcern.actor(etd, ability)
-    actor.create(attributes_for_actor)
     work_global_id = etd.to_global_id.to_s
     entity = Sipity::Entity.where(proxy_for_global_id: work_global_id).first
     described_class.new(entity, '', user, recipients)


### PR DESCRIPTION
The old style (Hyrax 1.0) actor stack calls were deprecated during the 2.0 upgrade. This removes some of the calls from tests, reducing the overall deprecated call footprint.