### PR TITLE
Cleans up copyrights and patents questions for ETD submission

### DIFF
--- a/app/assets/javascripts/review_my_etd.es6
+++ b/app/assets/javascripts/review_my_etd.es6
@@ -49,17 +49,35 @@ export default class ReviewMyETD {
 
     let data = $('.about-my-etd :input').serializeArray();
 
-    let optional_data = $('#about_my_etd :input.copyright').serializeArray();
+    let permission_data = "Unanswered"
 
-    let optional_values = ""
-
-    if(optional_data.length > 0){
-      for (var i = 0; i < optional_data.length; i++){
-        optional_values += optional_data[i].value;
-      }
+    if ($('#about_my_etd :input#etd_copyright_question_one_true').prop('checked')) {
+      permission_data = "Yes, my thesis or dissertation does contain third-party material that would require permission to use"
+    } else if ($('#about_my_etd :input#etd_copyright_question_one_false').prop('checked')) {
+      permission_data = "No, my thesis or dissertation does not contain third-party material that would require permission to use"
     }
-    let copyright_data = {'name': 'Copyrights and Patents', 'value': optional_values }
-    data.push(copyright_data)
+
+    let copyright_data = "Unanswered"
+
+    if ($('#about_my_etd :input#etd_copyright_question_two_true').prop('checked')) {
+      copyright_data = "Yes, my thesis or dissertation does contain content for which I no longer own copyright"
+    } else if ($('#about_my_etd :input#etd_copyright_question_two_false').prop('checked')) {
+      copyright_data = "No, my thesis or dissertation does not contain content for which I no longer own copyright"
+    }
+
+    let patent_data = "Unanswered"
+
+    if ($('#about_my_etd :input#etd_copyright_question_three_true').prop('checked')) {
+      patent_data = "Yes, my thesis or dissertation does have content that may be patented"
+    } else if ($('#about_my_etd :input#etd_copyright_question_three_false').prop('checked')) {
+      patent_data = "No, my thesis or dissertation does not have content that may be patented"
+    }
+
+    let permissions = {'name': 'ETD Requires Permission', 'value': permission_data}
+    let copyrights = {'name': 'ETD Contains Copyrighted Material', 'value': copyright_data}
+    let patents = {'name': 'ETD Might be Eligible for Patent', 'value': patent_data}
+
+    data.push(permissions, copyrights, patents)
 
     return data
   }
@@ -186,7 +204,7 @@ export default class ReviewMyETD {
     if (el === undefined){
       return
     }
-    if (el === "My Primary PDF" || el === "My Supplemental Files" || el.includes('Affiliation') || el.includes('Embargo') || el.includes('Copyrights')){
+    if (el === "My Primary PDF" || el === "My Supplemental Files" || el.includes('Affiliation') || el.includes('Embargo') || el.includes('Copyrighted') || el.includes('Permission') || el.includes('Patent')){
       return el
     }
 

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -145,4 +145,22 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     end
     admin_return_message + table_of_contents.first
   end
+
+  def requires_permission_question
+    return "Yes" if copyright_question_one.to_s.include?("true")
+    return "No" if copyright_question_one.to_s.include?("false")
+    "Unanswered"
+  end
+
+  def other_copyrights_question
+    return "Yes" if copyright_question_two.to_s.include?("true")
+    return "No" if copyright_question_two.to_s.include?("false")
+    return "Unanswered" unless copyright_question_two
+  end
+
+  def patents_question
+    return "Yes" if copyright_question_three.to_s.include?("true")
+    return "No" if copyright_question_three.to_s.include?("false")
+    return "Unanswered" unless copyright_question_three
+  end
 end

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -21,9 +21,9 @@
     <%= presenter.attribute_to_html(:permanent_url, label: "Permanent URL") %>
     <%= presenter.attribute_to_html(:rights_statement, render_as: :rights) %>
     <% if presenter.current_ability_is_approver? %>
-      <%= presenter.attribute_to_html(:copyright_question_one, label: t("hyrax.works.copyright_question_one_label"))%>
-      <%= presenter.attribute_to_html(:copyright_question_two, label: t("hyrax.works.copyright_question_two_label"))%>
-      <%= presenter.attribute_to_html(:copyright_question_three, label: t("hyrax.works.copyright_question_three_label"))%>
+      <%= presenter.attribute_to_html(:requires_permission_question, label: t("hyrax.works.copyright_question_one_label"))%>
+      <%= presenter.attribute_to_html(:other_copyrights_question, label: t("hyrax.works.copyright_question_two_label"))%>
+      <%= presenter.attribute_to_html(:patents_question, label: t("hyrax.works.copyright_question_three_label"))%>
       <%= presenter.attribute_to_html(:files_embargoed, label: "Files Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:abstract_embargoed, label: "Abstract Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:toc_embargoed, label: "Table of Contents Under Embargo", include_empty: true)%>

--- a/spec/features/create_etd_review_spec.rb
+++ b/spec/features/create_etd_review_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature 'Create an Etd', :clean do
       select 'Aeronomy', from: 'Research Field'
       fill_in 'Keyword', with: "Courtship"
       find('#question_1').choose('No')
+      find('#question_2').choose('Yes')
 
       expect(page).to have_css 'li#required-my-etd.complete'
 
@@ -121,6 +122,9 @@ RSpec.feature 'Create an Etd', :clean do
       expect(page).to have_content('Chapter One')
       expect(page).to have_content('Aeronomy')
       expect(page).to have_content('Courtship')
+      expect(page).to have_content('No, my thesis or dissertation does not contain third-party material that would require permission to use')
+      expect(page).to have_content('Yes, my thesis or dissertation does contain content for which I no longer own copyright')
+      expect(page).to have_content('Unanswered')
 
       # My Primary PDF
       expect(page).to have_content('miranda_thesis.pdf')
@@ -166,6 +170,7 @@ RSpec.feature 'Create an Etd', :clean do
       select 'Aeronomy', from: 'Research Field'
       fill_in 'Keyword', with: "Courtship"
       find('#question_1').choose('No')
+      find('#question_2').choose('Yes')
 
       expect(page).to have_css 'li#required-my-etd.complete'
 
@@ -248,6 +253,9 @@ RSpec.feature 'Create an Etd', :clean do
       expect(page).not_to have_content('Research Field required')
       expect(page).to have_content('Courtship')
       expect(page).not_to have_content('Keyword required')
+      expect(page).to have_content('No, my thesis or dissertation does not contain third-party material that would require permission to use')
+      expect(page).to have_content('Yes, my thesis or dissertation does contain content for which I no longer own copyright')
+      expect(page).to have_content('Unanswered')
 
       # My Primary PDF
       expect(page).to have_content('miranda_thesis.pdf')

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -254,4 +254,26 @@ describe EtdPresenter do
     it { is_expected.to delegate_method(:copyright_question_two).to(:solr_document) }
     it { is_expected.to delegate_method(:copyright_question_three).to(:solr_document) }
   end
+
+  context "copyrights and patents questions" do
+    let(:etd) { FactoryBot.build(:etd) }
+    let(:ability) { Ability.new(FactoryBot.build(:user)) }
+    let(:presenter) do
+      described_class.new(SolrDocument.new(etd.to_solr), ability)
+    end
+
+    it "returns selection for permission requirement if any" do
+      allow(presenter).to receive(:requires_permission_question).and_return("Yes")
+      expect(presenter.requires_permission_question).to eq("Yes")
+    end
+
+    it "returns selection for ownership of copyrights question if any" do
+      allow(presenter).to receive(:other_copyrights_question).and_return("No")
+      expect(presenter.other_copyrights_question).to eq("No")
+    end
+
+    it "returns selection for patents question eligibility if any" do
+      expect(presenter.patents_question).to eq("Unanswered")
+    end
+  end
 end


### PR DESCRIPTION
The copyrights and patents questions now have responses as long sentences when previewing an ETD instead of truefalsetrue. Also, the approver will now see Yes or No for those questions instead of true or false.

This PR is supposed to be against 1.6-stable