### PR TITLE
Adding version numbers to all migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
 before_script:
   - bundle exec rake db:create
 script:
+  - RAILS_ENV=test ./bin/rails db:migrate
   - RAILS_ENV=test ./bin/rails webpacker:compile
   - bundle exec rubocop
   - yarn test

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,29 +1,24 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# We run postgres in production so we should run
+# postgres in development and test environments too
 #
 default: &default
-  adapter: sqlite3
-  pool: 25
-  timeout: 5000
+  adapter:  postgresql
+  encoding: unicode
+  pool:     25
+  timeout:  5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: laevigata_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: laevigata_test
 
 production:
-  adapter: postgresql
-  encoding: unicode
   database: <%= ENV['DATABASE_NAME'] %>
-  pool: 25
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/db/migrate/20170404212221_create_searches.blacklight.rb
+++ b/db/migrate/20170404212221_create_searches.blacklight.rb
@@ -1,6 +1,6 @@
 # This migration comes from blacklight (originally 20140202020201)
 # frozen_string_literal: true
-class CreateSearches < ActiveRecord::Migration
+class CreateSearches < ActiveRecord::Migration[4.2]
   def self.up
     create_table :searches do |t|
       t.binary  :query_params

--- a/db/migrate/20170404212222_create_bookmarks.blacklight.rb
+++ b/db/migrate/20170404212222_create_bookmarks.blacklight.rb
@@ -1,6 +1,6 @@
 # This migration comes from blacklight (originally 20140202020202)
 # frozen_string_literal: true
-class CreateBookmarks < ActiveRecord::Migration
+class CreateBookmarks < ActiveRecord::Migration[4.2]
   def self.up
     create_table :bookmarks do |t|
       t.integer :user_id, index: true, null: false
@@ -15,5 +15,5 @@ class CreateBookmarks < ActiveRecord::Migration
   def self.down
     drop_table :bookmarks
   end
-  
+
 end

--- a/db/migrate/20170404212223_add_polymorphic_type_to_bookmarks.blacklight.rb
+++ b/db/migrate/20170404212223_add_polymorphic_type_to_bookmarks.blacklight.rb
@@ -1,9 +1,9 @@
 # This migration comes from blacklight (originally 20140320000000)
 # frozen_string_literal: true
-class AddPolymorphicTypeToBookmarks < ActiveRecord::Migration
+class AddPolymorphicTypeToBookmarks < ActiveRecord::Migration[4.2]
   def change
     add_column(:bookmarks, :document_type, :string) unless Bookmark.connection.column_exists? :bookmarks, :document_type
-    
+
     add_index :bookmarks, :user_id unless Bookmark.connection.index_exists? :bookmarks, :user_id
   end
 end

--- a/db/migrate/20170404212309_add_devise_guests_to_users.rb
+++ b/db/migrate/20170404212309_add_devise_guests_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeviseGuestsToUsers < ActiveRecord::Migration
+class AddDeviseGuestsToUsers < ActiveRecord::Migration[5.0]
   def self.up
     change_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20170404212413_create_version_committers.hyrax.rb
+++ b/db/migrate/20170404212413_create_version_committers.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222152)
-class CreateVersionCommitters < ActiveRecord::Migration
+class CreateVersionCommitters < ActiveRecord::Migration[4.2]
   def self.up
     create_table :version_committers do |t|
       t.string :obj_id

--- a/db/migrate/20170404212414_create_checksum_audit_logs.hyrax.rb
+++ b/db/migrate/20170404212414_create_checksum_audit_logs.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222153)
-class CreateChecksumAuditLogs < ActiveRecord::Migration
+class CreateChecksumAuditLogs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :checksum_audit_logs do |t|
       t.string :file_set_id

--- a/db/migrate/20170404212415_create_single_use_links.hyrax.rb
+++ b/db/migrate/20170404212415_create_single_use_links.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222154)
-class CreateSingleUseLinks < ActiveRecord::Migration
+class CreateSingleUseLinks < ActiveRecord::Migration[4.2]
   def change
     create_table :single_use_links do |t|
       t.string :downloadKey

--- a/db/migrate/20170404212416_add_social_to_users.hyrax.rb
+++ b/db/migrate/20170404212416_add_social_to_users.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222156)
-class AddSocialToUsers < ActiveRecord::Migration
+class AddSocialToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :facebook_handle, :string
     add_column :users, :twitter_handle, :string

