### PR TITLE
Rake task to fix collections with bad (missing translation) labels

### DIFF
--- a/lib/tasks/fix_collection_type_labels.rake
+++ b/lib/tasks/fix_collection_type_labels.rake
@@ -1,0 +1,15 @@
+# Run this if you are seeing Collections with a type of "translation missing..."
+# Check YOUR_SERVER//dashboard/collections?locale=en for a place where this might appear
+namespace :laevigata do
+  desc "Fix missing collection type labels"
+  task :fix_collection_type_labels do
+    collection_types = Hyrax::CollectionType.all
+    collection_types.each do |c|
+      next unless c.title =~ /^translation missing/
+      oldtitle = c.title
+      c.title = I18n.t(c.title.gsub("translation missing: en.", ''))
+      c.save
+      puts "#{oldtitle} changed to #{c.title}"
+    end
+  end
+end


### PR DESCRIPTION
Connected to https://github.com/curationexperts/laevigata/issues/1167

Obviously we would rather fix this upstream in Hyrax, but in the meantime we need a local fix. 

Upstream Hyrax bug at https://github.com/samvera/hyrax/issues/3136

Tested in production mode on `staging-upgrade-etd`. See https://staging-upgrade-etd.emory.edu/dashboard/collections?locale=en