### PR TITLE
Fix deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
-
 Rails.application.load_tasks
 
 require 'solr_wrapper/rake_task' unless Rails.env.production?

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,14 +11,18 @@ default: &default
 
 development:
   <<: *default
-  database: laevigata_development
+  database: <%= ENV['DATABASE_NAME'] || 'laevigata_development' %>
+  username: <%= ENV['DATABASE_USERNAME'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: laevigata_test
+  database: <%= ENV['DATABASE_NAME'] || 'laevigata_test' %>
+  username: <%= ENV['DATABASE_USERNAME'] %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
 
 production:
   adapter:  'postgresql'

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,7 @@ test:
   database: laevigata_test
 
 production:
+  adapter:  'postgresql'
   database: <%= ENV['DATABASE_NAME'] %>
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -12,49 +12,49 @@ unless Rails.env.production?
     check_style if test_suite == "style"
     ci_with_infrastructure(test_suite) unless test_suite == "style"
   end
-end
 
-def ci_with_infrastructure(test_suite)
-  ENV["environment"] = "test"
-  solr_params = {
-    port: 8985,
-    verbose: true,
-    managed: true
-  }
-  fcrepo_params = {
-    port: 8986,
-    verbose: true,
-    managed: true,
-    enable_jms: false,
-    fcrepo_home_dir: 'tmp/fcrepo4-test-data'
-  }
-  SolrWrapper.wrap(solr_params) do |solr|
-    solr.with_collection(
-      name: "hydra-test",
-      persist: false,
-      dir: Rails.root.join("solr", "config")
-    ) do
-      FcrepoWrapper.wrap(fcrepo_params) do
-        Rake::Task[test_suite].invoke
+  def ci_with_infrastructure(test_suite)
+    ENV["environment"] = "test"
+    solr_params = {
+      port: 8985,
+      verbose: true,
+      managed: true
+    }
+    fcrepo_params = {
+      port: 8986,
+      verbose: true,
+      managed: true,
+      enable_jms: false,
+      fcrepo_home_dir: 'tmp/fcrepo4-test-data'
+    }
+    SolrWrapper.wrap(solr_params) do |solr|
+      solr.with_collection(
+        name: "hydra-test",
+        persist: false,
+        dir: Rails.root.join("solr", "config")
+      ) do
+        FcrepoWrapper.wrap(fcrepo_params) do
+          Rake::Task[test_suite].invoke
+        end
       end
     end
+    # Rake::Task["doc"].invoke
   end
-  # Rake::Task["doc"].invoke
-end
 
-RSpec::Core::RakeTask.new(:integration) do |t|
-  t.rspec_opts = "--tag integration --profile"
-end
+  RSpec::Core::RakeTask.new(:integration) do |t|
+    t.rspec_opts = "--tag integration --profile"
+  end
 
-RSpec::Core::RakeTask.new(:unit) do |t|
-  t.rspec_opts = "--tag ~integration --profile"
-end
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.rspec_opts = "--tag ~integration --profile"
+  end
 
-desc "Run js tests"
-task :js do
-  sh "yarn test"
-end
+  desc "Run js tests"
+  task :js do
+    sh "yarn test"
+  end
 
-def check_style
-  sh "bundle exec rubocop"
+  def check_style
+    sh "bundle exec rubocop"
+  end
 end


### PR DESCRIPTION
Both of these changes are necessary to fix our capistrano deploy.

1. Wrap entire CI task in a block that excludes it from production (because rspec etc aren't installed in production)
2. Explicitly declare the database adapter for production. Not sure why this is necessary, but it's probably a good idea since we wouldn't want to accidentally override our production database adapater.