--- a/db/migrate/20170404212417_add_ldap_attrs_to_user.hyrax.rb
+++ b/db/migrate/20170404212417_add_ldap_attrs_to_user.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222157)
-class AddLdapAttrsToUser < ActiveRecord::Migration
+class AddLdapAttrsToUser < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, :display_name, :string
     add_column :users, :address, :string

--- a/db/migrate/20170404212418_add_avatars_to_users.hyrax.rb
+++ b/db/migrate/20170404212418_add_avatars_to_users.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222158)
-class AddAvatarsToUsers < ActiveRecord::Migration
+class AddAvatarsToUsers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :users, "avatar_file_name",    :string
     add_column :users, "avatar_content_type", :string

--- a/db/migrate/20170404212419_create_trophies.hyrax.rb
+++ b/db/migrate/20170404212419_create_trophies.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222161)
-class CreateTrophies < ActiveRecord::Migration
+class CreateTrophies < ActiveRecord::Migration[4.2]
   def change
     create_table :trophies do |t|
       t.integer :user_id

--- a/db/migrate/20170404212420_add_linkedin_to_users.hyrax.rb
+++ b/db/migrate/20170404212420_add_linkedin_to_users.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222162)
-class AddLinkedinToUsers < ActiveRecord::Migration
+class AddLinkedinToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :linkedin_handle, :string
   end

--- a/db/migrate/20170404212421_create_tinymce_assets.hyrax.rb
+++ b/db/migrate/20170404212421_create_tinymce_assets.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222163)
-class CreateTinymceAssets < ActiveRecord::Migration
+class CreateTinymceAssets < ActiveRecord::Migration[4.2]
   def change
     create_table :tinymce_assets do |t|
       t.string :file

--- a/db/migrate/20170404212422_create_content_blocks.hyrax.rb
+++ b/db/migrate/20170404212422_create_content_blocks.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222164)
-class CreateContentBlocks < ActiveRecord::Migration
+class CreateContentBlocks < ActiveRecord::Migration[4.2]
   def change
     create_table :content_blocks do |t|
       t.string :name

--- a/db/migrate/20170404212423_create_featured_works.hyrax.rb
+++ b/db/migrate/20170404212423_create_featured_works.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222165)
-class CreateFeaturedWorks < ActiveRecord::Migration
+class CreateFeaturedWorks < ActiveRecord::Migration[4.2]
   def change
     create_table :featured_works do |t|
       t.integer :order, default: 5

--- a/db/migrate/20170404212424_add_external_key_to_content_blocks.hyrax.rb
+++ b/db/migrate/20170404212424_add_external_key_to_content_blocks.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222166)
-class AddExternalKeyToContentBlocks < ActiveRecord::Migration
+class AddExternalKeyToContentBlocks < ActiveRecord::Migration[4.2]
   def change
     add_column :content_blocks, :external_key, :string
     remove_index :content_blocks, :name

--- a/db/migrate/20170404212425_create_proxy_deposit_rights.hyrax.rb
+++ b/db/migrate/20170404212425_create_proxy_deposit_rights.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222226)
-class CreateProxyDepositRights < ActiveRecord::Migration
+class CreateProxyDepositRights < ActiveRecord::Migration[4.2]
   def change
     create_table :proxy_deposit_rights do |t|
       t.references :grantor

--- a/db/migrate/20170404212426_create_proxy_deposit_requests.hyrax.rb
+++ b/db/migrate/20170404212426_create_proxy_deposit_requests.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222227)
-class CreateProxyDepositRequests < ActiveRecord::Migration
+class CreateProxyDepositRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :proxy_deposit_requests do |t|
       t.string :generic_file_id, null: false

--- a/db/migrate/20170404212427_create_file_view_stats.hyrax.rb
+++ b/db/migrate/20170404212427_create_file_view_stats.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222228)
-class CreateFileViewStats < ActiveRecord::Migration
+class CreateFileViewStats < ActiveRecord::Migration[4.2]
   def change
     create_table :file_view_stats do |t|
       t.datetime :date

--- a/db/migrate/20170404212428_create_file_download_stats.hyrax.rb
+++ b/db/migrate/20170404212428_create_file_download_stats.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222229)
-class CreateFileDownloadStats < ActiveRecord::Migration
+class CreateFileDownloadStats < ActiveRecord::Migration[4.2]
   def change
     create_table :file_download_stats do |t|
       t.datetime :date

