### PR TITLE
Basic uploading of supplementary files

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -25,6 +25,9 @@
             <div v-else-if="input.label === 'files'">
               <primary-file-uploader></primary-file-uploader>
             </div>
+              <div v-else-if="input.label === 'supplemental-files'">
+              <Supplemental-files></supplemental-files>
+            </div>
             <div v-else-if="input.label === 'Table of Contents'">
               <label>{{ input.label }}</label>
                <quill-editor ref="myTextEditor"
@@ -101,6 +104,7 @@ import CommitteeMember from "./CommitteeMember"
 import PrimaryFileUploader from './PrimaryFileUploader.vue'
 import CopyrightQuestions from './CopyrightQuestions'
 import Embargo from './Embargo'
+import SupplementalFiles from './SupplementalFiles'
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -134,7 +138,8 @@ export default {
     committeeMember: CommitteeMember,
     primaryFileUploader: PrimaryFileUploader,
     copyrightQuestions: CopyrightQuestions,
-    embargo: Embargo
+    embargo: Embargo,
+    SupplementalFiles: SupplementalFiles
   },
   methods: {
     // tabs that have been validated and the current tab are enabled
@@ -198,6 +203,7 @@ export default {
           that.errors = []
           that.errors.push(error.response.data.errors)
         })
+
     }
   }
 }

--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -2,7 +2,7 @@
   <div>
     <label>Department</label>
     <select class="form-control" id="department" v-model="selected">
-      <option v-for="department in sharedState.departments" v-bind:value="department.label" v-bind:key="department.label">
+      <option v-for="department in sharedState.departments" :selected="department.selected" v-bind:value="department.label" v-bind:key="department.label">
         {{ department.label }}
       </option>
     </select>
