### PR TITLE
replace parameter in signature of method

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -50,8 +50,8 @@ class InProgressEtdsController < ApplicationController
       etd.fetch(:currentTab, "About Me")
     end
 
-    def prepare_etd_data
-      # TODO: we need to use the json data we have if we have any
+    def prepare_etd_data(_saved_data)
+      # TODO: we need to use the _saved_data we have if we have any
       etd = request.parameters.fetch(:etd)
       prepare_committee_data(etd)
       add_supplemental_file_data(etd)


### PR DESCRIPTION
This commit replaces a parameter we do not yet use in the method, but call it with, a bug introduced recently.