### PR TITLE
Use a local actor instead of overriding `InterpretVisibilityActor`

### DIFF
--- a/app/actors/hyrax/actors/laevigata_embargo.rb
+++ b/app/actors/hyrax/actors/laevigata_embargo.rb
@@ -2,7 +2,7 @@
 # differ from the usual Hyrax behavior
 module Hyrax
   module Actors
-    class InterpretVisibilityActor < AbstractActor
+    class LaevigataEmbargo < AbstractActor
       attr_accessor :curation_concern
 
       def create(attributes)

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -273,3 +273,4 @@ module Hyrax
 end
 
 Hyrax::CurationConcern.actor_factory.insert_after(Hyrax::Actors::TransactionalRequest, PrimaryFileTitleActor)
+Hyrax::CurationConcern.actor_factory.swap(Hyrax::Actors::InterpretVisibilityActor, Hyrax::Actors::LaevigataEmbargo)

--- a/spec/actors/hyrax/actors/laevigata_embargo_spec.rb
+++ b/spec/actors/hyrax/actors/laevigata_embargo_spec.rb
@@ -1,14 +1,13 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
 
-describe Hyrax::Actors::InterpretVisibilityActor do
+describe Hyrax::Actors::LaevigataEmbargo do
   subject(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
       middleware.use described_class
     end
     stack.build(terminator)
   end
+
   let(:user) { create(:user) }
   let(:ability) { ::Ability.new(user) }
   let(:etd) { FactoryBot.create(:etd) }


### PR DESCRIPTION
Creates a local `LaevigataEmbargo` actor to replace the monkeypatch on
`InterpretVisibilityActor`. This is just a rename & replace of the existing
actor, but opens us up to dropping the override entirely.

Connected to #430.