### PR TITLE
disabling clicks on disabled tabs

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -2,7 +2,7 @@
   <div>
     <ul class="nav navtabs">
       <li v-for="(value,index) in form.tabs" v-bind:key="value.label">
-        <a href="#" data-turbolinks="false" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label)">{{ value.label }}</a>
+        <a href="#" data-turbolinks="false" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}</a>
       </li>
     </ul>
     <form role="form" id="vue_form" action="/concern/etds/new" method="post" @submit.prevent="onSubmit">
@@ -144,7 +144,7 @@ export default {
       var el = document.getElementById('saved_data');
       // when the load this form the first time, there will not be
       // any data in the data- attribute, therefore, pass empty
-      // hash rather than undefined. 
+      // hash rather than undefined.
       var savedData = {}
       if (el && el.hasAttribute("data-in-progress-etd")){
         savedData = JSON.parse(el.dataset.inProgressEtd);
@@ -168,12 +168,15 @@ export default {
         }
       }
     },
-    setCurrentStep(tab_label){
-      for (var tab in this.form.tabs){
-        if (this.form.tabs[tab].label == tab_label){
-          this.form.tabs[tab].currentStep = true
-        } else {
-          this.form.tabs[tab].currentStep = false
+    setCurrentStep(tab_label, event){
+      // display current tab unless click comes from disabled tab
+      if (!event.target.classList.contains("disabled")){
+        for (var tab in this.form.tabs){
+          if (this.form.tabs[tab].label == tab_label){
+            this.form.tabs[tab].currentStep = true
+          } else {
+            this.form.tabs[tab].currentStep = false
+          }
         }
       }
     },

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -12,6 +12,28 @@ describe('App.vue', () => {
   })
 
   describe('Tab Navigation', () => {
+    beforeEach(() => {
+      const wrapper = shallowMount(App, {
+      })
+      wrapper.vm.$data.form.tabs.about_me.complete = false
+      wrapper.vm.$data.form.tabs.my_program.complete = false
+      wrapper.vm.$data.form.tabs.my_advisor.complete = false
+      wrapper.vm.$data.form.tabs.my_etd.complete = false
+      wrapper.vm.$data.form.tabs.keywords.complete = false
+      wrapper.vm.$data.form.tabs.my_files.complete = false
+      wrapper.vm.$data.form.tabs.embargo.complete = false
+
+      wrapper.vm.$data.form.tabs.about_me.currentStep = true
+      wrapper.vm.$data.form.tabs.my_program.currentStep = false
+      wrapper.vm.$data.form.tabs.my_advisor.currentStep = false
+      wrapper.vm.$data.form.tabs.my_etd.currentStep = false
+      wrapper.vm.$data.form.tabs.keywords.currentStep = false
+      wrapper.vm.$data.form.tabs.my_files.currentStep = false
+      wrapper.vm.$data.form.tabs.embargo.currentStep = false
+
+      wrapper.vm.enableTabs()
+    });
+
     it('enables the completed and current tabs', () => {
       const wrapper = shallowMount(App, {
       })
@@ -37,9 +59,17 @@ describe('App.vue', () => {
     it('sets the current tab property', () => {
       const wrapper = shallowMount(App, {
       })
-      wrapper.vm.setCurrentStep('My Advisor')
+      // user has completed About Me tab, and My Program is current tab
+      wrapper.vm.$data.form.tabs.about_me.complete = true
+      wrapper.vm.$data.form.tabs.about_me.currentStep = false
+      wrapper.vm.$data.form.tabs.my_program.currentStep = true
+      wrapper.vm.enableTabs()
+      expect(wrapper.vm.$data.form.tabs.about_me.currentStep).toBe(false)
 
-      expect(wrapper.vm.$data.form.tabs.my_advisor.currentStep).toBe(true)
+      //find and click first tab
+      wrapper.find('a.tab').trigger('click')
+
+      expect(wrapper.vm.$data.form.tabs.about_me.currentStep).toBe(true)
     })
 
     it('determines the next current tab', () => {
@@ -48,6 +78,15 @@ describe('App.vue', () => {
       wrapper.vm.nextStepIsCurrent(3)
 
       expect(wrapper.vm.$data.form.tabs.keywords.currentStep).toBe(true)
+    })
+
+    it('prevents a user from navigating to disabled tabs', () => {
+      const wrapper = shallowMount(App, {
+      })
+      //find and click first disabled element (My Program)
+      wrapper.find('a.tab.disabled').trigger('click')
+
+      expect(wrapper.find('h1').text()).toBe('About Me');
     })
   })
 })


### PR DESCRIPTION
Users should not be able to navigate to disabled tabs, and this commit prevents them from doing so. Addresses #1302 