### PR TITLE
Add dynamic Submission Type dropdown

### DIFF
--- a/app/javascript/SubmittingType.vue
+++ b/app/javascript/SubmittingType.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <label>Submission Type</label>
+        <select name="etd[submitting_type]" class="form-control">
+            <option v-for="submittingType in submittingTypes" v-bind:value="submittingType.id" v-bind:key='submittingType.id' v-if="submittingType.active">
+                {{ submittingType.label }}
+            </option>
+        </select>
+    </div>
+</template>
+
+<script>
+import Axios from "axios"
+export default {
+  data() {
+    return {
+      submittingTypeEndpoint: "/authorities/terms/local/submitting_type",
+      submittingTypes: {}
+    }
+  },
+  methods: {
+    fetchData() {
+      Axios.get(this.submittingTypeEndpoint).then(response => {
+        this.submittingTypes = response.data
+      });
+    }
+  },
+  created() {
+    this.fetchData()
+  }
+}
+</script>

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -27,6 +27,9 @@
                </quill-editor> 
                <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" /> 
             </div>
+            <div v-if="input.label === 'Submitting Type'">
+              <submittingType></submittingType>
+            </div>
             <div v-else>
               <label>{{ input.label }}</label>
               <input class="form-control" :name="etdPrefix(index)" v-model="input.value">
@@ -49,6 +52,7 @@ import { quillEditor } from 'vue-quill-editor'
 import 'quill/dist/quill.core.css'
 import 'quill/dist/quill.snow.css'
 import 'quill/dist/quill.bubble.css'
+import SubmittingType from './SubmittingType'
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -83,7 +87,8 @@ export default {
   },
   components: {
     school: School,
-    quillEditor: quillEditor
+    quillEditor: quillEditor,
+    submittingType: SubmittingType
   },
   methods: {
     etdPrefix(index) {

--- a/app/javascript/test/SubmissionType.spec.js
+++ b/app/javascript/test/SubmissionType.spec.js
@@ -1,0 +1,27 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import SubmittingType from 'SubmittingType'
+
+describe('SubmittingType.vue', () => {
+  it('renders a form', () => {
+    const wrapper = shallowMount(SubmittingType, {
+    })
+    expect(wrapper.findAll('select')).toHaveLength(1)
+  })
+
+  it('has a label that contains Submission Type', () => {
+    const wrapper = shallowMount(SubmittingType, {
+    })
+    console.log(wrapper.html())
+    expect(wrapper.findAll('label')).toHaveLength(1)
+  })
+
+  it('has the correct html', () => {
+    const wrapper = shallowMount(SubmittingType, {
+    })
+    console.log(wrapper.html())
+    expect(wrapper.html()).toEqual(`<div><label>Submission Type</label> <select name="etd[submitting_type]" class="form-control"></select></div>`)
+  })
+})


### PR DESCRIPTION
This commit adds a component that renders the
the submission types dropdown on the form. It
does an XHR request to the QA endpoint to accomplish
this.

There is a basic spec in place, but to fully test
the component, there will need to be an Axios mock
in place. The spec currently triggers a node warning.