### PR TITLE
Update datatable styling and embargo titles

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -116,3 +116,21 @@ border-bottom: solid 5px #d2b000;
     color: #163b84;
     font-weight: bold;
 }
+
+table.dataTable thead .sorting:after,
+table.dataTable thead .sorting_asc:after,
+table.dataTable thead .sorting_desc:after {
+    position: relative;
+    display: inline;
+    vertical-align: middle;
+    top: 0px;
+    right: 0px;
+    left: 0.5em;
+}
+
+table.dataTable.table-condensed thead .sorting:after,
+table.dataTable.table-condensed thead .sorting_asc:after,
+table.dataTable.table-condensed thead .sorting_desc:after {
+    top: 0px;
+    right: 0px;
+}

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -32,6 +32,13 @@ en:
       form_files:
         external_upload: "Upload Large Files"
         local_upload: "Upload Small Files"
+    embargoes:
+      table_headers:
+        type: Type
+        title: Title
+        viz_current: Visibility
+        release_date: Ends
+        viz_after: Post-Embargo
     workflow:
         unauthorized: "The work is not currently available because it has not yet completed the publishing process"
     works:


### PR DESCRIPTION
The css changes will apply to all data tables across the application.
They reposition the sort controls to the immediate left of each
column title.

The localization changes provide shorter column titles for the
embargo views.

Connected to #1159

<img width="1162" alt="1159 - default - no data" src="https://user-images.githubusercontent.com/3064318/42117338-92416004-7bc1-11e8-966e-da91f1d4a1e8.png">

<img width="1163" alt="1159 - default - live data" src="https://user-images.githubusercontent.com/3064318/42117349-98875d6a-7bc1-11e8-9e5c-e14640f3a021.png">

<img width="1161" alt="1159 - post changes - live data" src="https://user-images.githubusercontent.com/3064318/42117359-a1db6618-7bc1-11e8-8cf2-004b2ba5aa25.png">
