### PR TITLE
Don't hard-code the database config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ coverage
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+
+# Don't hard-code the config
+config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jdk:
 rvm:
   - 2.4.2
 before_script:
+  - cp config/database.yml.sample config/database.yml
   - bundle exec rake db:create
 script:
   - RAILS_ENV=test ./bin/rails db:migrate

--- a/bin/setup
+++ b/bin/setup
@@ -18,10 +18,10 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  puts "\n== Copying sample files =="
+  unless File.exist?('config/database.yml')
+    cp 'config/database.yml.sample', 'config/database.yml'
+  end
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,6 +1,3 @@
-# We run postgres in production so we should run
-# postgres in development and test environments too
-#
 default: &default
   adapter:  postgresql
   encoding: unicode

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -27,6 +27,7 @@ append :linked_dirs, "log"
 
 append :linked_files, ".env.production"
 append :linked_files, "config/secrets.yml"
+append :linked_files, "config/database.yml"
 
 # We have to re-define capistrano-sidekiq's tasks to work with
 # systemctl in production


### PR DESCRIPTION
The problem I'm trying to solve with this change is unwanted coupling
between environments.  When another developer makes a change to the
config of their local dev environment, my dev environment should be
unaffected by that change.

@bess Could you confirm whether or not this change would require changes to the provisioning and/or deploy scripts?  For example, do we need to put a `config/database.yml` into the shared dir on the environments, or does the deployment already handle the database config?