### PR TITLE
Add copyright questions to the form

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -54,6 +54,9 @@
             <div v-else-if="input.label === 'Research Field'">
               <researchField></researchField>
             </div>
+            <div v-else-if="input.label === 'Copyright & Patents'">
+              <copyrightQuestions></copyrightQuestions>
+            </div>
             <div v-else-if="input.label === 'Language'">
               <language></language>
             </div>
@@ -91,8 +94,8 @@ import GraduationDate from "./GraduationDate"
 import Language from "./Language"
 import Subfield from "./Subfield"
 import CommitteeMember from "./CommitteeMember"
-import PrimaryFileUploader from './PrimaryFileUploader.vue';
-
+import PrimaryFileUploader from './PrimaryFileUploader.vue'
+import CopyrightQuestions from './CopyrightQuestions'
 let token = document
   .querySelector('meta[name="csrf-token"]')
   .getAttribute("content")
@@ -122,7 +125,8 @@ export default {
     department: Department,
     subfield: Subfield,
     committeeMember: CommitteeMember,
-    primaryFileUploader: PrimaryFileUploader
+    primaryFileUploader: PrimaryFileUploader,
+    copyrightQuestions: CopyrightQuestions
   },
   methods: {
     etdPrefix(index) {

--- a/app/javascript/CopyrightQuestions.vue
+++ b/app/javascript/CopyrightQuestions.vue
@@ -1,0 +1,29 @@
+<template>
+    <div>
+        <div v-for="question in sharedState.copyrightQuestions" v-bind:key="question.name">
+            <label :for="question.name">{{ question.label }}</label>
+            <p>{{ question.text }}</p>
+          <input :id="question.name" class="checkbox copyright-checkbox" :name="question.name" type="checkbox" v-model="question.choice"
+          true-value="yes" false-value="no">
+        </div>
+    </div>
+</template>
+
+<script>
+import Vue from "vue"
+import App from "./App"
+import { formStore } from './formStore'
+export default {
+ data() {
+     return {
+         sharedState: formStore
+     }
+ }
+}
+</script>
+
+<style scoped>
+.copyright-checkbox {
+    margin-bottom: 3em;
+}
+</style>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -42,7 +42,7 @@ export var formStore = {
       completed: false,
       step: 3,
       inputs: {
-        committee_member: { label: 'Committee Member', value: [], required: true },
+        committee_member: { label: 'Committee Member', value: [], required: true }
 
       }
     },
@@ -70,21 +70,7 @@ export var formStore = {
       inputs: {
         research_field: { label: 'Research Field', value: [], required: true },
         keyword: { label: 'Keyword', value: [], required: true },
-        requires_permissions: {
-          label: 'Requires Permissions Question',
-          value: false,
-          required: true
-        },
-        additional_copyrights: {
-          label: 'Additional Copyrights Question',
-          value: false,
-          required: true
-        },
-        patents: {
-          label: 'Patents Question',
-          value: false,
-          required: true
-        }
+        copyrights: { label: 'Copyright & Patents' }
       }
     },
     my_files: {
@@ -125,12 +111,29 @@ export var formStore = {
       step: 8
     }
   },
+  copyrightQuestions: [{
+    'label': 'Fair Use',
+    'text': `Does your thesis or dissertation contain any thirdy-party text, audiovisual content or other material which is beyond a fair use and would require permission?`,
+    'choice': 'no',
+    'name': 'etd[requires_permissions]'
+  }, {
+    'label': 'Copyright',
+    'text': `Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have quiestions about your use of copyrighted material, contact the Scholarly Communications Office at scholcom@listserv.cc.emory.edu`,
+    'choice': 'no',
+    'name': 'etd[additional_copyrights]'
+  },
+  {
+    'label': 'Patents',
+    'text': `Does your thesis or dissertation disclose or described any inventions or discoveries that could potentially have commerical application and therefore may be patended? If so please contact the Office of Technology Transfer (OTT) at (404) 727-2211.`,
+    'choice': 'no',
+    'name': 'etd[patents]'
+  }],
   committeeChairs: [],
   deletablePrimaryFiles: [],
   departments: [],
   selectedDepartment: '',
   subfields: [],
-  languages: [{ 'value': '', 'active': true, 'label': 'Select a Language', 'disabled':'disabled' ,'selected': 'selected'}],
+  languages: [{ 'value': '', 'active': true, 'label': 'Select a Language', 'disabled': 'disabled', 'selected': 'selected' }],
   languagesEndpoint: '/authorities/terms/local/languages_list',
   subfieldEndpoints: {
     'Biological and Biomedical Sciences': '/authorities/terms/local/biological_programs',
@@ -145,7 +148,7 @@ export var formStore = {
     this.subfields = []
   },
   addCommitteeMember (affilation, name) {
-    this.committeeChairs.push({affilation: affilation, name: name})
+    this.committeeChairs.push({ affilation: affilation, name: name })
   },
   setSelectedDepartment (department) {
     this.selectedDepartment = department

--- a/app/javascript/test/CopyrightQuestions.spec.js
+++ b/app/javascript/test/CopyrightQuestions.spec.js
@@ -1,0 +1,15 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import CopyrightQuestions from 'CopyrightQuestions'
+
+describe('CopyrightQuestions.vue', () => {
+  it('has the correct html', () => {
+    const wrapper = shallowMount(CopyrightQuestions, {
+    })
+    expect(wrapper.html()).toContain(`etd[requires_permissions]`)
+    expect(wrapper.html()).toContain(`etd[additional_copyrights]`)
+    expect(wrapper.html()).toContain(`etd[patents]`)
+  })
+})

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -1,0 +1,29 @@
+/* global describe */
+/* global it */
+/* global expect */
+
+import { formStore } from '../formStore'
+
+describe('formStore', () => {
+  it('has copyrightQuestions', () => {
+    expect(formStore.copyrightQuestions).toEqual(
+      [{
+        'label': 'Fair Use',
+        'text': `Does your thesis or dissertation contain any thirdy-party text, audiovisual content or other material which is beyond a fair use and would require permission?`,
+        'choice': 'no',
+        'name': 'etd[requires_permissions]'
+      }, {
+        'label': 'Copyright',
+        'text': `Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have quiestions about your use of copyrighted material, contact the Scholarly Communications Office at scholcom@listserv.cc.emory.edu`,
+        'choice': 'no',
+        'name': 'etd[additional_copyrights]'
+      },
+      {
+        'label': 'Patents',
+        'text': `Does your thesis or dissertation disclose or described any inventions or discoveries that could potentially have commerical application and therefore may be patended? If so please contact the Office of Technology Transfer (OTT) at (404) 727-2211.`,
+        'choice': 'no',
+        'name': 'etd[patents]'
+      }]
+    )
+  })
+})


### PR DESCRIPTION
This adds the new copyright questions attributes
to the form. Previously they were `question_one`,etc, but recently they changed to have more meaningful names.