@@ -17,7 +17,7 @@ import { formStore } from "./formStore";
 export default {
   data() {
     return {
-      selected: "",
+      selected: formStore.getSelectedDepartment(),
       sharedState: formStore
     };
   },

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -20,7 +20,7 @@ export default {
   data() {
     return {
       sharedState: formStore,
-      selected: ''
+      selected: formStore.getSelectedSchool()
     }
   },
   methods: {

--- a/app/javascript/SupplementalFiles.vue
+++ b/app/javascript/SupplementalFiles.vue
@@ -1,11 +1,11 @@
 <template>
     <div>
-        <input name="primary_files[]" type="file" ref="fileInput" @change="onFileChange" accept="application/pdf"/>
+        <input name="supplemental_files[]" type="file" ref="fileInput" @change="onFileChange" accept="application/pdf"/>
         <br>
         <div class="progress">
           <div class="progress-bar" :style="'width:' + progress + '%'" role="progressbar" :aria-valuenow="progress" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
-        <div v-for="files in sharedState.deletablePrimaryFiles" v-bind:key="files[0].deleteUrl">
+        <div v-for="files in sharedState.deletableSupplementalFiles" v-bind:key="files[0].deleteUrl">
             <div v-for="file in files" v-bind:key="file.deleteUrl">
                 {{ file.name }}
                 <a href="#" data-turbolinks="false" @click="deleteFile(file.deleteUrl)">Remove this file</a>
@@ -16,7 +16,6 @@
 
 <script>
 import { formStore } from "./formStore"
-import axios from 'axios'
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -33,14 +32,13 @@ export default {
     onFileChange(e) {
       var files = e.target.files || e.dataTransfer.files
       if (!files.length) return
-
       var xhr = new XMLHttpRequest()
       xhr.upload.addEventListener("progress", this.onprogressHandler, false)
       xhr.open("POST", "/uploads/", true)
       xhr.setRequestHeader("X-CSRF-Token", token)
       xhr.onreadystatechange = () => {
         if (xhr.readyState == XMLHttpRequest.DONE) {
-          formStore.deletablePrimaryFiles.push(
+          this.sharedState.addDeleteableSupplementalFile(
             JSON.parse(xhr.responseText).files
           )
           const input = this.$refs.fileInput
@@ -49,7 +47,6 @@ export default {
         }
       }
       xhr.send(this.getFormData())
-      this.progress = 0
     },
     onprogressHandler(evt) {
       var percent = evt.loaded / evt.total * 100
@@ -61,15 +58,7 @@ export default {
       return formData
     },
     deleteFile(deleteUrl) {
-      var xhr = new XMLHttpRequest()
-      xhr.open("DELETE", deleteUrl, true)
-      xhr.setRequestHeader("X-CSRF-Token", token)
-      xhr.send(null)
-      console.log(deleteUrl)
-      const filteredFiles = this.sharedState.deletablePrimaryFiles.filter(
-        file => file[0].deleteUrl !== deleteUrl
-      )
-      this.sharedState.deletablePrimaryFiles = filteredFiles
+     this.sharedState.deleteSupplementalFile(deleteUrl, token)
     }
   }
 }

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -90,7 +90,8 @@ export var formStore = {
       currentStep: false,
       step: 5,
       inputs: {
-        files: { label: 'files', value: [] }
+        files: { label: 'files', value: [] },
+        supplementalFiles: { label: 'supplemental-files' }
       }
     },
     embargo: {
@@ -161,8 +162,7 @@ export var formStore = {
       {
         text: 'Select a School',
         value: '',
-        disabled: 'disabled',
-        selected: 'selected'
+        disabled: 'disabled'
       },
       { text: 'Candler School of Theology', value: 'candler' },
       { text: 'Emory College', value: 'emory' },
@@ -192,6 +192,26 @@ export var formStore = {
       {value: '1 year'}, {value: '2 Years'}, {value: '6 years'}],
     rollins: [{value: 'None - open access immediately', selected: 'selected'},
       {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}]
+  },
+  token: 'gokeoge',
+  deletableSupplementalFiles: [],
+  addDeleteableSupplementalFile (deletableFile) {
+    this.deletableSupplementalFiles.push(deletableFile)
+  },
+  getDeleteableSupplementalFiles () {
+    return this.deletableSupplementalFiles
+  },
+  deleteSupplementalFile (deleteUrl, token) {
+    const filteredFiles = this.deletableSupplementalFiles.filter(
+      file => file.deleteUrl !== deleteUrl
+    )
+    this.deletableSupplementalFiles = filteredFiles
+
+    axios.defaults.headers.common['X-CSRF-Token'] = token
+    axios.delete(deleteUrl).then((response) => {
+    }, (error) => {
+      console.log('Error deleting file from the server')
+    })
   },
   clearSubfields () {
     this.subfields = []

--- a/app/javascript/test/SupplementalFiles.spec.js
+++ b/app/javascript/test/SupplementalFiles.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import SupplementalFiles from 'SupplementalFiles'
+
+describe('SupplmentalFiles.vue', () => {
+  it('has the correct html', () => {
+    const wrapper = shallowMount(SupplementalFiles, {
+    })
+    expect(wrapper.html()).toContain('<div><input name="supplemental_files[]" type="file" accept="application/pdf"> <br> <div class="progress"><div role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" class="progress-bar" style="width: 0%;"></div></div> </div>')
+  })
+})

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -1,9 +1,9 @@
 /* global describe */
 /* global it */
 /* global expect */
-
+import axios from 'axios'
 import { formStore } from '../formStore'
-
+jest.mock('axios')
 describe('formStore', () => {
   it('returns the correct embargo length based on the selected school', () => {
     formStore.setSelectedSchool('emory')
@@ -13,17 +13,37 @@ describe('formStore', () => {
 
   it('returns the correct embargo contents', () => {
     expect(formStore.getEmbargoContents()).toEqual([{ text: 'Files',
-    value: '[:files_embargoed]',
-    disabled: false
-  },
-  { text: 'Files and Table of Contents',
-    value: '[:files_embargoed, :toc_embargoed]',
-    disabled: false
-  },
-  { text: 'Files and Table of Contents and Abstract',
-    value: '[:files_embargoed, :toc_embargoed, :abstract_embargoed]',
-    disabled: false
-  }
-                                                 ])
+      value: '[:files_embargoed]',
+      disabled: false
+    },
+    { text: 'Files and Table of Contents',
+      value: '[:files_embargoed, :toc_embargoed]',
+      disabled: false
+    },
+    { text: 'Files and Table of Contents and Abstract',
+      value: '[:files_embargoed, :toc_embargoed, :abstract_embargoed]',
+      disabled: false
+    }
+    ])
+  })
+
+  it('can add and return all the deletable supplemental files', () => {
+    const deletableFile = { deleteType: 'DELETE',
+      deleteUrl: '/uploads/2?locale=en',
+      id: 2,
+      name: 'sample.pdf',
+      size: 19971 }
+
+    formStore.addDeleteableSupplementalFile(deletableFile)
+    expect(formStore.getDeleteableSupplementalFiles()).toEqual([deletableFile])
+  })
+
+  it('can delete a file from the supplemental files', () => {
+    const resp = {data: ['']}
+    axios.delete.mockResolvedValue(resp)
+    const deleteUrl = formStore.deletableSupplementalFiles[0].deleteUrl
+    expect(deleteUrl).toEqual('/uploads/2?locale=en')
+    formStore.deleteSupplementalFile(deleteUrl, 'token')
+    expect(formStore.deletableSupplementalFiles.length).toEqual(0)
   })
 })


### PR DESCRIPTION
This commit adds basic supplementary file
functionality. It doesn't include the metadata
inputs needed for the form. Those will need to be
added later.

Right now the delete action for the supplementary files
isn't working correctly (I assume that there is a different
controller that deletes those files?)

This also changes some of the state management for drop-downs
in the form. Select boxes need to be handled a little bit
differently than the other input components.