### PR TITLE
Turn off coverage for CI builds with old form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   global:
     - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   matrix:
-    - NEW_UI_ENABLED=false
+    - NEW_UI_ENABLED=false NO_COVERAGE=true
     - NEW_UI_ENABLED=true
 install:
   - nvm install node


### PR DESCRIPTION
Coverage reports on the parallel builds was not useful since it varied depending on which build reported to coveralls when. We decided to just disable coveralls for the (soon to be legacy?) mainline.