--- a/db/migrate/20170404212429_add_orcid_to_users.hyrax.rb
+++ b/db/migrate/20170404212429_add_orcid_to_users.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222230)
-class AddOrcidToUsers < ActiveRecord::Migration
+class AddOrcidToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :orcid, :string
   end

--- a/db/migrate/20170404212430_create_user_stats.hyrax.rb
+++ b/db/migrate/20170404212430_create_user_stats.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222231)
-class CreateUserStats < ActiveRecord::Migration
+class CreateUserStats < ActiveRecord::Migration[4.2]
   def change
     create_table :user_stats do |t|
       t.integer :user_id

--- a/db/migrate/20170404212431_create_work_view_stats.hyrax.rb
+++ b/db/migrate/20170404212431_create_work_view_stats.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222232)
-class CreateWorkViewStats < ActiveRecord::Migration
+class CreateWorkViewStats < ActiveRecord::Migration[4.2]
   def change
     create_table :work_view_stats do |t|
       t.datetime :date

--- a/db/migrate/20170404212432_add_works_to_user_stats.hyrax.rb
+++ b/db/migrate/20170404212432_add_works_to_user_stats.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222233)
-class AddWorksToUserStats < ActiveRecord::Migration
+class AddWorksToUserStats < ActiveRecord::Migration[4.2]
   def self.up
     add_column :user_stats, :work_views, :integer
     add_column :work_view_stats, :user_id, :integer

--- a/db/migrate/20170404212433_change_trophy_generic_file_id_to_work_id.hyrax.rb
+++ b/db/migrate/20170404212433_change_trophy_generic_file_id_to_work_id.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222236)
-class ChangeTrophyGenericFileIdToWorkId < ActiveRecord::Migration
+class ChangeTrophyGenericFileIdToWorkId < ActiveRecord::Migration[4.2]
   def change
     rename_column :trophies, :generic_file_id, :work_id
   end

--- a/db/migrate/20170404212434_change_proxy_deposit_generic_file_id_to_work_id.hyrax.rb
+++ b/db/migrate/20170404212434_change_proxy_deposit_generic_file_id_to_work_id.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222237)
-class ChangeProxyDepositGenericFileIdToWorkId < ActiveRecord::Migration
+class ChangeProxyDepositGenericFileIdToWorkId < ActiveRecord::Migration[4.2]
   def change
     rename_column :proxy_deposit_requests, :generic_file_id, :work_id
   end

--- a/db/migrate/20170404212435_change_audit_log_generic_file_id_to_file_set_id.hyrax.rb
+++ b/db/migrate/20170404212435_change_audit_log_generic_file_id_to_file_set_id.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222238)
-class ChangeAuditLogGenericFileIdToFileSetId < ActiveRecord::Migration
+class ChangeAuditLogGenericFileIdToFileSetId < ActiveRecord::Migration[4.2]
   def change
     rename_column :checksum_audit_logs, :generic_file_id, :file_set_id unless ChecksumAuditLog.column_names.include?('file_set_id')
   end

--- a/db/migrate/20170404212436_change_proxy_deposit_request_generic_file_id_to_work_id.hyrax.rb
+++ b/db/migrate/20170404212436_change_proxy_deposit_request_generic_file_id_to_work_id.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160328222239)
-class ChangeProxyDepositRequestGenericFileIdToWorkId < ActiveRecord::Migration
+class ChangeProxyDepositRequestGenericFileIdToWorkId < ActiveRecord::Migration[4.2]
   def change
     rename_column :proxy_deposit_requests, :generic_file_id, :generic_id if ProxyDepositRequest.column_names.include?('generic_file_id')
   end

--- a/db/migrate/20170404212437_create_uploaded_files.hyrax.rb
+++ b/db/migrate/20170404212437_create_uploaded_files.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160401142419)
-class CreateUploadedFiles < ActiveRecord::Migration
+class CreateUploadedFiles < ActiveRecord::Migration[4.2]
   def change
     create_table :uploaded_files do |t|
       t.string :file

--- a/db/migrate/20170404212438_create_features.hyrax.rb
+++ b/db/migrate/20170404212438_create_features.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160415212015)
-class CreateFeatures < ActiveRecord::Migration
+class CreateFeatures < ActiveRecord::Migration[4.2]
   def change
     create_table :hyrax_features do |t|
       t.string :key, null: false

--- a/db/migrate/20170404212439_create_operations.hyrax.rb
+++ b/db/migrate/20170404212439_create_operations.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160427155928)
-class CreateOperations < ActiveRecord::Migration
+class CreateOperations < ActiveRecord::Migration[4.2]
   def change
     create_table :curation_concerns_operations do |t|
       t.string :status

