### PR TITLE
Add additional QA-driven dropdowns

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -27,11 +27,20 @@
                </quill-editor> 
                <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" /> 
             </div>
+             <div v-if="input.label === 'Graduation Date'">
+              <graduationDate></graduationDate>
+            </div>
             <div v-if="input.label === 'Submitting Type'">
               <submittingType></submittingType>
             </div>
             <div v-if="input.label === 'Degree'">
               <degree></degree>
+            </div>
+            <div v-if="input.label === 'Research Field'">
+              <researchField></researchField>
+            </div>
+            <div v-if="input.label === 'Language'">
+              <language></language>
             </div>
             <div v-else>
               <label>{{ input.label }}</label>
@@ -50,13 +59,16 @@
 import axios from "axios"
 import VueAxios from "vue-axios"
 import { formStore } from "./form_store"
-import School from "./school"
+import School from "./School"
 import { quillEditor } from 'vue-quill-editor'
 import 'quill/dist/quill.core.css'
 import 'quill/dist/quill.snow.css'
 import 'quill/dist/quill.bubble.css'
 import SubmittingType from './SubmittingType'
-import Degree from "./degree"
+import Degree from "./Degree"
+import ResearchField from "./ResearchField"
+import GraduationDate from "./GraduationDate"
+import Language from "./Language"
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -93,7 +105,10 @@ export default {
     school: School,
     quillEditor: quillEditor,
     submittingType: SubmittingType,
-    degree: Degree
+    degree: Degree,
+    researchField: ResearchField,
+    graduationDate: GraduationDate,
+    language: Language
   },
   methods: {
     etdPrefix(index) {

--- a/app/javascript/Degree.vue
+++ b/app/javascript/Degree.vue
@@ -2,7 +2,7 @@
     <div>
         <label>Degree</label>
         <select name="etd[degree]" class="form-control">
-            <option v-for="degree in degrees" v-bind:value="degree.id" v-bind:key='degree.label'>
+            <option v-for="degree in degrees" v-bind:value="degree.id" v-bind:key='degree.label' :selected='degree.selected' :disabled='degree.disabled'>
                 {{ degree.label }}
             </option>
         </select>
@@ -22,6 +22,8 @@ export default {
     fetchData() {
       Axios.get(this.degreeEndpoint).then(response => {
         this.degrees = response.data
+        this.degrees.unshift({ "value": "", "active": true, "label": "Select a Degree", "disabled":"disabled" ,"selected": "selected"})
+
       });
     }
   },

--- a/app/javascript/GraduationDate.vue
+++ b/app/javascript/GraduationDate.vue
@@ -1,0 +1,35 @@
+<template>
+    <div>
+        <label>Graduation Date</label>
+        <select name="etd[graduation_date]" class="form-control">
+            <option v-for="graduationDate in graduationDates" v-bind:value="graduationDate.id" 
+            v-bind:key='graduationDate.id' v-if="graduationDate.active" :disabled="graduationDate.disabled"  
+            :selected="graduationDate.selected">
+                {{ graduationDate.label }}
+            </option>
+        </select>
+    </div>
+</template>
+
+<script>
+import Axios from "axios"
+export default {
+  data() {
+    return {
+      graduationDatesEndpoint: "/authorities/terms/local/graduation_dates",
+      graduationDates: {}
+    }
+  },
+  methods: {
+    fetchData() {
+      Axios.get(this.graduationDatesEndpoint).then(response => {
+        this.graduationDates = response.data
+        this.graduationDates.unshift({ "value": "", "active": true, "label": "Select a Graduation Date", "disabled":"disabled" ,"selected": "selected"})
+      });
+    }
+  },
+  created() {
+    this.fetchData()
+  }
+}
+</script>

--- a/app/javascript/Language.spec.js
+++ b/app/javascript/Language.spec.js
@@ -1,0 +1,25 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Language from 'Language'
+
+describe('Language.vue', () => {
+  it('renders a form', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.findAll('select')).toHaveLength(1)
+  })
+
+  it('has a label that contains Langauge', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.findAll('label')).toHaveLength(1)
+  })
+
+  it('has the correct html', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.html()).toEqual(`<div><label>Language</label> <select name="etd[language]" class="form-control"></select></div>`)
+  })
+})

