### PR TITLE
Clear out subfields when changing school

### DIFF
--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -51,6 +51,7 @@ export default {
   watch: {
     selected() {
       this.fetchData();
+      formStore.clearSubfields() 
     }
   }
 };

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -139,6 +139,9 @@ export var formStore = {
     'Psychology': '/authorities/terms/local/psychology_programs',
     'Executive Masters of Public Health - MPH': '/authorities/terms/local/executive_programs'
   },
+  clearSubfields () {
+    this.subfields = []
+  },
   addCommitteeMember (affilation, name) {
     this.committeeChairs.push({affilation: affilation, name: name})
   },


### PR DESCRIPTION
This commit clears out the subfields when you
change the school. Changing the department does
this, but the user might change the school as well.