### PR TITLE
Try splitting our test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,19 @@ before_script:
   - bundle exec rake db:create
 script:
   - RAILS_ENV=test ./bin/rails webpacker:compile
-  - bundle exec rubocop
-  - yarn test
   - xvfb-run -a bundle exec rake ci[$TEST_SUITE]
 env:
   global:
     - COVERALLS_PARALLEL=true
     - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   matrix:
+    - TEST_SUITE=style
     - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=unit
     - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=integration
+    - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=js
     - NEW_UI_ENABLED=true TEST_SUITE=unit
     - NEW_UI_ENABLED=true TEST_SUITE=integration
+    - NEW_UI_ENABLED=true TEST_SUITE=js
 install:
   - nvm install node
   - node -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,16 @@ script:
   - RAILS_ENV=test ./bin/rails webpacker:compile
   - bundle exec rubocop
   - yarn test
-  - xvfb-run -a bundle exec rake ci
+  - xvfb-run -a bundle exec rake ci[$TEST_SUITE]
 env:
   global:
     - COVERALLS_PARALLEL=true
     - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   matrix:
-    - NEW_UI_ENABLED=false NO_COVERAGE=true
-    - NEW_UI_ENABLED=true
+    - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=unit
+    - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=integration
+    - NEW_UI_ENABLED=true TEST_SUITE=unit
+    - NEW_UI_ENABLED=true TEST_SUITE=integration
 install:
   - nvm install node
   - node -v

--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,3 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 require 'solr_wrapper/rake_task' unless Rails.env.production?
-
-RSpec::Core::RakeTask.new(:integration) do |t|
-  t.rspec_opts = "--tag integration --profile"
-end
-
-RSpec::Core::RakeTask.new(:unit) do |t|
-  t.rspec_opts = "--tag ~integration --profile"
-end

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,11 @@ require_relative 'config/application'
 Rails.application.load_tasks
 
 require 'solr_wrapper/rake_task' unless Rails.env.production?
+
+RSpec::Core::RakeTask.new(:integration) do |t|
+  t.rspec_opts = "--tag integration --profile"
+end
+
+RSpec::Core::RakeTask.new(:unit) do |t|
+  t.rspec_opts = "--tag ~integration --profile"
+end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -7,7 +7,8 @@ unless Rails.env.production?
   require 'solr_wrapper/rake_task'
 
   desc "Run Continuous Integration"
-  task :ci do
+  task :ci, [:test_suite] do |task, args|
+    test_suite = args[:test_suite] || "spec"
     ENV["environment"] = "test"
     solr_params = {
       port: 8985,
@@ -28,7 +29,7 @@ unless Rails.env.production?
         dir: Rails.root.join("solr", "config")
       ) do
         FcrepoWrapper.wrap(fcrepo_params) do
-          Rake::Task["spec"].invoke
+          Rake::Task[test_suite].invoke
         end
       end
     end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -9,30 +9,52 @@ unless Rails.env.production?
   desc "Run Continuous Integration"
   task :ci, [:test_suite] do |task, args|
     test_suite = args[:test_suite] || "spec"
-    ENV["environment"] = "test"
-    solr_params = {
-      port: 8985,
-      verbose: true,
-      managed: true
-    }
-    fcrepo_params = {
-      port: 8986,
-      verbose: true,
-      managed: true,
-      enable_jms: false,
-      fcrepo_home_dir: 'tmp/fcrepo4-test-data'
-    }
-    SolrWrapper.wrap(solr_params) do |solr|
-      solr.with_collection(
-        name: "hydra-test",
-        persist: false,
-        dir: Rails.root.join("solr", "config")
-      ) do
-        FcrepoWrapper.wrap(fcrepo_params) do
-          Rake::Task[test_suite].invoke
-        end
+    check_style if test_suite == "style"
+    ci_with_infrastructure(test_suite) unless test_suite == "style"
+  end
+end
+
+def ci_with_infrastructure(test_suite)
+  ENV["environment"] = "test"
+  solr_params = {
+    port: 8985,
+    verbose: true,
+    managed: true
+  }
+  fcrepo_params = {
+    port: 8986,
+    verbose: true,
+    managed: true,
+    enable_jms: false,
+    fcrepo_home_dir: 'tmp/fcrepo4-test-data'
+  }
+  SolrWrapper.wrap(solr_params) do |solr|
+    solr.with_collection(
+      name: "hydra-test",
+      persist: false,
+      dir: Rails.root.join("solr", "config")
+    ) do
+      FcrepoWrapper.wrap(fcrepo_params) do
+        Rake::Task[test_suite].invoke
       end
     end
