### PR TITLE
Use FormData to submit the form to InProgressEtds controller

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -1,15 +1,11 @@
 class InProgressEtdsController < ApplicationController
   def new
     @in_progress_etd = InProgressEtd.find_or_create_by(user_ppid: current_user.id)
-    @form = Hyrax::EtdForm.new(Etd.new, current_user.ability, Hyrax::EtdsController)
-    @curation_concern = Etd.new
-
-    # Showing the form that we get from Hyrax::EtdForm
   end
 
   def create
     @in_progress_etd = InProgressEtd.new
-    @in_progress_etd.data = params['etd'].to_json
+    @in_progress_etd.data = sanitize_params.to_json
     @in_progress_etd.save
     redirect_to @in_progress_etd
   end
@@ -34,7 +30,31 @@ class InProgressEtdsController < ApplicationController
 
   private
 
+    def sanitize_params
+      params["etd"].delete("committee_chair")
+      params["etd"].delete("committee_members")
+      prepare_committee_data
+
+      params["etd"]
+    end
+
+    def prepare_committee_data
+      # use real names; check what type of id is needed.
+      params["etd"]["committee_chair_attributes"] = { "0" => {
+        "affiliation_type" => "Emory Committee Chair", "name" => ["Curie, Marie"],
+        "id" => "#nested_g70334968021140"
+      }, "1" => { "affiliation_type" =>
+        "Emory Committee Chair", "name" => [""] } }
+
+      params["etd"]["committee_members_attributes"] = { "0" =>
+      { "affiliation_type" => "Non-Emory Committee Member", "affiliation" => ["NASA"],
+        "name" => ["Maher, Valerie"], "id" => "#nested_g70334919944200" } }
+    end
+
     def in_progress_etd_params
-      params.permit(Hyrax::EtdForm.terms)
+      terms = TermService.new(etd_terms: Hyrax::EtdForm.terms).filtered_terms
+      terms << "committee_chair_attributes"
+      terms << "committee_members_attributes"
+      params.permit(terms)
     end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -5,18 +5,17 @@
         <a href="#" data-turbolinks="false" class="tab" v-on:click="form.toggleSelected(index)">{{ value.label }}</a>
       </li>
     </ul>
-    <form role="form" action="/concern/etds/new" method="post" @submit.prevent="onSubmit">
+    <form role="form" id="vue_form" action="/concern/etds/new" method="post" @submit.prevent="onSubmit">
       <div v-for="value in form.tabs" v-bind:key="value.label">
-
         <div class="tab-content form-group" v-if="value.selected">
           <h1> {{ value.label }} </h1>
-          <div v-for="input in value.inputs" v-bind:key="input">
+          <div v-for="(input, index) in value.inputs" v-bind:key="index">
             <div v-if="input.label === 'School'">
               <school></school>
             </div>
             <div v-else>
               <label>{{ input.label }}</label>
-              <input class="form-control" v-model="input.value">
+              <input class="form-control" :name="etdPrefix(index)" v-model="input.value">
             </div>
           </div>
           <button type="submit" class="btn btn-default">Submit</button>
@@ -27,39 +26,47 @@
 </template>
 
 <script>
+import axios from "axios"
+import VueAxios from "vue-axios"
+import { formStore } from "./form_store"
+import School from "./school"
 
-import axios from 'axios'
-import VueAxios from 'vue-axios'
-import { formStore } from "./form_store";
-import School from "./school";
-
-let token = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-axios.defaults.headers.common['X-CSRF-Token'] = token
-
+let token = document
+  .querySelector('meta[name="csrf-token"]')
+  .getAttribute("content")
+axios.defaults.headers.common["X-CSRF-Token"] = token
 
 export default {
   data() {
     return {
       form: formStore,
-      about_me: formStore.tabs.about_me.inputs
+      tabInputs: []
     }
   },
   components: {
     school: School
   },
   methods: {
+    etdPrefix(index) {
+      return "etd[" + index + "]"
+    },
+    getFormData() {
+      var form = document.getElementById("vue_form")
+      var formData = new FormData(form)
+      return formData
+    },
     onSubmit() {
-      axios.post('/in_progress_etds',
-      {
-        etd: this.about_me
-      })
-      .then(response => {})
-      .catch(e => {
-        this.errors.push(e)
-      })
+      axios
+        .post("/in_progress_etds", this.getFormData(), {
+          config: { headers: { "Content-Type": "multipart/form-data" } }
+        })
+        .then(response => {})
+        .catch(e => {
+          this.errors.push(e)
+        })
     }
   }
-};
+}
 </script>
 
 <style scoped>

--- a/app/javascript/packs/submit_etd_for_approval.js
+++ b/app/javascript/packs/submit_etd_for_approval.js
@@ -19,7 +19,7 @@ document.addEventListener('turbolinks:load', function () {
     methods: {
       submitEtd: function(){
         axios.post(`/concern/etds`, {
-          etd: document.getElementById('postBody').value
+          etd: {"etd": document.getElementById('postBody').value }
         })
         .then(response => {})
         .catch(e => {


### PR DESCRIPTION
This commit changes the form so that the InProgressEtds controller
received a form submission that mimics what Hyrax returns when
submitting a form. The form is submitted as `multipart/form-data`
, but this is saved as JSON in the database. This JSON can be
used to create a Hyrax object, but needs a few more changes to
complete the process -- mainly an admin set id. This might
need to be derived from the `Hyrax::EtdForm`.