### PR TITLE
Add a term service to filter unwanted terms

### DIFF
--- a/app/services/term_service.rb
+++ b/app/services/term_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class TermService
+  attr_reader :etd_terms
+
+  FILTERED_TERMS = [:identifier, :representative_id, :thumbnail_id, :rendering_ids,
+                    :ordered_member_ids, :in_works_ids, :member_of_collection_ids,
+                    :admin_set_ids, :based_near, :source, :related_url].freeze
+
+  def initialize(etd_terms: [])
+    @etd_terms = etd_terms
+  end
+
+  def terms
+    @etd_terms
+  end
+
+  def rejected_terms
+    FILTERED_TERMS
+  end
+
+  def filtered_terms
+    @etd_terms.reject { |term| rejected_terms.include?(term) }
+  end
+end

--- a/spec/services/hyrax/term_service_spec.rb
+++ b/spec/services/hyrax/term_service_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TermService do
+  let(:term_service) { described_class.new(etd_terms: terms) }
+  let(:terms) { Hyrax::EtdForm.terms }
+  describe 'getting the filtered terms' do
+    it 'is initialized with all the etd terms' do
+      expect(term_service.terms).to include(:identifier)
+    end
+    it 'returns the filtered terms' do
+      expect(term_service.filtered_terms).not_to include(term_service.rejected_terms)
+    end
+  end
+end


### PR DESCRIPTION
This service will filter out Hyrax specific terms
that are in the Etd form. When creating a custom
form these terms do not need to appear.

Related to #1120