-    # Rake::Task["doc"].invoke
   end
+  # Rake::Task["doc"].invoke
+end
+
+RSpec::Core::RakeTask.new(:integration) do |t|
+  t.rspec_opts = "--tag integration --profile"
+end
+
+RSpec::Core::RakeTask.new(:unit) do |t|
+  t.rspec_opts = "--tag ~integration --profile"
+end
+
+desc "Run js tests"
+task :js do
+  sh "yarn test"
+end
+
+def check_style
+  sh "bundle exec rubocop"
 end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.feature 'Admin dashboard',
+              integration: true,
               workflow: { admin_sets_config: 'spec/fixtures/config/emory/epidemiology_admin_sets.yml' } do
 
   context 'as an admin user' do

--- a/spec/features/blacklisted_email_spec.rb
+++ b/spec/features/blacklisted_email_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
-RSpec.feature 'Do not send email to blacklisted addresses', :clean do
+RSpec.feature 'Do not send email to blacklisted addresses',
+              :clean,
+              integration: true do
   before do
     ActionMailer::Base.deliveries.clear
   end

--- a/spec/features/candler_workflow_etd_spec.rb
+++ b/spec/features/candler_workflow_etd_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Candler approval workflow', :perform_jobs, :clean do
+RSpec.feature 'Candler approval workflow', :perform_jobs, :clean, integration: true do
   let(:depositing_user) { FactoryBot.create(:user) }
   let(:approving_user) { User.where(uid: "candleradmin").first }
   let(:admin_superuser) { User.where(uid: "tezprox").first } # uid from superuser.yml

--- a/spec/features/controlled_vocabulary_spec.rb
+++ b/spec/features/controlled_vocabulary_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Using Controlled Vocabularies', :workflow do
+RSpec.feature 'Using Controlled Vocabularies', :workflow, integration: true do
   let(:admin) { create(:admin) }
   let(:user)  { create(:user) }
 

--- a/spec/features/create_etd_about_me_spec.rb
+++ b/spec/features/create_etd_about_me_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Create an Etd' do
+RSpec.feature 'Create an Etd', integration: true do
   let(:user) { create :user }
 
   context 'a logged in user fills in their About Me and My Program data' do

--- a/spec/features/create_etd_about_my_etd_spec.rb
+++ b/spec/features/create_etd_about_my_etd_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Create an Etd: My Etd' do
+RSpec.feature 'Create an Etd: My Etd', integration: true do
   let(:user) { create :user }
 
   context 'a logged in user' do

--- a/spec/features/create_etd_embargo_spec.rb
+++ b/spec/features/create_etd_embargo_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Create an Etd: My Embargoes' do
+RSpec.feature 'Create an Etd: My Embargoes', integration: true do
   let(:user) { create :user }
 
   context 'a logged in user' do

--- a/spec/features/create_etd_review_spec.rb
+++ b/spec/features/create_etd_review_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create an Etd', :clean do
+RSpec.feature 'Create an Etd', :clean, integration: true do
   let(:user) { create :user }
 
   context 'a logged in (non-admin) user' do

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Create an Etd', :clean do
+RSpec.feature 'Create an Etd', :clean, integration: true do
   let(:student) { create :user }
 
   context 'a logged in user' do

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean do
+RSpec.feature 'Edit an existing ETD', :perform_jobs, :clean, integration: true do
   let(:approver) { User.where(uid: "tezprox").first }
   let(:student) { create :user }
 

