### PR TITLE
Fixed error when click 'All Collections' link. Story #1204

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,4 +3,5 @@ class Collection < ActiveFedora::Base
   include ::Hyrax::CollectionBehavior
   # You can replace these metadata if they're not suitable
   include Hyrax::BasicMetadata
+  self.indexer = Hyrax::CollectionWithBasicMetadataIndexer
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,7 +81,7 @@ class SolrDocument
   end
 
   def description
-    self[Solrizer.solr_name('description')]
+    self[Solrizer.solr_name('description')] || []
   end
 
   def embargo_length

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ::SolrDocument, type: :model do
+  describe '#description' do
+    subject(:description) { solr_doc.description }
+
+    let(:solr_doc) { described_class.new(coll.to_solr) }
+
+    context 'A collection with a description' do
+      let(:desc) { 'A Description of My Collection' }
+      let(:coll) { Collection.new(title: ['A'], description: [desc]) }
+
+      it { is_expected.to eq [desc] }
+    end
+
+    context 'A collection without a description' do
+      let(:coll) { Collection.new(title: ['A']) }
+
+      # Because some views assume array. Story #1204.
+      it 'returns an empty array' do
+        expect(description).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are 2 parts to this fix:

1. The hyrax view assumes that the description returned by the presenter
is an array (and attempts to call `.first` on it).  That will cause an
error in the case where description is nil.  So I made a change to the
SolrDocument#description to return empty array if description is nil to
avoid raising an error.

2. In the case where the Collection does have a description, the
presenter/SolrDocument was returning nil.  This is because the
Collection model was using an indexer that doesn't index the
BasicMetadata.  (We missed a new indexer during our recent hyrax gem
upgrades.)