### PR TITLE
Story #1191: Make the committee members fields work with the new UI.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,10 @@ Layout/MultilineHashBraceLayout:
   Exclude:
     - 'spec/controllers/hyrax/etds_controller_spec.rb'
 
+Layout/IndentHash:
+  Exclude:
+    - 'spec/models/in_progress_etd_spec.rb'
+
 Lint/Void:
   Enabled: false
 
@@ -89,6 +93,10 @@ RSpec/MessageSpies:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+Style/BracesAroundHashParameters:
+  Exclude:
+    - 'spec/models/in_progress_etd_spec.rb'
 
 Style/CommentAnnotation:
   Enabled: false

--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -8,7 +8,7 @@ class InProgressEtdsController < ApplicationController
   # TODO: this needs to be authorized
   def create
     @in_progress_etd = InProgressEtd.find_by(user_ppid: current_user.id)
-    @in_progress_etd.data = prepare_etd_data(@in_progress_etd).to_json
+    @in_progress_etd.data = prepare_etd_data.to_json
 
     if @in_progress_etd.save
       # TODO: we'll want all the json data sent back
@@ -34,8 +34,9 @@ class InProgressEtdsController < ApplicationController
 
   def show
     @in_progress_etd = InProgressEtd.find(params[:id])
-    @etd = InProgressEtd.find(params[:id]).data
-    @uploaded_files = ["1"] # @etd['uploaded_files']
+
+    # @uploaded_files = ["1"] # JSON.parse(@in_progress_etd.data)['uploaded_files']
+    # @uploaded_files = []
   end
 
   private
@@ -50,30 +51,20 @@ class InProgressEtdsController < ApplicationController
       etd.fetch(:currentTab, "About Me")
     end
 
-    def prepare_etd_data(_saved_data)
-      # TODO: we need to use the _saved_data we have if we have any
-      etd = request.parameters.fetch(:etd)
-      prepare_committee_data(etd)
-      add_supplemental_file_data(etd)
+    def prepare_etd_data
+      new_data = request.parameters.fetch(:etd, {})
+
+      # Add temporarily hard-coded data into the new data
+      # TODO: Replace the hard-coded data with real data from the form
+      add_supplemental_file_data(new_data)
       # uploaded_files = Hyrax::UploadedFile.id
-      # add_uploaded_file_data(etd)
-      add_agreement_data(etd)
-      add_embargo_data(etd)
-      add_school_department_subfield(etd)
-      etd
-    end
+      # add_uploaded_file_data(new_data)
+      add_agreement_data(new_data)
+      add_embargo_data(new_data)
+      add_school_department_subfield(new_data)
 
-    def prepare_committee_data(etd)
-      # use real names; check what type of nested_id is needed.
-      etd["committee_chair_attributes"] = { "0" => {
-        "affiliation_type" => "Emory Committee Chair", "name" => ["Curie, Marie"],
-        "id" => "#nested_g70334968021140"
-      }, "1" => { "affiliation_type" =>
-        "Emory Committee Chair", "name" => [""] } }
-
-      etd["committee_members_attributes"] = { "0" =>
-      { "affiliation_type" => "Non-Emory Committee Member", "affiliation" => ["NASA"],
-        "name" => ["Maher, Valerie"], "id" => "#nested_g70334919944200" } }
+      # Add the new data to the existing persisted data
+      @in_progress_etd.add_data(new_data)
     end
 
     # TODO: Get each of these from the form

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -53,7 +53,7 @@ module Hyrax
       end
 
       def self.my_advisor_terms
-        [:committee_member_attributes, :committee_chair_attributes]
+        [:committee_members_attributes, :committee_chair_attributes]
       end
 
       def self.keyword_terms

--- a/app/helpers/etd_form_helper.rb
+++ b/app/helpers/etd_form_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module EtdFormHelper
+  def summarize_committee_member(label, attrs_hash)
+    content_tag :p do
+      content_tag(:b, label) +
+        ": #{attrs_hash['name'].first} (#{attrs_hash['affiliation'].first})"
+    end
+  end
+end

