### PR TITLE
Don't stub `ActiveJob::Base` in tests

### DIFF
--- a/spec/features/create_etd_review_spec.rb
+++ b/spec/features/create_etd_review_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Create an Etd', :clean do
     before do
       # Don't run background jobs during the spec
       page.driver.console_messages
-      allow(ActiveJob::Base).to receive_messages(perform_later: nil, perform_now: nil)
 
       # Create AdminSet and Workflow
       workflow_setup.setup

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -37,9 +37,6 @@ RSpec.feature 'Create an Etd', :clean do
     let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
 
     before do
-      # Don't run background jobs during the spec
-      allow(ActiveJob::Base).to receive_messages(perform_later: nil, perform_now: nil)
-
       # Create AdminSet and Workflow
       workflow_setup.setup
 

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
+RSpec.feature 'Edit an existing ETD', :clean do
   let(:approver) { User.where(uid: "tezprox").first }
   let(:student) { create :user }
 
@@ -77,9 +77,6 @@ RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
 
     # Approver requests changes, so student will be able to edit the ETD
     change_workflow_status(etd, "request_changes", approver)
-
-    # Don't run background jobs during the spec
-    allow(ActiveJob::Base).to receive_messages(perform_later: nil, perform_now: nil)
   end
 
   context 'a logged in student' do


### PR DESCRIPTION
We use the test adapter for `ActiveJob`, so stubbing `Base` makes things more complex for no particular benefit. We can count on the adapter to manage which jobs are run during the test suite.