### PR TITLE
Use local cache directories during test runs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,6 @@
 export RAILS_HOST=localhost:3000
 export PROQUEST_NOTIFICATION_EMAIL=proquest@example.com
+
+export UPLOAD_PATH=tmp/uploads
+export CACHE_PATH=tmp/uploads/cache
+export WORKING_PATH=tmp/uploads


### PR DESCRIPTION
Not all environments (like mine) give the default user access to create directories under `/opt`.  When running the test suite locally or on a CI server, it should be fine to use caching directories under the local `tmp/` directory.