### PR TITLE
Restart apache after a capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -51,3 +51,14 @@ namespace :sidekiq do
     end
   end
 end
+
+# Capistrano passenger restart isn't working consistently,
+# so restart apache2 after a successful deploy, to ensure
+# changes are picked up.
+namespace :deploy do
+  after :finishing, :restart_apache do
+    on roles(:app) do
+      execute :sudo, :systemctl, :restart, :apache2
+    end
+  end
+end


### PR DESCRIPTION
Capistrano passenger restart isn't working consistently,
so restart apache2 after a successful deploy, to ensure
changes are picked up.