--- a/db/migrate/20170404212440_change_featured_work_generic_file_id_to_work_id.hyrax.rb
+++ b/db/migrate/20170404212440_change_featured_work_generic_file_id_to_work_id.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160510000007)
-class ChangeFeaturedWorkGenericFileIdToWorkId < ActiveRecord::Migration
+class ChangeFeaturedWorkGenericFileIdToWorkId < ActiveRecord::Migration[4.2]
   def change
     return unless column_exists?(:featured_works, :generic_file_id)
     rename_column :featured_works, :generic_file_id, :work_id

--- a/db/migrate/20170404212441_add_arkivo_to_users.hyrax.rb
+++ b/db/migrate/20170404212441_add_arkivo_to_users.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160516190435)
-class AddArkivoToUsers < ActiveRecord::Migration
+class AddArkivoToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :arkivo_token, :string
     add_column :users, :arkivo_subscription, :string

--- a/db/migrate/20170404212442_create_sipity.hyrax.rb
+++ b/db/migrate/20170404212442_create_sipity.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20160919151348)
-class CreateSipity < ActiveRecord::Migration
+class CreateSipity < ActiveRecord::Migration[4.2]
   def change
     create_table "sipity_notification_recipients" do |t|
       t.integer  "notification_id",                null: false

--- a/db/migrate/20170404212443_create_sipity_workflow_methods.hyrax.rb
+++ b/db/migrate/20170404212443_create_sipity_workflow_methods.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20161012182404)
-class CreateSipityWorkflowMethods < ActiveRecord::Migration
+class CreateSipityWorkflowMethods < ActiveRecord::Migration[4.2]
   def change
     create_table :sipity_workflow_methods do |t|
       t.string   "service_name",                    null: false

--- a/db/migrate/20170404212444_create_permission_template.hyrax.rb
+++ b/db/migrate/20170404212444_create_permission_template.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20161021175854)
-class CreatePermissionTemplate < ActiveRecord::Migration
+class CreatePermissionTemplate < ActiveRecord::Migration[4.2]
   def change
     create_table :permission_templates do |t|
       t.belongs_to :workflow

--- a/db/migrate/20170404212445_create_permission_template_access.hyrax.rb
+++ b/db/migrate/20170404212445_create_permission_template_access.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20161021180154)
-class CreatePermissionTemplateAccess < ActiveRecord::Migration
+class CreatePermissionTemplateAccess < ActiveRecord::Migration[4.2]
   def change
     create_table :permission_template_accesses do |t|
       t.references :permission_template, foreign_key: true

--- a/db/migrate/20170404212446_add_release_to_permission_templates.hyrax.rb
+++ b/db/migrate/20170404212446_add_release_to_permission_templates.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20161116222307)
-class AddReleaseToPermissionTemplates < ActiveRecord::Migration
+class AddReleaseToPermissionTemplates < ActiveRecord::Migration[4.2]
   def change
     add_column :permission_templates, :release_date, :date
     add_column :permission_templates, :release_period, :string

--- a/db/migrate/20170404212447_add_permission_template_to_sipity_workflow.hyrax.rb
+++ b/db/migrate/20170404212447_add_permission_template_to_sipity_workflow.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20170131142607)
-class AddPermissionTemplateToSipityWorkflow < ActiveRecord::Migration
+class AddPermissionTemplateToSipityWorkflow < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_workflows, :permission_template_id, :integer, index: true
     remove_index :sipity_workflows, :name

--- a/db/migrate/20170404212448_tidy_up_because_of_bad_exception.hyrax.rb
+++ b/db/migrate/20170404212448_tidy_up_because_of_bad_exception.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20170307142607)
-class TidyUpBecauseOfBadException < ActiveRecord::Migration
+class TidyUpBecauseOfBadException < ActiveRecord::Migration[4.2]
   def change
     if Hyrax::PermissionTemplate.column_names.include?('workflow_id')
       Hyrax::PermissionTemplate.all.each do |permission_template|

--- a/db/migrate/20170404212449_add_allows_access_grant_to_workflow.hyrax.rb
+++ b/db/migrate/20170404212449_add_allows_access_grant_to_workflow.hyrax.rb
@@ -1,5 +1,5 @@
 # This migration comes from hyrax (originally 20170308175556)
