### PR TITLE
New ui/add tab validation - About Me

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -6,8 +6,11 @@ class InProgressEtdsController < ApplicationController
   def create
     @in_progress_etd = InProgressEtd.new
     @in_progress_etd.data = prepare_etd_data.to_json
-    @in_progress_etd.save
-    redirect_to @in_progress_etd
+    if @in_progress_etd.save
+      redirect_to @in_progress_etd
+    else
+      render json: { errors: @in_progress_etd.errors.messages }, status: 422
+    end
   end
 
   def edit

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -38,6 +38,17 @@ module Hyrax
 
     self.single_valued_fields = [:title, :creator, :post_graduation_email, :submitting_type, :graduation_date, :degree, :subfield, :department, :school, :language, :abstract, :table_of_contents]
 
+    # methods for accessing new tab-determined sets of terms on new form tabs in new ui
+    if Rails.application.config_for(:new_ui).fetch('enabled', false)
+      def self.about_me_terms
+        [:creator, :graduation_date, :post_graduation_email, :school]
+      end
+
+      def self.my_program_terms
+        [:department, :subfield, :partnering_agency, :degree, :submitting_type]
+      end
+    end
+
     def about_me_fields
       [:creator, :graduation_date, :post_graduation_email]
     end

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -24,14 +24,14 @@
                <quill-editor ref="myTextEditor"
                 v-model="input.value[0]">
                </quill-editor>
-               <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />   
+               <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />
             </div>
             <div v-else-if="input.label === 'Abstract'">
                <label>{{ input.label }}</label>
                <quill-editor ref="myTextEditor"
                 v-model="input.value[0]">
-               </quill-editor> 
-               <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" /> 
+               </quill-editor>
+               <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />
             </div>
              <div v-else-if="input.label === 'Graduation Date'">
               <graduationDate></graduationDate>
@@ -54,7 +54,12 @@
             </div>
           </div>
           <!--  TODO: add tab label as hidden input, for validation -->
+          <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <button type="submit" class="btn btn-default">Submit</button>
+          <section v-if="errored">
+            Invalidation Errors happened:        
+              <p>{{ errors }}</p>
+          </section>
         </div>
       </div>
     </form>
@@ -89,6 +94,8 @@ export default {
       tabInputs: [],
       editorOptions: {
       },
+      errored: false,
+      errors: []
     }
   },
   components: {
@@ -112,13 +119,17 @@ export default {
       return formData
     },
     onSubmit() {
+      var that = this;
       axios
         .post("/in_progress_etds", this.getFormData(), {
           config: { headers: { "Content-Type": "multipart/form-data" } }
         })
-        .then(response => {})
-        .catch(e => {
-          this.errors.push(e)
+        .then(response => {
+        })
+        .catch(error => {
+          that.errored = true
+          that.errors = []
+          that.errors.push(error.response.data.errors)
         })
     }
   }

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -1,2 +1,5 @@
 class InProgressEtd < ApplicationRecord
+  # custom validators check for presence of tab-determined set of fields based on presence of tab-identifying data
+  validates_with AboutMeValidator
+  validates_with MyProgramValidator
 end

--- a/app/validators/about_me_validator.rb
+++ b/app/validators/about_me_validator.rb
@@ -1,0 +1,16 @@
+class AboutMeValidator < ActiveModel::Validator
+  def validate(record)
+    return unless current_tab?(record)
+    ::Hyrax::EtdForm.about_me_terms.each do |field|
+      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].empty?
+    end
+  end
+
+  def parsed_data(record)
+    JSON.parse(record.data)
+  end
+
+  def current_tab?(record)
+    parsed_data(record)['currentTab'] == "About Me"
+  end
+end

--- a/app/validators/my_program_validator.rb
+++ b/app/validators/my_program_validator.rb
@@ -1,0 +1,16 @@
+class MyProgramValidator < ActiveModel::Validator
+  def validate(record)
+    return unless current_tab?(record)
+    ::Hyrax::EtdForm.my_program_terms.each do |field|
+      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].empty?
+    end
+  end
+
+  def parsed_data(record)
+    JSON.parse(record.data)
+  end
+
+  def current_tab?(record)
+    parsed_data(record)['currentTab'] == "My Program"
+  end
+end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe InProgressEtd do
+  before(:all) do
+    new_ui = Rails.application.config_for(:new_ui).fetch('enabled', false)
+
+    skip("InProgress ETD model tests run only when NEW_UI_ENABLED") unless new_ui
+  end
+
+  describe "About Me" do
+    context "with valid data" do
+      let(:data) do
+        { currentTab: "About Me", creator: "Student", graduation_date: "tomorrow", post_graduation_email: "tester@test.com", school: "Laney Graduate School" }
+      end
+      let(:in_progress_etd) { described_class.new(data: data.to_json) }
+
+      it "is valid" do
+        expect(in_progress_etd).to be_valid
+      end
+    end
+
+    context "with invalid data" do
+      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", graduation_date: "tomorrow", post_graduation_email: "", school: "" }.to_json) }
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+  end
+
+  describe "My Program" do
+    context "with valid data" do
+      let(:data) do
+        { currentTab: "My Program", department: "Anthropology", subfield: "Foo", partnering_agency: "DCD", degree: "Non", submitting_type: "Phd" }
+      end
+      let(:in_progress_etd) { described_class.new(data: data.to_json) }
+
+      it "is valid" do
+        expect(in_progress_etd).to be_valid
+      end
+    end
+
+    context "with invalid data" do
+      let(:data) do
+        { currentTab: "My Program", department: "", subfield: "Foo", partnering_agency: "DCD", degree: "Non", submitting_type: "" }
+      end
+      let(:in_progress_etd) { described_class.new(data: data.to_json) }
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This might be easiest and simplest way to validate an InProgressEtd on a per-tab basis. The name of the tab is added to the data, and a custom Validator class uses a current_tab? to check the tab name and determine whether to run. If it runs, it checks the fields in a list stored in the HyraxEtd Form class, via a new method in the etd class (based on similar methods and lists for the current ETD tab contents). 

It might be a little repetitive, and there might be other flaws. It needs tests. So, I want to discuss.
