### PR TITLE
Sortable Embargo Index

### DIFF
--- a/app/views/hyrax/embargoes/_list_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_active_embargoes.html.erb
@@ -1,0 +1,18 @@
+<table class="embargoes table">
+  <thead>
+    <tr>
+      <%= render partial: 'table_headers' %>
+    </tr>
+  </thead>
+  <tbody>
+  <% assets_under_embargo.each do |curation_concern| %>
+    <tr>
+      <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
+      <td class="title"><%= link_to curation_concern, edit_embargo_path(curation_concern) %></td>
+      <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
+      <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
+      <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/embargoes/_list_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_active_embargoes.html.erb
@@ -1,4 +1,4 @@
-<table class="embargoes table">
+<table class="embargoes table datatable">
   <thead>
     <tr>
       <%= render partial: 'table_headers' %>
@@ -10,7 +10,7 @@
       <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
       <td class="title"><%= link_to curation_concern, edit_embargo_path(curation_concern) %></td>
       <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
-      <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
+      <td class="embargo-release-date" data-sort="<%= curation_concern.sortable_release_date %>"><%= curation_concern.embargo_release_date %></td>
       <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
     </tr>
   <% end %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -201,6 +201,16 @@ Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 
+Hyrax::EmbargoPresenter.class_eval do
+  def sortable_release_date
+    return solr_document.embargo_release_date&.iso8601 unless
+      method(__method__).super_method
+
+    warn "#{self.class}##{__method__} has been implemented in Hyrax and can be removed."
+    super
+  end
+end
+
 Hyrax::CurationConcern.class_eval do
   def self.actor(*args)
     @work_middleware_stack ||= actor_factory.build(Hyrax::Actors::Terminator.new)

--- a/spec/presenters/hyrax/embargo_presenter_spec.rb
+++ b/spec/presenters/hyrax/embargo_presenter_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Hyrax::EmbargoPresenter do
+  subject(:presenter) { described_class.new(SolrDocument.new(attributes)) }
+  let(:attributes)    { { 'embargo_release_date_dtsi' => '2015-10-15T00:00:00Z' } }
+
+  describe '#embargo_release_date' do
+    it { expect(presenter.embargo_release_date).to eq '15 Oct 2015' }
+  end
+
+  describe '#sortable_release_date' do
+    it { expect(presenter.sortable_release_date).to eq '2015-10-15' }
+  end
+end


### PR DESCRIPTION
Implements sorting on release date for the embargo index view. To achieve this, we add [DataTables](https://datatables.net) support to the embargos table. The embargo presenter is extended to expose a sortable date.

Connected to #1070.