### PR TITLE
New UI testing: creating a Hyrax ETD

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -5,7 +5,7 @@ class InProgressEtdsController < ApplicationController
 
   def create
     @in_progress_etd = InProgressEtd.new
-    @in_progress_etd.data = sanitize_params.to_json
+    @in_progress_etd.data = prepare_etd_data.to_json
     @in_progress_etd.save
     redirect_to @in_progress_etd
   end
@@ -26,35 +26,69 @@ class InProgressEtdsController < ApplicationController
 
   def show
     @in_progress_etd = InProgressEtd.find(params[:id])
+    @etd = InProgressEtd.find(params[:id]).data
+    @uploaded_files = ["1"] # @etd['uploaded_files']
   end
 
   private
 
-    def sanitize_params
-      params["etd"].delete("committee_chair")
-      params["etd"].delete("committee_members")
-      prepare_committee_data
-
-      params["etd"]
+    def prepare_etd_data
+      etd = request.parameters.fetch(:etd)
+      prepare_committee_data(etd)
+      add_supplemental_file_data(etd)
+      # uploaded_files = Hyrax::UploadedFile.id
+      # add_uploaded_file_data(etd)
+      add_agreement_data(etd)
+      add_embargo_data(etd)
+      add_school_and_department(etd)
+      etd
     end
 
-    def prepare_committee_data
-      # use real names; check what type of id is needed.
-      params["etd"]["committee_chair_attributes"] = { "0" => {
+    def prepare_committee_data(etd)
+      # use real names; check what type of nested_id is needed.
+      etd["committee_chair_attributes"] = { "0" => {
         "affiliation_type" => "Emory Committee Chair", "name" => ["Curie, Marie"],
         "id" => "#nested_g70334968021140"
       }, "1" => { "affiliation_type" =>
         "Emory Committee Chair", "name" => [""] } }
 
-      params["etd"]["committee_members_attributes"] = { "0" =>
+      etd["committee_members_attributes"] = { "0" =>
       { "affiliation_type" => "Non-Emory Committee Member", "affiliation" => ["NASA"],
         "name" => ["Maher, Valerie"], "id" => "#nested_g70334919944200" } }
     end
 
+    # TODO: Get each of these from the form
+
+    def add_supplemental_file_data(etd)
+      etd["no_supplemental_files"] = "0"
+    end
+
+    def add_uploaded_file_data(etd)
+      etd["uploaded_files"] = "1"
+    end
+
+    def add_agreement_data(etd)
+      etd["agreement"] = "1"
+    end
+
+    def add_embargo_data(etd)
+      etd["no_embargoes"] = "1"
+    end
+
+    def add_school_and_department(etd)
+      etd["school"] = "Emory College"
+      etd["department"] = "Anthropology"
+    end
+
+    # TODO: confirm whether this is not needed
     def in_progress_etd_params
       terms = TermService.new(etd_terms: Hyrax::EtdForm.terms).filtered_terms
       terms << "committee_chair_attributes"
       terms << "committee_members_attributes"
+      terms << "uploaded_files"
+      terms << "no_embargoes"
+      terms << "agreement"
+      terms << "no_supplemental_files"
       params.permit(terms)
     end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -18,6 +18,7 @@
               <input class="form-control" :name="etdPrefix(index)" v-model="input.value">
             </div>
           </div>
+          <!--  TODO: add tab label as hidden input, for validation -->
           <button type="submit" class="btn btn-default">Submit</button>
         </div>
       </div>

--- a/app/javascript/packs/submit_etd_for_approval.js
+++ b/app/javascript/packs/submit_etd_for_approval.js
@@ -8,19 +8,22 @@ Vue.use(TurbolinksAdapter, VueAxios, axios)
 document.addEventListener('turbolinks:load', function () {
   let token = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
   axios.defaults.headers.common['X-CSRF-Token'] = token
-  axios.defaults.headers.common['Accept'] = 'application/json'
+  axios.defaults.headers.common['Content-Type'] = 'multipart/form-data'
 
   Vue.component('submit-for-approval', {
     data: function () {
       return {
-        postBody: ""
       }
     },
     methods: {
+      getEtdData: function(){
+        var form = document.getElementById("etd_form")
+        var formData = new FormData(form)
+        return formData
+      },
       submitEtd: function(){
-        axios.post(`/concern/etds`, {
-          etd: {"etd": document.getElementById('postBody').value }
-        })
+        axios.post('/concern/etds', this.getEtdData()
+        )
         .then(response => {})
         .catch(e => {
           this.errors.push(e)

--- a/app/views/in_progress_etds/show.html.erb
+++ b/app/views/in_progress_etds/show.html.erb
@@ -6,11 +6,22 @@
     </ul>
     <%= link_to('Edit', edit_in_progress_etd_path(@in_progress_etd)) %>
 
+    <% in_progress_etd = @etd %>
+
+    <form role="form" id="etd_form" action="/concern/etds/new" method="post">
+      <% JSON.parse(in_progress_etd).each do |k, v| %>
+      <p><b><%= k %>:</b> <%= v %></p>
+
+      <input type='hidden' id="etd" name="etd[<%= k %>]" value="<%= v %>"/>
+      <% end %>
+
+      <input type='hidden' id="files" name='uploaded_files[]' value="1"/>
+    </form>
+
     <div id='submit-etd'>
       <submit-for-approval></submit-for-approval>
     </div>
 
-    <input type="hidden" v-model="postBody" id='postBody' name="etd" value="<%= @in_progress_etd.data %>"/>
   </body>
 </html>
 


### PR DESCRIPTION
This commit allows a user to persist an in-progress ETD, view and then successfully submit it for publication as a Hyrax ETD. It contains hard-coded values for parts of the new Vue form that are as yet not built out (committee data, uploaded and supplemental files, embargo data, and the agreement). As those parts of the form are built they will replace the hard-coding. 

The in-progress ETD is submitted as form-data to Hyrax, although the original intention had been to submit JSON data (the Hyrax controller does not seem to parse JSON). This will probably allow us to re-use most of our Vue structures. The submit occurs from the 'show' view of the in-progress-etds, so `http://localhost:3000/in_progress_etds/ID`. The user testing with this code is expected to have at least one UploadedFile record in their local database, the id 1 is hard-coded. Creating a Hyrax ETD with the old UI and a pdf will create that object and row in the database.

See this article for information about using Rails instance variables in Vue components: https://medium.com/@devanflaherty/passing-props-to-vue-in-a-rails-view-56e287be9c2d