--- a/spec/features/edit_rollins_spec.rb
+++ b/spec/features/edit_rollins_spec.rb
@@ -4,6 +4,7 @@ require 'workflow_setup'
 include Warden::Test::Helpers
 
 RSpec.feature 'Edit an existing ETD',
+              integration: true,
               workflow: { admin_sets_config: 'spec/fixtures/config/emory/epidemiology_admin_sets.yml' } do
   let(:approver) { User.where(uid: "epidemiology_admin").first }
   let(:student) { create :user }

--- a/spec/features/embargo_show_spec.rb
+++ b/spec/features/embargo_show_spec.rb
@@ -3,7 +3,7 @@ require 'workflow_setup'
 require 'etd_factory'
 include Warden::Test::Helpers
 
-RSpec.feature 'Display an ETD with embargoed content', :clean do
+RSpec.feature 'Display an ETD with embargoed content', :clean, integration: true do
   let(:etd) do
     etd = FactoryBot.create(:sample_data_with_everything_embargoed, school: ["Candler School of Theology"])
     etd_factory = EtdFactory.new

--- a/spec/features/feature_set_spec.rb
+++ b/spec/features/feature_set_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Feature configuration' do
+RSpec.feature 'Feature configuration', integration: true do
   context 'via a config file' do
     scenario 'unwanted features are disabled' do
       expect(Flipflop.proxy_deposit?).to eq false

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Laney Graduate School two step approval workflow', :perform_jobs, :clean, :js do
+RSpec.feature 'Laney Graduate School two step approval workflow',
+              :perform_jobs,
+              :clean,
+              :js,
+              integration: true do
   let(:depositing_user) { FactoryBot.create(:user) }
   let(:approving_user) { User.where(uid: "laneyadmin").first }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }

--- a/spec/features/read_only_mode_spec.rb
+++ b/spec/features/read_only_mode_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Read Only Mode' do
+RSpec.feature 'Read Only Mode', integration: true do
   let(:student) { create :user }
 
   context 'a logged in user' do

--- a/spec/features/rollins_workflow_etd_spec.rb
+++ b/spec/features/rollins_workflow_etd_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Create a Rollins ETD', :perform_jobs, :clean, :js do
+RSpec.feature 'Create a Rollins ETD', :perform_jobs, :clean, :js, integration: true do
   let(:depositing_user) { FactoryBot.create(:user) }
   let(:approving_user) { User.where(uid: "epidemiology_admin").first }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/epidemiology_admin_sets.yml", "/dev/null") }