-class AddAllowsAccessGrantToWorkflow < ActiveRecord::Migration
+class AddAllowsAccessGrantToWorkflow < ActiveRecord::Migration[4.2]
   def change
     add_column :sipity_workflows, :allows_access_grant, :boolean
   end

--- a/db/migrate/20170404212458_create_mailboxer.mailboxer_engine.rb
+++ b/db/migrate/20170404212458_create_mailboxer.mailboxer_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from mailboxer_engine (originally 20110511145103)
-class CreateMailboxer < ActiveRecord::Migration
+class CreateMailboxer < ActiveRecord::Migration[4.2]
   def self.up
   #Tables
     #Conversations

--- a/db/migrate/20170404212459_add_conversation_optout.mailboxer_engine.rb
+++ b/db/migrate/20170404212459_add_conversation_optout.mailboxer_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from mailboxer_engine (originally 20131206080416)
-class AddConversationOptout < ActiveRecord::Migration
+class AddConversationOptout < ActiveRecord::Migration[4.2]
   def self.up
     create_table :mailboxer_conversation_opt_outs do |t|
       t.references :unsubscriber, :polymorphic => true

--- a/db/migrate/20170404212460_add_missing_indices.mailboxer_engine.rb
+++ b/db/migrate/20170404212460_add_missing_indices.mailboxer_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from mailboxer_engine (originally 20131206080417)
-class AddMissingIndices < ActiveRecord::Migration
+class AddMissingIndices < ActiveRecord::Migration[4.2]
   def change
     # We'll explicitly specify its name, as the auto-generated name is too long and exceeds 63
     # characters limitation.

--- a/db/migrate/20170404212461_add_delivery_tracking_info_to_mailboxer_receipts.mailboxer_engine.rb
+++ b/db/migrate/20170404212461_add_delivery_tracking_info_to_mailboxer_receipts.mailboxer_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from mailboxer_engine (originally 20151103080417)
-class AddDeliveryTrackingInfoToMailboxerReceipts < ActiveRecord::Migration
+class AddDeliveryTrackingInfoToMailboxerReceipts < ActiveRecord::Migration[4.2]
   def change
     add_column :mailboxer_receipts, :is_delivered, :boolean, default: false
     add_column :mailboxer_receipts, :delivery_method, :string

--- a/db/migrate/20170404212634_create_minter_states.active_fedora_noid_engine.rb
+++ b/db/migrate/20170404212634_create_minter_states.active_fedora_noid_engine.rb
@@ -1,6 +1,6 @@
 # This migration comes from active_fedora_noid_engine (originally 20160610010003)
 # frozen_string_literal: true
-class CreateMinterStates < ActiveRecord::Migration
+class CreateMinterStates < ActiveRecord::Migration[4.2]
   def change
     create_table :minter_states do |t|
       t.string :namespace, null: false, default: 'default'

--- a/db/migrate/20170404212635_rename_minter_state_random_to_rand.active_fedora_noid_engine.rb
+++ b/db/migrate/20170404212635_rename_minter_state_random_to_rand.active_fedora_noid_engine.rb
@@ -1,6 +1,6 @@
 # This migration comes from active_fedora_noid_engine (originally 20161021203429)
 # frozen_string_literal: true
-class RenameMinterStateRandomToRand < ActiveRecord::Migration
+class RenameMinterStateRandomToRand < ActiveRecord::Migration[4.2]
   def change
     rename_column :minter_states, :random, :rand
   end

--- a/db/migrate/20170501141542_user_roles.rb
+++ b/db/migrate/20170501141542_user_roles.rb
@@ -1,4 +1,4 @@
-class UserRoles < ActiveRecord::Migration
+class UserRoles < ActiveRecord::Migration[4.2]
   def up
     create_table :roles do |t|
       t.string :name

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,10 @@
 
 ActiveRecord::Schema.define(version: 20180627152109) do
 
-  create_table "bookmarks", force: :cascade do |t|
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"
     t.string "document_id"
@@ -24,7 +27,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "checksum_audit_logs", force: :cascade do |t|
+  create_table "checksum_audit_logs", id: :serial, force: :cascade do |t|
     t.string "file_set_id"
     t.string "file_id"
     t.string "checked_uri"
@@ -37,7 +40,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
   end
 
-  create_table "collection_branding_infos", force: :cascade do |t|
+  create_table "collection_branding_infos", id: :serial, force: :cascade do |t|
     t.string "collection_id"
     t.string "role"
     t.string "local_path"
