### PR TITLE
CSV report of all PhD records in new ETDs for the academic year 17-18

### DIFF
--- a/lib/tasks/laney_csv_report.rake
+++ b/lib/tasks/laney_csv_report.rake
@@ -1,0 +1,28 @@
+require 'csv'
+
+namespace :emory do
+  desc "csv reports for Laney Graduate School admins"
+
+  task csv_report: [:environment] do
+    puts 'Loading environment...'
+    puts 'Starting export...'
+
+    etds = Etd.where(degree: 'Ph.D.', school: 'Laney Graduate School')
+    academic_year = ['Fall 2017', 'Spring 2018', 'Summer 2018', 'Fall 2018']
+    CSV.open("csv_report.csv", "wb", write_headers: true,
+                                     headers: ["Creator", "Advisor", "Committee Members", "Date", "Program"]) do |csv|
+      etds.each do |etd|
+        creator = etd.creator.to_a
+        chair = etd.committee_chair_name.to_a
+        members = etd.committee_members_names.to_a
+        date =  etd.date_uploaded.to_date
+        program = etd.research_field.to_a
+        puts etd.graduation_year
+        if academic_year.include? etd.graduation_year
+          csv << [creator.first, chair.first, members.first, date, program.first]
+        end
+      end
+    end
+    puts 'export complete.'
+  end
+end


### PR DESCRIPTION
https://waffle.io/emory-libraries/etd-issues/cards/5b1d8d381a0cb5001c524f7e

This rake command generates a csv report that includes the following fields: Author's name, faculty advisor, committee members, date of submission, and student program.

