### PR TITLE
validate for missing fields as well as empty fields

### DIFF
--- a/app/validators/about_me_validator.rb
+++ b/app/validators/about_me_validator.rb
@@ -2,8 +2,11 @@ class AboutMeValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
     ::Hyrax::EtdForm.about_me_terms.each do |field|
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].empty?
+      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     end
+  # TODO: confirm this rescue is not too general
+  rescue NoMethodError
+    missing_fields(record)
   end
 
   def parsed_data(record)
@@ -12,5 +15,13 @@ class AboutMeValidator < ActiveModel::Validator
 
   def current_tab?(record)
     parsed_data(record)['currentTab'] == "About Me"
+  end
+
+  # a user can submit a tab without having selected certain fields, graduation_date and school in this case, and the keys will not be
+  # present in the record's data. Since this is effectively the same as if they had not entered information, the fields are added to the errors.
+  def missing_fields(record)
+    record.errors.add("graduation_date", "graduation_date is required") unless parsed_data(record).keys.include?("graduation_date")
+
+    record.errors.add("school", "school is required") unless parsed_data(record).keys.include?("school")
   end
 end

--- a/app/validators/my_etd_validator.rb
+++ b/app/validators/my_etd_validator.rb
@@ -1,7 +1,7 @@
-class MyProgramValidator < ActiveModel::Validator
+class MyEtdValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
-    ::Hyrax::EtdForm.my_program_terms.each do |field|
+    ::Hyrax::EtdForm.my_etd_terms.each do |field|
       record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     end
   end
@@ -11,6 +11,6 @@ class MyProgramValidator < ActiveModel::Validator
   end
 
   def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Program"
+    parsed_data(record)['currentTab'] == "My Etd"
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -26,6 +26,14 @@ describe InProgressEtd do
         expect(in_progress_etd).not_to be_valid
       end
     end
+
+    context "with missing school and graduation_date" do
+      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", post_graduation_email: "" }.to_json) }
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
   end
 
   describe "My Program" do


### PR DESCRIPTION
Because two inputs on the About Me form require user interaction in order for their data to be sent to the server, a user can submit the About Me tab without the keys the validation expects. Rather than require anything more special on the front end, this code expects this situation to occur and treats it as an invalid case, the same as if those keys had been sent without data values. I am hoping this is the correct pattern to use for the rest of these validators as well.