--- a/app/javascript/Language.vue
+++ b/app/javascript/Language.vue
@@ -1,0 +1,36 @@
+<template>
+    <div>
+        <label>Language</label>
+        <select name="etd[language]" class="form-control">
+            <option v-for="langauge in langauges" v-bind:value="langauge.id" 
+            v-bind:key='langauge.id' v-if="langauge.active" :disabled="researchField.disabled"  
+            :selected="researchField.selected">
+                {{ langauge.label }}
+            </option>
+        </select>
+    </div>
+</template>
+
+<script>
+import Axios from "axios"
+export default {
+  data() {
+    return {
+      langaugesEndpoint: "/authorities/terms/local/languages_list",
+      langauges: {}
+    }
+  },
+  methods: {
+    fetchData() {
+      Axios.get(this.languagesEndpoint).then(response => {
+        this.langauges = response.data
+        this.langauges.unshift({ "value": "", "active": true, "label": "Select a Language", "disabled":"disabled" ,"selected": "selected"})
+
+      })
+    }
+  },
+  created() {
+    this.fetchData()
+  }
+}
+</script>

--- a/app/javascript/ResearchField.vue
+++ b/app/javascript/ResearchField.vue
@@ -1,0 +1,35 @@
+<template>
+    <div>
+        <label>Research Field</label>
+        <select name="etd[research_field][]" class="form-control">
+            <option v-for="researchField in researchFields" v-bind:value="researchField.id" v-bind:key='researchField.id' 
+            v-if="researchField.active" :disabled="researchField.disabled"  
+            :selected="researchField.selected">
+                {{ researchField.id }}
+            </option>
+        </select>
+    </div>
+</template>
+
+<script>
+import Axios from "axios"
+export default {
+  data() {
+    return {
+      researchFieldsEndpoint: "/authorities/terms/local/research_fields",
+      researchFields: {}
+    }
+  },
+  methods: {
+    fetchData() {
+      Axios.get(this.researchFieldsEndpoint).then(response => {
+        this.researchFields = response.data
+        this.researchFields.unshift({ "value": "", "active": true, "label": "Select a Submission Type", "disabled":"disabled" ,"selected": "selected"})
+      })
+    }
+  },
+  created() {
+    this.fetchData()
+  }
+}
+</script>

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -19,7 +19,7 @@
 import Vue from "vue";
 import axios from "axios";
 import VueAxios from "vue-axios";