--- a/spec/features/search_etd_spec.rb
+++ b/spec/features/search_etd_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Search for an ETD' do
+RSpec.feature 'Search for an ETD', integration: true do
   let(:etd) do
     FactoryBot.create(
       :etd,

--- a/spec/features/show_admin_set_spec.rb
+++ b/spec/features/show_admin_set_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'show admin set' do
+RSpec.feature 'show admin set', integration: true do
   let(:admin_set) { FactoryBot.create(:admin_set) }
   let(:admin) { FactoryBot.create(:admin) }
 

--- a/spec/features/show_etd_spec.rb
+++ b/spec/features/show_etd_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Display ETD metadata', :clean do
+RSpec.feature 'Display ETD metadata', :clean, integration: true do
   let(:etd) do
     FactoryBot.create(:sample_data_with_copyright_questions,
                       partnering_agency: ["CDC"],

--- a/spec/features/show_user_spec.rb
+++ b/spec/features/show_user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'show user profile' do
+RSpec.feature 'show user profile', integration: true do
   let(:user) { FactoryBot.create(:user) }
 
   scenario "show user profile but not email address" do

--- a/spec/features/skip_dashboard_spec.rb
+++ b/spec/features/skip_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Skip the dashboard' do
+RSpec.feature 'Skip the dashboard', integration: true do
   let(:user) { FactoryBot.create(:user) }
 
   context 'an unauthenticated user' do

--- a/spec/features/suppress_collections_spec.rb
+++ b/spec/features/suppress_collections_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-RSpec.feature 'Collection objects should not appear in search results', :clean do
+RSpec.feature 'Collection objects should not appear in search results',
+              :clean, integration: true do
   let(:collection) { build(:collection) }
 
   context 'a search for everything' do

--- a/spec/features/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/features/undergrad_honors_workflow_etd_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Emory College approval workflow', :perform_jobs, :clean, :js do
+RSpec.feature 'Emory College approval workflow',
+              :perform_jobs, :clean, :js, integration: true do
   let(:depositing_user) { User.where(ppid: etd.depositor).first }
   let(:approving_user) { User.where(uid: "ecadmin").first }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }

--- a/spec/features/upload_files_spec.rb
+++ b/spec/features/upload_files_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Primary PDF' do
+RSpec.feature 'Primary PDF', integration: true do
   let(:user) { create :user }
   context 'a logged in user uploads Primary PDF' do
     before do

--- a/spec/features/upload_supplemental_files_spec.rb
+++ b/spec/features/upload_supplemental_files_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include Warden::Test::Helpers
 
-RSpec.feature 'Supplemental files' do
+RSpec.feature 'Supplemental files', integration: true do
   let(:user) { create :user }
   context 'logged in user uploads Supplemental files' do
     before do

--- a/spec/features/validate_new_etd_about_spec.rb
+++ b/spec/features/validate_new_etd_about_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 include Warden::Test::Helpers
 
-RSpec.feature 'Validate an Etd: About Me' do
+RSpec.feature 'Validate an Etd: About Me', integration: true do
   let(:user) { create :user }
 
   context 'a logged in user' do

--- a/spec/features/validate_new_etd_supplemental_files_spec.rb
+++ b/spec/features/validate_new_etd_supplemental_files_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Form Validation: "Supplemental Files" tab' do
+RSpec.feature 'Form Validation: "Supplemental Files" tab', integration: true do
   let(:student) { create :user }
 
   context 'a student (non-admin user)' do

--- a/spec/features/virus_workflow_etd_spec.rb
+++ b/spec/features/virus_workflow_etd_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Virus checking', :perform_jobs, :clean, :js do
+RSpec.feature 'Virus checking', :perform_jobs, :clean, :js, integration: true do
   let(:depositing_user) { User.where(ppid: etd.depositor).first }
   let(:approving_user) { User.where(uid: "candleradmin").first }
   let(:admin_superuser) { User.where(uid: "tezprox").first } # uid from superuser.yml

--- a/spec/features/workflow_approval_spec.rb
+++ b/spec/features/workflow_approval_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'workflow_setup'
 include Warden::Test::Helpers
 
-RSpec.feature 'Dashboard workflow', :clean do
+RSpec.feature 'Dashboard workflow', :clean, integration: true do
   let(:approving_user)  { User.find_by(uid: "candleradmin") }
   let(:depositing_user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
I keep encountering failed CI runs because travis timed out because the tests took too long. 
I'd like to try splitting our test suite into "unit" and "integration" parts and run them in parallel. This is what PSU does, and it's also one of the things Travis recommends for speeding up the build: https://docs.travis-ci.com/user/speeding-up-the-build/

Integration tests (right now, just our feature tests) are the longer-running individually, but there are fewer of them. We could put more things in the "integration" set of tests to even things out a bit more, and maybe also put the yarn tests in a separate run (right now the yarn tests are running twice... once with unit and once with integration).

Hard to get an exact apples-to-apples time comparison but best case I think this takes our build from ~34 minutes to ~26, with more room for improvement. 

Fixes #1272 

Edit: I split out rubocop and js (yarn) into their own parallel runs too. Now our run time is down even further. 