### PR TITLE
Yarn rake task fix

### DIFF
--- a/lib/tasks/yarn.rake
+++ b/lib/tasks/yarn.rake
@@ -1,0 +1,6 @@
+namespace :yarn do
+  desc "Install all JavaScript dependencies as specified via Yarn"
+  task :install do
+    system("yarn install --no-progress --production")
+  end
+end


### PR DESCRIPTION
There is a bug in the current version of the webpacker gem that 
interferes with our capistrano deployment.

See:
https://github.com/rails/webpacker/issues/810

This adds a rake task which overrides the one provided by the gem so that yarn is called from the system version and not a binstub.