@@ -49,7 +52,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "collection_type_participants", force: :cascade do |t|
+  create_table "collection_type_participants", id: :serial, force: :cascade do |t|
     t.integer "hyrax_collection_type_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -59,7 +62,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["hyrax_collection_type_id"], name: "hyrax_collection_type_id"
   end
 
-  create_table "content_blocks", force: :cascade do |t|
+  create_table "content_blocks", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "value"
     t.datetime "created_at", null: false
@@ -67,7 +70,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.string "external_key"
   end
 
-  create_table "curation_concerns_operations", force: :cascade do |t|
+  create_table "curation_concerns_operations", id: :serial, force: :cascade do |t|
     t.string "status"
     t.string "operation_type"
     t.string "job_class"
@@ -88,7 +91,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
-  create_table "featured_works", force: :cascade do |t|
+  create_table "featured_works", id: :serial, force: :cascade do |t|
     t.integer "order", default: 5
     t.string "work_id"
     t.datetime "created_at", null: false
@@ -97,7 +100,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["work_id"], name: "index_featured_works_on_work_id"
   end
 
-  create_table "file_download_stats", force: :cascade do |t|
+  create_table "file_download_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "downloads"
     t.string "file_id"
@@ -108,7 +111,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_file_download_stats_on_user_id"
   end
 
-  create_table "file_view_stats", force: :cascade do |t|
+  create_table "file_view_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "views"
     t.string "file_id"
@@ -119,7 +122,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_file_view_stats_on_user_id"
   end
 
-  create_table "hyrax_collection_types", force: :cascade do |t|
+  create_table "hyrax_collection_types", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.string "machine_id"
@@ -136,14 +139,14 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["machine_id"], name: "index_hyrax_collection_types_on_machine_id", unique: true
   end
 
-  create_table "hyrax_features", force: :cascade do |t|
+  create_table "hyrax_features", id: :serial, force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "in_progress_etds", force: :cascade do |t|
+  create_table "in_progress_etds", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.string "graduation_date"
@@ -158,7 +161,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.string "data"
   end
 
-  create_table "job_io_wrappers", force: :cascade do |t|
+  create_table "job_io_wrappers", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "uploaded_file_id"
     t.string "file_set_id"
@@ -172,7 +175,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_job_io_wrappers_on_user_id"
   end
 
-  create_table "mailboxer_conversation_opt_outs", force: :cascade do |t|
+  create_table "mailboxer_conversation_opt_outs", id: :serial, force: :cascade do |t|
     t.string "unsubscriber_type"
     t.integer "unsubscriber_id"
     t.integer "conversation_id"
@@ -180,13 +183,13 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
   end
 
-  create_table "mailboxer_conversations", force: :cascade do |t|
+  create_table "mailboxer_conversations", id: :serial, force: :cascade do |t|
     t.string "subject", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "mailboxer_notifications", force: :cascade do |t|
+  create_table "mailboxer_notifications", id: :serial, force: :cascade do |t|
     t.string "type"
     t.text "body"
     t.string "subject", default: ""
@@ -208,7 +211,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["type"], name: "index_mailboxer_notifications_on_type"
   end
 
-  create_table "mailboxer_receipts", force: :cascade do |t|
+  create_table "mailboxer_receipts", id: :serial, force: :cascade do |t|
     t.string "receiver_type"
     t.integer "receiver_id"
     t.integer "notification_id", null: false
@@ -225,18 +228,18 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end
 
-  create_table "minter_states", force: :cascade do |t|
+  create_table "minter_states", id: :serial, force: :cascade do |t|
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", limit: 8, default: 0
+    t.bigint "seq", default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["namespace"], name: "index_minter_states_on_namespace", unique: true
   end
 
-  create_table "permission_template_accesses", force: :cascade do |t|
+  create_table "permission_template_accesses", id: :serial, force: :cascade do |t|
     t.integer "permission_template_id"
     t.string "agent_type"
     t.string "agent_id"
@@ -246,7 +249,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["permission_template_id", "agent_id", "agent_type", "access"], name: "uk_permission_template_accesses", unique: true
   end
 
-  create_table "permission_templates", force: :cascade do |t|
+  create_table "permission_templates", id: :serial, force: :cascade do |t|
     t.string "source_id"
     t.string "visibility"
     t.datetime "created_at"
@@ -256,7 +259,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["source_id"], name: "index_permission_templates_on_source_id", unique: true
   end
 
