### PR TITLE
Remove redundant css in hyrax.scss

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -49,7 +49,6 @@ body.dashboard {
 
 #masthead {
     background: #002878 none repeat scroll 0 0;
-    min-height: 150px;
     background-position: bottom right;
     min-height: 135px;
     background-repeat: no-repeat;


### PR DESCRIPTION
Only the last setting for each value gets read, the first is redundant.