### PR TITLE
add the Puma web server gem to development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :development do
   gem 'pry-byebug'
   # Spring speeds up development by keeping your application running in the
   # background. Read more: https://github.com/rails/spring
+  gem 'puma'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Access an IRB console on exception pages or by using <%= console %> anywhere

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -594,6 +594,7 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.1)
     pul_uv_rails (2.0.1)
+    puma (3.11.4)
     qa (2.0.1)
       activerecord-import
       deprecation
@@ -950,6 +951,7 @@ DEPENDENCIES
   pg (~> 0.21)
   pry
   pry-byebug
+  puma
   rails (~> 5.1)
   rails-controller-testing
   rsolr (~> 1.0)


### PR DESCRIPTION
Hyrax notifications (missing endpoint) errors are logged by the default Rails web server to the js console, and it becomes too clogged to easily use it for js development. The Puma web server doesn't have these problems (no messages in the js console about notification errors).