-  create_table "proxy_deposit_requests", force: :cascade do |t|
+  create_table "proxy_deposit_requests", id: :serial, force: :cascade do |t|
     t.string "work_id", null: false
     t.integer "sending_user_id", null: false
     t.integer "receiving_user_id", null: false
@@ -270,7 +273,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["sending_user_id"], name: "index_proxy_deposit_requests_on_sending_user_id"
   end
 
-  create_table "proxy_deposit_rights", force: :cascade do |t|
+  create_table "proxy_deposit_rights", id: :serial, force: :cascade do |t|
     t.integer "grantor_id"
     t.integer "grantee_id"
     t.datetime "created_at", null: false
@@ -279,14 +282,14 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["grantor_id"], name: "index_proxy_deposit_rights_on_grantor_id"
   end
 
-  create_table "qa_local_authorities", force: :cascade do |t|
+  create_table "qa_local_authorities", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
-  create_table "qa_local_authority_entries", force: :cascade do |t|
+  create_table "qa_local_authority_entries", id: :serial, force: :cascade do |t|
     t.integer "local_authority_id"
     t.string "label"
     t.string "uri"
@@ -296,7 +299,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
-  create_table "roles", force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
     t.string "name"
   end
 
@@ -307,7 +310,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id", "role_id"], name: "index_roles_users_on_user_id_and_role_id"
   end
 
-  create_table "searches", force: :cascade do |t|
+  create_table "searches", id: :serial, force: :cascade do |t|
     t.binary "query_params"
     t.integer "user_id"
     t.string "user_type"
@@ -316,7 +319,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
-  create_table "single_use_links", force: :cascade do |t|
+  create_table "single_use_links", id: :serial, force: :cascade do |t|
     t.string "downloadKey"
     t.string "path"
     t.string "itemId"
@@ -325,7 +328,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "sipity_agents", force: :cascade do |t|
+  create_table "sipity_agents", id: :serial, force: :cascade do |t|
     t.string "proxy_for_id", null: false
     t.string "proxy_for_type", null: false
     t.datetime "created_at", null: false
@@ -333,7 +336,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["proxy_for_id", "proxy_for_type"], name: "sipity_agents_proxy_for", unique: true
   end
 
-  create_table "sipity_comments", force: :cascade do |t|
+  create_table "sipity_comments", id: :serial, force: :cascade do |t|
     t.integer "entity_id", null: false
     t.integer "agent_id", null: false
     t.text "comment"
@@ -344,7 +347,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["entity_id"], name: "index_sipity_comments_on_entity_id"
   end
 
-  create_table "sipity_entities", force: :cascade do |t|
+  create_table "sipity_entities", id: :serial, force: :cascade do |t|
     t.string "proxy_for_global_id", null: false
     t.integer "workflow_id", null: false
     t.integer "workflow_state_id"
@@ -355,7 +358,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_state_id"], name: "index_sipity_entities_on_workflow_state_id"
   end
 
-  create_table "sipity_entity_specific_responsibilities", force: :cascade do |t|
+  create_table "sipity_entity_specific_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.string "entity_id", null: false
     t.integer "agent_id", null: false
@@ -367,7 +370,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_role_id"], name: "sipity_entity_specific_responsibilities_role"
   end
 
-  create_table "sipity_notifiable_contexts", force: :cascade do |t|
+  create_table "sipity_notifiable_contexts", id: :serial, force: :cascade do |t|
     t.integer "scope_for_notification_id", null: false
     t.string "scope_for_notification_type", null: false
     t.string "reason_for_notification", null: false
@@ -380,7 +383,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["scope_for_notification_id", "scope_for_notification_type"], name: "sipity_notifiable_contexts_concern"
   end
 
-  create_table "sipity_notification_recipients", force: :cascade do |t|
+  create_table "sipity_notification_recipients", id: :serial, force: :cascade do |t|
     t.integer "notification_id", null: false
     t.integer "role_id", null: false
     t.string "recipient_strategy", null: false
@@ -392,7 +395,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["role_id"], name: "sipity_notification_recipients_role"
   end
 
-  create_table "sipity_notifications", force: :cascade do |t|
+  create_table "sipity_notifications", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "notification_type", null: false
     t.datetime "created_at", null: false
@@ -401,7 +404,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["notification_type"], name: "index_sipity_notifications_on_notification_type"
   end
 
-  create_table "sipity_roles", force: :cascade do |t|
+  create_table "sipity_roles", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -409,7 +412,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["name"], name: "index_sipity_roles_on_name", unique: true
   end
 
