### PR TITLE
Add Embargoes to the form

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -54,6 +54,9 @@
             <div v-else-if="input.label === 'Research Field'">
               <researchField></researchField>
             </div>
+            <div v-else-if="input.label === 'Embargo'">
+              <embargo></embargo>
+            </div>
             <div v-else-if="input.label === 'Copyright & Patents'">
               <copyrightQuestions></copyrightQuestions>
             </div>
@@ -97,6 +100,8 @@ import Subfield from "./Subfield"
 import CommitteeMember from "./CommitteeMember"
 import PrimaryFileUploader from './PrimaryFileUploader.vue'
 import CopyrightQuestions from './CopyrightQuestions'
+import Embargo from './Embargo'
+
 let token = document
   .querySelector('meta[name="csrf-token"]')
   .getAttribute("content")
@@ -128,7 +133,8 @@ export default {
     subfield: Subfield,
     committeeMember: CommitteeMember,
     primaryFileUploader: PrimaryFileUploader,
-    copyrightQuestions: CopyrightQuestions
+    copyrightQuestions: CopyrightQuestions,
+    embargo: Embargo
   },
   methods: {
     // tabs that have been validated and the current tab are enabled

--- a/app/javascript/Embargo.vue
+++ b/app/javascript/Embargo.vue
@@ -1,0 +1,46 @@
+<template>
+<div>
+  <label for="embargo-length">Requested Embargo Length</label>
+  <select v-model="selectedEmbargo" name="etd[embargo_length]" class="form-control" id="embargo-length">
+    <option v-for="length in lengths" :value="length.value" :selected="length.selected" :disabled="length.disabled">
+        {{ length.value }}
+      </option>
+    </select>
+  <div v-if="selectedEmbargo != 'None - open access immediately'">
+    <label for="content-to-embargo">Content to Embargo</label>
+    <select name="embargo_type" class="form-control" id="content-to-embargo">
+      <option v-for="content in contents" :value="content.value" :disabled="content.disabled">
+        {{ content.text }}
+      </option>
+    </select>
+    </div>
+    </div>
+</div>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from './formStore'
+
+export default {
+  data() {
+    return {
+      selectedEmbargo: 'None - open access immediately'
+    }
+  },
+  computed: {
+    lengths () {
+      return formStore.getEmbargoLengths()
+    },
+    contents () {
+      return formStore.getEmbargoContents()
+    }
+ }
+}
+</script>
+
+<style>
+select {
+  margin-bottom: 1em;
+}
+</style>

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -2,8 +2,8 @@
   <div>
     <label>School</label>
     <select class="form-control" v-model="selected" id="school">
-      <option v-for="option in options" v-bind:value="option.value" v-bind:key='option.value' :selected='option.selected' :disabled='option.disabled'>
-        {{ option.text }}
+      <option v-for="school in this.sharedState.schools.options" v-bind:value="school.value" v-bind:key='school.value' :selected='school.selected' :disabled='school.disabled'>
+        {{ school.text }}
       </option>
     </select>
   </div>
@@ -19,39 +19,21 @@ import { formStore } from './formStore'
 export default {
   data() {
     return {
-      schools: {
-        candler:
-          "/authorities/terms/local/candler_programs",
-        emory: "/authorities/terms/local/emory_programs",
-        laney: "/authorities/terms/local/laney_programs",
-        rollins:
-          "/authorities/terms/local/rollins_programs"
-      },
-      selected: "",
-      options: [
-        {
-          text: "Select a School",
-          value: "",
-          disabled: "disabled",
-          selected: "selected"
-        },
-        { text: "Candler School of Theology", value: "candler" },
-        { text: "Emory College", value: "emory" },
-        { text: "Laney Graduate School", value: "laney" },
-        { text: "Rollins School of Public Health", value: "rollins" }
-      ]
-    };
+      sharedState: formStore,
+      selected: ''
+    }
   },
   methods: {
     fetchData() {
-      var selectedSchool = this.schools[this.selected];
+      var selectedSchool = this.sharedState.schools[this.selected];
+      formStore.setSelectedSchool(this.selected)
       formStore.getDepartments(selectedSchool)
     }
   },
   watch: {
     selected() {
       this.fetchData();
-      formStore.clearSubfields() 
+      formStore.clearSubfields()
     }
   }
 };

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -1,4 +1,4 @@
-import Axios from 'axios'
+import axios from 'axios'
 
 export var formStore = {
   tabs: {
@@ -102,10 +102,7 @@ export var formStore = {
       currentStep: false,
       step: 6,
       inputs: {
-        embargo_length: { label: 'embargo_length', value: [], required: true },
-        files_embargoed: { label: 'files_embargoed', value: [], required: true },
-        abstract_embargoed: { label: 'abstract_embargoed', value: [], required: true },
-        toc_embargoed: { label: 'toc_embargoed', value: [], required: true }
+        embargo: { label: 'Embargo', value: [] }
       }
     },
     submit: {
@@ -152,6 +149,50 @@ export var formStore = {
     'Psychology': '/authorities/terms/local/psychology_programs',
     'Executive Masters of Public Health - MPH': '/authorities/terms/local/executive_programs'
   },
+  schools: {
+    candler:
+    '/authorities/terms/local/candler_programs',
+    emory: '/authorities/terms/local/emory_programs',
+    laney: '/authorities/terms/local/laney_programs',
+    rollins:
+    '/authorities/terms/local/rollins_programs',
+    selected: '',
+    options: [
+      {
+        text: 'Select a School',
+        value: '',
+        disabled: 'disabled',
+        selected: 'selected'
+      },
+      { text: 'Candler School of Theology', value: 'candler' },
+      { text: 'Emory College', value: 'emory' },
+      { text: 'Laney Graduate School', value: 'laney' },
+      { text: 'Rollins School of Public Health', value: 'rollins' }
+    ]
+  },
+  embargoContents: [{ text: 'Files',
+    value: '[:files_embargoed]',
+    disabled: false
+  },
+  { text: 'Files and Table of Contents',
+    value: '[:files_embargoed, :toc_embargoed]',
+    disabled: false
+  },
+  { text: 'Files and Table of Contents and Abstract',
+    value: '[:files_embargoed, :toc_embargoed, :abstract_embargoed]',
+    disabled: false
+  }
+  ],
+  embargoLengths: {
+    emory: [{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}],
+    candler: [{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}],
+    laney: [{value: 'None - open access immediately', selected: 'selected'}, {value: '6 Months'},
+      {value: '1 year'}, {value: '2 Years'}, {value: '6 years'}],
+    rollins: [{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}]
+  },
   clearSubfields () {
     this.subfields = []
   },
@@ -164,13 +205,25 @@ export var formStore = {
   getSelectedDepartment () {
     return this.selectedDepartment
   },
+  setSelectedSchool (school) {
+    this.schools.selected = school
+  },
+  getEmbargoLengths () {
+    return this.embargoLengths[this.schools.selected]
+  },
+  getEmbargoContents () {
+    return this.embargoContents
+  },
+  getSelectedSchool () {
+    return this.schools.selected
+  },
   getDepartments (selectedSchool) {
-    Axios.get(selectedSchool).then(response => {
+    axios.get(selectedSchool).then(response => {
       this.departments = response.data
     })
   },
   getSubfields () {
-    Axios.get(this.subfieldEndpoints[this.selectedDepartment]).then(response => {
+    axios.get(this.subfieldEndpoints[this.selectedDepartment]).then(response => {
       this.subfields = response.data
     })
   }

--- a/app/javascript/test/Embargo.spec.js
+++ b/app/javascript/test/Embargo.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Embargo from 'Embargo'
+
+describe('Embargo.vue', () => {
+  it('has the correct html', () => {
+    const wrapper = shallowMount(Embargo, {
+    })
+    expect(wrapper.html()).toContain(`<select name="etd[embargo_length]" id="embargo-length" class="form-control"></select>`)
+  })
+})

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -5,25 +5,25 @@
 import { formStore } from '../formStore'
 
 describe('formStore', () => {
-  it('has copyrightQuestions', () => {
-    expect(formStore.copyrightQuestions).toEqual(
-      [{
-        'label': 'Fair Use',
-        'text': `Does your thesis or dissertation contain any thirdy-party text, audiovisual content or other material which is beyond a fair use and would require permission?`,
-        'choice': 'no',
-        'name': 'etd[requires_permissions]'
-      }, {
-        'label': 'Copyright',
-        'text': `Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have quiestions about your use of copyrighted material, contact the Scholarly Communications Office at scholcom@listserv.cc.emory.edu`,
-        'choice': 'no',
-        'name': 'etd[additional_copyrights]'
-      },
-      {
-        'label': 'Patents',
-        'text': `Does your thesis or dissertation disclose or described any inventions or discoveries that could potentially have commerical application and therefore may be patended? If so please contact the Office of Technology Transfer (OTT) at (404) 727-2211.`,
-        'choice': 'no',
-        'name': 'etd[patents]'
-      }]
-    )
+  it('returns the correct embargo length based on the selected school', () => {
+    formStore.setSelectedSchool('emory')
+    expect(formStore.getEmbargoLengths()).toEqual([{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}])
+  })
+
+  it('returns the correct embargo contents', () => {
+    expect(formStore.getEmbargoContents()).toEqual([{ text: 'Files',
+    value: '[:files_embargoed]',
+    disabled: false
+  },
+  { text: 'Files and Table of Contents',
+    value: '[:files_embargoed, :toc_embargoed]',
+    disabled: false
+  },
+  { text: 'Files and Table of Contents and Abstract',
+    value: '[:files_embargoed, :toc_embargoed, :abstract_embargoed]',
+    disabled: false
+  }
+                                                 ])
   })
 })


### PR DESCRIPTION
This commit adds embargoes to the form. When you
select a school, that determines which lengths are
valid for that embargo. If you choose not to have
an embargo the form won't display an option for the
length of the embargo.

Related to #1188