### PR TITLE
Add Quill for editing abstract and toc

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -13,6 +13,20 @@
             <div v-if="input.label === 'School'">
               <school></school>
             </div>
+            <div v-else-if="input.label === 'Table of Contents'">
+              <label>{{ input.label }}</label>
+               <quill-editor ref="myTextEditor"
+                v-model="input.value[0]">
+               </quill-editor>
+               <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />   
+            </div>
+            <div v-else-if="input.label === 'Abstract'">
+               <label>{{ input.label }}</label>
+               <quill-editor ref="myTextEditor"
+                v-model="input.value[0]">
+               </quill-editor> 
+               <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" /> 
+            </div>
             <div v-else>
               <label>{{ input.label }}</label>
               <input class="form-control" :name="etdPrefix(index)" v-model="input.value">
@@ -30,6 +44,10 @@ import axios from "axios"
 import VueAxios from "vue-axios"
 import { formStore } from "./form_store"
 import School from "./school"
+import { quillEditor } from 'vue-quill-editor'
+import 'quill/dist/quill.core.css'
+import 'quill/dist/quill.snow.css'
+import 'quill/dist/quill.bubble.css'
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -40,11 +58,31 @@ export default {
   data() {
     return {
       form: formStore,
-      tabInputs: []
+      tabInputs: [],
+      editorOptions: {
+          modules: {
+            toolbar: [
+              ['bold', 'italic', 'underline', 'strike'],
+              ['blockquote', 'code-block'],
+              [{ 'header': 1 }, { 'header': 2 }],
+              [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+              [{ 'script': 'sub' }, { 'script': 'super' }],
+              [{ 'indent': '-1' }, { 'indent': '+1' }],
+              [{ 'direction': 'rtl' }],
+              [{ 'size': ['small', false, 'large', 'huge'] }],
+              [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+              [{ 'font': [] }],
+              [{ 'color': [] }, { 'background': [] }],
+              [{ 'align': [] }],
+              ['clean'],
+            ]
+          }
+      },
     }
   },
   components: {
-    school: School
+    school: School,
+    quillEditor: quillEditor
   },
   methods: {
     etdPrefix(index) {
@@ -97,5 +135,14 @@ ul li a {
 
 input {
   margin-bottom: 1em;
+}
+
+.quill-hidden-field {
+  display: none;
+}
+
+.quill-editor {
+  height: 10em;
+  margin-bottom:7em;
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "vue": "^2.5.16",
     "vue-axios": "^2.1.1",
     "vue-loader": "14.2.2",
+    "vue-quill-editor": "^3.0.6",
     "vue-template-compiler": "^2.5.16",
     "vue-turbolinks": "^2.0.3"
   },
@@ -44,7 +45,8 @@
       "app/javascript"
     ],
     "moduleNameMapper": {
-      "^@/(.*)$": "<rootDir>/$1"
+      "^@/(.*)$": "<rootDir>/$1",
+      ".*\\.css$": "<rootDir>/app/javascript/test/dummy.js"
     },
     "transform": {
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,7 +1412,7 @@ clone-deep@^2.0.1:
     kind-of "^6.0.0"
     shallow-clone "^1.0.0"
 
-clone@2.x:
+clone@2.x, clone@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
 
@@ -2416,6 +2416,10 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+eventemitter3@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+
 eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -2542,7 +2546,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.1, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -2603,6 +2607,10 @@ fast-deep-equal@^1.0.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
+fast-diff@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -5028,6 +5036,10 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+parchment@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parchment/-/parchment-1.1.4.tgz#aeded7ab938fe921d4c34bc339ce1168bc2ffde5"
+
 parse-asn1@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.1.tgz#f6bf293818332bd0dab54efb16087724745e6ca8"
@@ -5874,6 +5886,25 @@ querystring@0.2.0:
 querystringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.0.0.tgz#fa3ed6e68eb15159457c89b37bc6472833195755"
+
+quill-delta@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/quill-delta/-/quill-delta-3.6.2.tgz#76eed0163b8b09a076fba6ade29307c42b40b8d8"
+  dependencies:
+    deep-equal "^1.0.1"
+    extend "^3.0.1"
+    fast-diff "1.1.2"
+
+quill@^1.3.4:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-1.3.6.tgz#99f4de1fee85925a0d7d4163b6d8328f23317a4d"
+  dependencies:
+    clone "^2.1.1"
+    deep-equal "^1.0.1"
+    eventemitter3 "^2.0.3"
+    extend "^3.0.1"
+    parchment "^1.1.4"
+    quill-delta "^3.6.2"
 
 randomatic@^3.0.0:
   version "3.0.0"
@@ -7327,6 +7358,13 @@ vue-loader@14.2.2:
     vue-hot-reload-api "^2.2.0"
     vue-style-loader "^4.0.1"
     vue-template-es2015-compiler "^1.6.0"
+
+vue-quill-editor@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/vue-quill-editor/-/vue-quill-editor-3.0.6.tgz#1f85646211d68a31a80a72cb7f45bb2f119bc8fb"
+  dependencies:
+    object-assign "^4.1.1"
+    quill "^1.3.4"
 
 vue-style-loader@^4.0.1:
   version "4.1.0"


### PR DESCRIPTION
This adds the Quill editor for rich text editing
of the abstract and table of contents. There
will need to be a follow up PR that sets the
toolbar options.

The text that is output by Quill is bound to a
hidden input field with the correct name for
the form submission.

https://quilljs.com/

Related to #1189