### PR TITLE
Use i18n to give the ETD model a human readable label

### DIFF
--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -1,4 +1,7 @@
 en:
+  activefedora:
+    models:
+      etd:                  "ETD"
   hyrax:
     icons:
       etd:     'fa fa-file-text-o'

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Etd do
+  context "human readable type" do
+    it "capitalizes ETD because it is an acronym" do
+      expect(I18n.t("activefedora.models.etd")).to eq "ETD"
+    end
+  end
+
   context "#hidden?" do
     let(:etd) { FactoryBot.build(:etd) }
     context "with a new ETD" do


### PR DESCRIPTION
The previous system for doing this, model.human_readable_name,
has been deprecated. This seems to be the new preferred system
for giving a model a human readable label.

Connected to https://github.com/curationexperts/laevigata/issues/1219