### PR TITLE
adding other validators

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -47,6 +47,18 @@ module Hyrax
       def self.my_program_terms
         [:department, :subfield, :partnering_agency, :degree, :submitting_type]
       end
+
+      def self.my_etd_terms
+        [:title, :language, :abstract, :table_of_contents]
+      end
+
+      def self.my_advisor_terms
+        [:committee_member_attributes, :committee_chair_attributes]
+      end
+
+      def self.keyword_terms
+        [:keyword, :research_field]
+      end
     end
 
     def about_me_fields

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -63,7 +63,7 @@
           <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <button type="submit" class="btn btn-default">Submit</button>
           <section v-if="errored">
-            Invalidation Errors happened:        
+            Invalidation Errors happened:
               <p>{{ errors }}</p>
           </section>
         </div>
@@ -134,6 +134,8 @@ export default {
           config: { headers: { "Content-Type": "multipart/form-data" } }
         })
         .then(response => {
+          that.errored = false
+          that.errors = []
         })
         .catch(error => {
           that.errored = true
@@ -163,7 +165,7 @@ ul {
      position: relative;
      margin-bottom: 0;
      min-width:100px;
-     text-align: center 
+     text-align: center
 }
  ul li a {
      display: block;

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -2,4 +2,8 @@ class InProgressEtd < ApplicationRecord
   # custom validators check for presence of tab-determined set of fields based on presence of tab-identifying data
   validates_with AboutMeValidator
   validates_with MyProgramValidator
+  validates_with MyEtdValidator
+  validates_with MyAdvisorValidator
+  validates_with KeywordValidator
+  validates_with EmbargoValidator
 end

--- a/app/validators/about_me_validator.rb
+++ b/app/validators/about_me_validator.rb
@@ -2,7 +2,7 @@ class AboutMeValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
     ::Hyrax::EtdForm.about_me_terms.each do |field|
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].empty?
+      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     end
   end
 

--- a/app/validators/embargo_validator.rb
+++ b/app/validators/embargo_validator.rb
@@ -1,0 +1,19 @@
+class EmbargoValidator < ActiveModel::Validator
+  def validate(record)
+    return unless current_tab?(record)
+    # TODO: the embargo form will send 'no' values by default,
+    # but this tab hasn't been built to conform to the wireframes yet.
+    # when it is this validator will check for actual values.
+    # ::Hyrax::EtdForm.embargo_terms.each do |field|
+    #   record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
+    # end
+  end
+
+  def parsed_data(record)
+    JSON.parse(record.data)
+  end
+
+  def current_tab?(record)
+    parsed_data(record)['currentTab'] == "Embargo"
+  end
+end

--- a/app/validators/keyword_validator.rb
+++ b/app/validators/keyword_validator.rb
@@ -1,7 +1,7 @@
-class MyProgramValidator < ActiveModel::Validator
+class KeywordValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
-    ::Hyrax::EtdForm.my_program_terms.each do |field|
+    ::Hyrax::EtdForm.keyword_terms.each do |field|
       record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     end
   end
@@ -11,6 +11,6 @@ class MyProgramValidator < ActiveModel::Validator
   end
 
   def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Program"
+    parsed_data(record)['currentTab'] == "Keywords"
   end
 end

--- a/app/validators/my_advisor_validator.rb
+++ b/app/validators/my_advisor_validator.rb
@@ -1,7 +1,7 @@
-class MyProgramValidator < ActiveModel::Validator
+class MyAdvisorValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
-    ::Hyrax::EtdForm.my_program_terms.each do |field|
+    ::Hyrax::EtdForm.my_advisor_terms.each do |field|
       record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     end
   end
@@ -11,6 +11,6 @@ class MyProgramValidator < ActiveModel::Validator
   end
 
   def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Program"
+    parsed_data(record)['currentTab'] == "My Advisor"
   end
 end

--- a/app/validators/my_etd_validator.rb
+++ b/app/validators/my_etd_validator.rb
@@ -1,7 +1,7 @@
-class MyProgramValidator < ActiveModel::Validator
+class MyEtdValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
-    ::Hyrax::EtdForm.my_program_terms.each do |field|
+    ::Hyrax::EtdForm.my_etd_terms.each do |field|
       record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     end
   end
@@ -11,6 +11,6 @@ class MyProgramValidator < ActiveModel::Validator
   end
 
   def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Program"
+    parsed_data(record)['currentTab'] == "My Etd"
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 describe InProgressEtd do
+  let(:in_progress_etd) { described_class.new(data: data.to_json) }
   before(:all) do
     new_ui = Rails.application.config_for(:new_ui).fetch('enabled', false)
 
@@ -12,7 +13,6 @@ describe InProgressEtd do
       let(:data) do
         { currentTab: "About Me", creator: "Student", graduation_date: "tomorrow", post_graduation_email: "tester@test.com", school: "Laney Graduate School" }
       end
-      let(:in_progress_etd) { described_class.new(data: data.to_json) }
 
       it "is valid" do
         expect(in_progress_etd).to be_valid
@@ -26,6 +26,13 @@ describe InProgressEtd do
         expect(in_progress_etd).not_to be_valid
       end
     end
+    context "with missing data" do
+      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", post_graduation_email: "" }.to_json) }
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
   end
 
   describe "My Program" do
@@ -33,7 +40,6 @@ describe InProgressEtd do
       let(:data) do
         { currentTab: "My Program", department: "Anthropology", subfield: "Foo", partnering_agency: "DCD", degree: "Non", submitting_type: "Phd" }
       end
-      let(:in_progress_etd) { described_class.new(data: data.to_json) }
 
       it "is valid" do
         expect(in_progress_etd).to be_valid
@@ -44,11 +50,89 @@ describe InProgressEtd do
       let(:data) do
         { currentTab: "My Program", department: "", subfield: "Foo", partnering_agency: "DCD", degree: "Non", submitting_type: "" }
       end
-      let(:in_progress_etd) { described_class.new(data: data.to_json) }
 
       it "is not valid" do
         expect(in_progress_etd).not_to be_valid
       end
+    end
+  end
+
+  describe "My Advisor" do
+    # TODO: align with committee front end if it changes, which it is likely to
+    context "with valid data" do
+      let(:data) do
+        { currentTab: "My Advisor", "committee_member_attributes": ["member_info"], "committee_chair_attributes": ["chair_info"] }
+      end
+
+      it "is valid" do
+        expect(in_progress_etd).to be_valid
+      end
+    end
+
+    context "without valid data" do
+      let(:data) do
+        { currentTab: "My Advisor" }
+      end
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+  end
+
+  describe "My ETD" do
+    context "with valid data" do
+      let(:data) do
+        { currentTab: "My Etd", "title": "A title", "language": "Francais", "abstract": "<b>Abstract</b>", "table_of_contents": "<i>Chapter One</i>" }
+      end
+
+      it "is valid" do
+        expect(in_progress_etd).to be_valid
+      end
+    end
+
+    context "with invalid data" do
+      let(:data) do
+        { currentTab: "My Etd", "title": "", "language": "", "abstract": "", "table_of_contents": "" }
+      end
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+  end
+
+  # TODO: needs to be adjusted to fit real data structure when tab is built according to wireframe
+  describe "Keywords" do
+    context "with valid data" do
+      let(:data) do
+        { currentTab: "Keywords", "keyword": "something", "research_field": ["things"] }
+      end
+
+      it "is valid" do
+        expect(in_progress_etd).to be_valid
+      end
+    end
+
+    context "with invalid data" do
+      let(:data) do
+        { currentTab: "Keywords" }
+      end
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+  end
+
+  # TODO: the validator needs to be adjusted for real embargo front end tab
+  describe "Embargo" do
+    let(:data) do
+      { currentTab: "Embargo" }
+    end
+
+    it "is valid" do
+      expect(in_progress_etd).to be_valid
     end
   end
 end


### PR DESCRIPTION
This commit adds a validator for each of the new form tabs, minus the Files tab. It's intended to provide the bulk of what is needed to enforce an order through the tab submission process. It addresses #1184.