--- a/app/javascript/CommitteeMember.vue
+++ b/app/javascript/CommitteeMember.vue
@@ -81,13 +81,13 @@ export default {
         return `etd[committee_chair_attributes][${chair.id}][affiliation_type]`
       },
       memberNameAttr(member) {
-          return `etd[committee_member_attributes][${member.id}][name][]`
+          return `etd[committee_members_attributes][${member.id}][name][]`
       },
       memberAffiliationAttr(member) {
-          return `etd[committee_member_attributes][${member.id}][affiliation][]`
+          return `etd[committee_members_attributes][${member.id}][affiliation][]`
       },
       memberAffiliationTypeAttr(member) {
-        return `etd[committee_member_attributes][${member.id}][affiliation_type]`
+        return `etd[committee_members_attributes][${member.id}][affiliation_type]`
       }
   },
   watch: {

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -6,4 +6,16 @@ class InProgressEtd < ApplicationRecord
   validates_with MyAdvisorValidator
   validates_with KeywordValidator
   validates_with EmbargoValidator
+
+  # @param new_data [Hash, HashWithIndifferentAccess] New data to add to the existing data store.
+  # @return [Hash] The resulting hash, with new data added to old data.
+  def add_data(new_data)
+    json_data = data || {}.to_json
+    existing_data = JSON.parse(json_data)
+    return existing_data unless new_data
+
+    resulting_data = existing_data.merge(new_data)
+    self.data = resulting_data.to_json
+    resulting_data
+  end
 end

--- a/app/views/in_progress_etds/show.html.erb
+++ b/app/views/in_progress_etds/show.html.erb
@@ -6,16 +6,27 @@
     </ul>
     <%= link_to('Edit', edit_in_progress_etd_path(@in_progress_etd)) %>
 
-    <% in_progress_etd = @etd %>
+    <% etd_attrs = @in_progress_etd.data ? JSON.parse(@in_progress_etd.data) : {} %>
+    <% chair_attrs = etd_attrs.delete('committee_chair_attributes') || [] %>
+    <% member_attrs = etd_attrs.delete('committee_members_attributes') || [] %>
 
-    <form role="form" id="etd_form" action="/concern/etds/new" method="post">
-      <% JSON.parse(in_progress_etd).each do |k, v| %>
-      <p><b><%= k %>:</b> <%= v %></p>
-
-      <input type='hidden' id="etd" name="etd[<%= k %>]" value="<%= v %>"/>
+    <form role="form" id="etd_form" action="/concern/etds" method="post">
+      <% etd_attrs.each do |k, v| %>
+        <p><b><%= k %>:</b> <%= v %></p>
+        <input type='hidden' id="etd" name="etd[<%= k %>]" value="<%= v %>"/>
       <% end %>
 
-      <input type='hidden' id="files" name='uploaded_files[]' value="1"/>
+      <% chair_attrs.each do |i, chair| %>
+        <%= summarize_committee_member('Committee Chair', chair) %>
+        <input type='hidden' name="etd[committee_chair_attributes][<%= i %>][name][]" value="<%= chair['name'] %>"/>
+        <input type='hidden' name="etd[committee_chair_attributes][<%= i %>][affiliation][]" value="<%= chair['affiliation'] %>"/>
+      <% end %>
+
+      <% member_attrs.each do |i, member| %>
+        <%= summarize_committee_member('Committee Member', member) %>
+        <input type='hidden' name="etd[committee_members_attributes][<%= i %>][name][]" value="<%= member['name'] %>"/>
+        <input type='hidden' name="etd[committee_members_attributes][<%= i %>][affiliation][]" value="<%= member['affiliation'] %>"/>
+      <% end %>
     </form>
 
     <div id='submit-etd'>

--- a/spec/helpers/etd_form_helper_spec.rb
+++ b/spec/helpers/etd_form_helper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe EtdFormHelper do
+  describe '#summarize_committee_member' do
+    subject(:summary) {
+      summarize_committee_member(label, attrs)
+    }
+
+    let(:label) { 'My Committee Member' }
+    let(:attrs) {
+      { 'name' => ['Professor Martin'],
+        'affiliation' => ['Emory University'] }
+    }
+
+    it 'returns the displayable summary' do
+      expect(summary).to match(/\A.*My Committee Member.*Professor Martin \(Emory University\).*\Z/)
+    end
+  end
+end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -61,7 +61,7 @@ describe InProgressEtd do
     # TODO: align with committee front end if it changes, which it is likely to
     context "with valid data" do
       let(:data) do
-        { currentTab: "My Advisor", "committee_member_attributes": ["member_info"], "committee_chair_attributes": ["chair_info"] }
+        { currentTab: "My Advisor", "committee_members_attributes": ["member_info"], "committee_chair_attributes": ["chair_info"] }
       end
 
       it "is valid" do
@@ -133,6 +133,86 @@ describe InProgressEtd do
 
     it "is valid" do
       expect(in_progress_etd).to be_valid
+    end
+  end
+
+  describe '#add_data' do
+    let(:in_progress_etd) { described_class.new(data: old_data.to_json) }
+
+    let(:old_data) { { 'title': 'The Old Title' } }
+    let(:new_data) { nil }
+    let(:resulting_data) { JSON.parse(in_progress_etd.data) } # in-memory data
+    let(:return_value) { in_progress_etd.add_data(new_data) }
+
+    before { return_value } # Call the method
+
+    context 'with new data' do
+      let(:new_data) { { 'creator': 'A Student' } }
+
+      it 'adds the new data to the old data' do
+        expect(resulting_data).to eq({
+          'title' => 'The Old Title',
+          'creator' => 'A Student'
+        })
+      end
+    end
+
+    context 'with updated data' do
+      let(:new_data) { { 'title': 'The New Title' } }
+      it 'changes the existing data' do
+        expect(resulting_data).to eq({
+          'title' => 'The New Title'
+        })
+      end
+    end
+
+    context 'with updated data (symbol vs string keys)' do
+      let(:old_data) { { title: 'The Old Title' } }
+      let(:new_data) { { 'title': 'The New Title' } }
+
+      it 'changes the existing data without duplicating data' do
+        expect(resulting_data).to eq({
+          'title' => 'The New Title'
+        })
+      end
+    end
+
+    context 'with no new data' do
+      let(:new_data) { {} }
+
+      it 'keeps the old data' do
+        expect(resulting_data).to eq({
+          'title' => 'The Old Title'
+        })
+      end
+    end
+
+    context 'with nil (but existing data)' do
+      let(:new_data) { nil }
+
+      it 'keeps the old data' do
+        expect(resulting_data).to eq({
+          'title' => 'The Old Title'
+        })
+      end
+    end
+
+    context 'with nil new data (and nil existing data)' do
+      let(:in_progress_etd) { described_class.new } # data field is nil
+      let(:new_data) { nil }
+
+      it 'returns empty hash' do
+        expect(return_value).to eq({})
+      end
+    end
+
+    context 'with no new data (and no existing data)' do
+      let(:in_progress_etd) { described_class.new } # data field is nil
+      let(:new_data) { {} }
+
+      it 'returns empty hash' do
+        expect(resulting_data).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
I added a method to the model that allows you to add new data to the
existing JSON data store.  This method will be used in the controller,
and will eventually replace all the temporarily hard-coded data in the
controller.

The form to create an Etd record from an InProgressEtd record uses
Rails-style nested attribute fields committee_chair_attributes and
committee_members_attributes.  I fixed the spelling of
committee_members_attributes in some places in the code.