-import App from "./app.vue";
+import App from "./App";
 
 export default {
   data() {

--- a/app/javascript/SubmittingType.vue
+++ b/app/javascript/SubmittingType.vue
@@ -2,7 +2,9 @@
     <div>
         <label>Submission Type</label>
         <select name="etd[submitting_type]" class="form-control">
-            <option v-for="submittingType in submittingTypes" v-bind:value="submittingType.id" v-bind:key='submittingType.id' v-if="submittingType.active">
+            <option v-for="submittingType in submittingTypes" v-bind:value="submittingType.id" 
+            v-bind:key='submittingType.id' v-if="submittingType.active" :disabled="submittingType.disabled"  
+            :selected="submittingType.selected">
                 {{ submittingType.label }}
             </option>
         </select>
@@ -22,6 +24,8 @@ export default {
     fetchData() {
       Axios.get(this.submittingTypeEndpoint).then(response => {
         this.submittingTypes = response.data
+        this.submittingTypes.unshift({ "value": "", "active": true, "label": "Select a Submission Type", "disabled":"disabled" ,"selected": "selected"})
+
       });
     }
   },

--- a/app/javascript/packs/root.js
+++ b/app/javascript/packs/root.js
@@ -1,6 +1,6 @@
 import TurbolinksAdapter from 'vue-turbolinks'
 import Vue from 'vue/dist/vue.esm'
-import App from '../app.vue'
+import App from '../App'
 import { formStore } from '../form_store'
 import axios from 'axios'
 import VueAxios from 'vue-axios'

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -2,7 +2,7 @@
 /* global it */
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
-import App from 'app.vue'
+import App from 'App'
 
 describe('App.vue', () => {
   it('renders a form', () => {

--- a/app/javascript/test/Degree.spec.js
+++ b/app/javascript/test/Degree.spec.js
@@ -2,7 +2,7 @@
 /* global it */
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
-import Degree from 'degree.vue'
+import Degree from 'Degree'
 
 describe('Degree.vue', () => {
   it('renders a select element', () => {
@@ -14,14 +14,12 @@ describe('Degree.vue', () => {
   it('has a label that contains Degree', () => {
     const wrapper = shallowMount(Degree, {
     })
-    console.log(wrapper.html())
     expect(wrapper.findAll('label')).toHaveLength(1)
   })
 
   it('has the correct html', () => {
     const wrapper = shallowMount(Degree, {
     })
-    console.log(wrapper.html())
     expect(wrapper.html()).toEqual(`<div><label>Degree</label> <select name="etd[degree]" class="form-control"></select></div>`)
   })
 })

--- a/app/javascript/test/GraduationDate.spec.js
+++ b/app/javascript/test/GraduationDate.spec.js
@@ -1,0 +1,25 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import GraduationDate from 'GraduationDate'
+
+describe('GraduationDate.vue', () => {
+  it('renders a select element', () => {
+    const wrapper = shallowMount(GraduationDate, {
+    })
+    expect(wrapper.findAll('select')).toHaveLength(1)
+  })
+
+  it('has a label that contains Graduation Date', () => {
+    const wrapper = shallowMount(GraduationDate, {
+    })
+    expect(wrapper.findAll('label')).toHaveLength(1)
+  })
+
+  it('has the correct html', () => {
+    const wrapper = shallowMount(GraduationDate, {
+    })
+    expect(wrapper.html()).toEqual(`<div><label>Graduation Date</label> <select name="etd[graduation_date]" class="form-control"></select></div>`)
+  })
+})

--- a/app/javascript/test/Language.spec.js
+++ b/app/javascript/test/Language.spec.js
@@ -1,0 +1,25 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Language from 'Language'
+
+describe('Language.vue', () => {
+  it('renders a form', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.findAll('select')).toHaveLength(1)
+  })
+
+  it('has a label that contains Langauge', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.findAll('label')).toHaveLength(1)
+  })
+
+  it('has the correct html', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.html()).toEqual(`<div><label>Language</label> <select name="etd[language]" class="form-control"></select></div>`)
+  })
+})

--- a/app/javascript/test/ResearchField.spec.js
+++ b/app/javascript/test/ResearchField.spec.js
@@ -1,0 +1,25 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import ResearchField from 'ResearchField'
+
+describe('ResearchField.vue', () => {
+  it('renders a select element', () => {
+    const wrapper = shallowMount(ResearchField, {
+    })
+    expect(wrapper.findAll('select')).toHaveLength(1)
+  })
+
+  it('has a label that contains Research Field', () => {
+    const wrapper = shallowMount(ResearchField, {
+    })
+    expect(wrapper.findAll('label')).toHaveLength(1)
+  })
+
+  it('has the correct html', () => {
+    const wrapper = shallowMount(ResearchField, {
+    })
+    expect(wrapper.html()).toEqual(`<div><label>Research Field</label> <select name="etd[research_field][]" class="form-control"></select></div>`)
+  })
+})

--- a/app/javascript/test/School.spec.js
+++ b/app/javascript/test/School.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Language from 'School'
+
+describe('School.vue', () => {
+  it('has the correct html', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    expect(wrapper.html()).toContain(`<div><label>School</label> <select id="school" class="form-control"><option disabled="disabled" value="">`)
+  })
+})

--- a/app/javascript/test/SubmissionType.spec.js
+++ b/app/javascript/test/SubmissionType.spec.js
@@ -5,7 +5,7 @@ import { shallowMount } from '@vue/test-utils'
 import SubmittingType from 'SubmittingType'
 
 describe('SubmittingType.vue', () => {
-  it('renders a form', () => {
+  it('renders a select element', () => {
     const wrapper = shallowMount(SubmittingType, {
     })
     expect(wrapper.findAll('select')).toHaveLength(1)
@@ -14,14 +14,12 @@ describe('SubmittingType.vue', () => {
   it('has a label that contains Submission Type', () => {
     const wrapper = shallowMount(SubmittingType, {
     })
-    console.log(wrapper.html())
     expect(wrapper.findAll('label')).toHaveLength(1)
   })
 
   it('has the correct html', () => {
     const wrapper = shallowMount(SubmittingType, {
     })
-    console.log(wrapper.html())
     expect(wrapper.html()).toEqual(`<div><label>Submission Type</label> <select name="etd[submitting_type]" class="form-control"></select></div>`)
   })
 })


### PR DESCRIPTION
This commit includes the additional dropdowns that are
driven by QA authorities to the form.

There are also some minor changes in this dealing with
the naming of the files. Vue components are typically
capitalized so I've followed that pattern in the file names.

In JS, objects that can be initialized with `new` are typically
capitalized.

There is also an additonal spec for the `School` component