-  create_table "sipity_workflow_actions", force: :cascade do |t|
+  create_table "sipity_workflow_actions", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "resulting_workflow_state_id"
     t.string "name", null: false
@@ -420,7 +423,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_id"], name: "sipity_workflow_actions_workflow"
   end
 
-  create_table "sipity_workflow_methods", force: :cascade do |t|
+  create_table "sipity_workflow_methods", id: :serial, force: :cascade do |t|
     t.string "service_name", null: false
     t.integer "weight", null: false
     t.integer "workflow_action_id", null: false
@@ -429,7 +432,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_action_id"], name: "index_sipity_workflow_methods_on_workflow_action_id"
   end
 
-  create_table "sipity_workflow_responsibilities", force: :cascade do |t|
+  create_table "sipity_workflow_responsibilities", id: :serial, force: :cascade do |t|
     t.integer "agent_id", null: false
     t.integer "workflow_role_id", null: false
     t.datetime "created_at", null: false
@@ -437,7 +440,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["agent_id", "workflow_role_id"], name: "sipity_workflow_responsibilities_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_roles", force: :cascade do |t|
+  create_table "sipity_workflow_roles", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -445,7 +448,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_id", "role_id"], name: "sipity_workflow_roles_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_action_permissions", force: :cascade do |t|
+  create_table "sipity_workflow_state_action_permissions", id: :serial, force: :cascade do |t|
     t.integer "workflow_role_id", null: false
     t.integer "workflow_state_action_id", null: false
     t.datetime "created_at", null: false
@@ -453,7 +456,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_role_id", "workflow_state_action_id"], name: "sipity_workflow_state_action_permissions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_state_actions", force: :cascade do |t|
+  create_table "sipity_workflow_state_actions", id: :serial, force: :cascade do |t|
     t.integer "originating_workflow_state_id", null: false
     t.integer "workflow_action_id", null: false
     t.datetime "created_at", null: false
@@ -461,7 +464,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["originating_workflow_state_id", "workflow_action_id"], name: "sipity_workflow_state_actions_aggregate", unique: true
   end
 
-  create_table "sipity_workflow_states", force: :cascade do |t|
+  create_table "sipity_workflow_states", id: :serial, force: :cascade do |t|
     t.integer "workflow_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -470,7 +473,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
   end
 
-  create_table "sipity_workflows", force: :cascade do |t|
+  create_table "sipity_workflows", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "label"
     t.text "description"
@@ -482,20 +485,20 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["permission_template_id", "name"], name: "index_sipity_workflows_on_permission_template_and_name", unique: true
   end
 
-  create_table "tinymce_assets", force: :cascade do |t|
+  create_table "tinymce_assets", id: :serial, force: :cascade do |t|
     t.string "file"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "trophies", force: :cascade do |t|
+  create_table "trophies", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "work_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "uploaded_files", force: :cascade do |t|
+  create_table "uploaded_files", id: :serial, force: :cascade do |t|
     t.string "file"
     t.integer "user_id"
     t.string "file_set_uri"
@@ -510,7 +513,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
-  create_table "user_stats", force: :cascade do |t|
+  create_table "user_stats", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.datetime "date"
     t.integer "file_views"
@@ -521,7 +524,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["user_id"], name: "index_user_stats_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -566,7 +569,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "version_committers", force: :cascade do |t|
+  create_table "version_committers", id: :serial, force: :cascade do |t|
     t.string "obj_id"
     t.string "datastream_id"
     t.string "version_id"
@@ -575,7 +578,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "work_view_stats", force: :cascade do |t|
+  create_table "work_view_stats", id: :serial, force: :cascade do |t|
     t.datetime "date"
     t.integer "work_views"
     t.string "work_id"
@@ -586,4 +589,12 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id", name: "mb_opt_outs_on_conversations_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id", name: "notifications_on_conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id", name: "receipts_on_notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "qa_local_authority_entries", "qa_local_authorities", column: "local_authority_id"
+  add_foreign_key "uploaded_files", "users"
 end


### PR DESCRIPTION
Without these, the software will not install on a
clean postgres database.

ALSO: 
I noticed over the weekend that we were mixing sqlite in dev and test with postgres in production. This is explicitly contraindicated by the rails community, and can lead to unexpected problems. We decided as a team awhile ago that if we're using postgres in production we should be using it in dev and test too. I put in a PR to move laevigata to using postgres in dev and test. Once this PR is merged, you must re-create your local development database and clean out fedora.