### PR TITLE
Move `babel-preset-es2015` out of dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@rails/webpacker": "3.5",
     "axios": "^0.18.0",
+    "babel-preset-es2015": "^6.24.1",
     "eslint": "^5.0.1",
     "vue": "^2.5.16",
     "vue-axios": "^2.1.1",
@@ -17,7 +18,6 @@
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.20",
     "babel-jest": "^23.2.0",
-    "babel-preset-es2015": "^6.24.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-node": "^6.0.1",


### PR DESCRIPTION
Similar to a Gemfile, `package.json` has dev dependencies. This was added to dev dependencies, but needs to be present to deploy. This commit moves it.

Related to #1233