### PR TITLE
Use defaults that don't require editing

### DIFF
--- a/dotenv.sample
+++ b/dotenv.sample
@@ -25,8 +25,6 @@ export NO_COVERAGE=true
 export _JAVA_OPTIONS="-Xmx600m"
 
 # For hyrax config
-export RAILS_ROOT=/path/to/your/project/dir
-export UPLOAD_PATH=$RAILS_ROOT/tmp/uploads
-export CACHE_PATH=$RAILS_ROOT/tmp/uploads/cache
-export WORKING_PATH=$RAILS_ROOT/tmp/uploads
-
+export UPLOAD_PATH=tmp/uploads
+export CACHE_PATH=tmp/uploads/cache
+export WORKING_PATH=tmp/uploads


### PR DESCRIPTION
To simplify developer setup, let's just use relative paths to the temp directory.  In production, we don't generally put these files under RAILS_ROOT anyway and would be changing this to something more like `/opt/uploads`