### PR TITLE
Cleanup more aggressively for `WorkflowSetup` specs

### DIFF
--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -3,6 +3,8 @@ require 'workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.describe WorkflowSetup, :clean do
+  before(:context) { DatabaseCleaner.clean_with(:truncation) }
+
   # Change "/dev/null" to STDOUT to see all logging output
   let(:w) { described_class.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/admin_sets.yml", "/dev/null") }
   let(:superuser_uid) { "superuser001" }


### PR DESCRIPTION
Specs for `WorkflowSetup` require a clean database, but they were previously
relying on transactional cleanup and the beginning state. If a prior test failed
to cleanup properly, the tests could fail due to existing database content.

This sets up truncation cleanup before the workflow tests to ensure the tests
run on an empty database.