### PR TITLE
Update and test `CreateWithRemoteFilesActor`

### DIFF
--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -85,7 +85,8 @@ module Hyrax
         # @param [FileSet] fs
         # @param [Work] curation_concern
         def apply_saved_metadata(fs, curation_concern)
-          uf = ::Hyrax::UploadedFile.where(browse_everything_url: fs.import_url).first
+          uf = ::Hyrax::UploadedFile.find_by(browse_everything_url: fs.import_url)
+
           if uf&.pcdm_use == ::FileSet::PRIMARY
             fs.pcdm_use = ::FileSet::PRIMARY
             fs.title = curation_concern.title
@@ -95,7 +96,6 @@ module Hyrax
             fs.description = Array.wrap(uf&.description)
             fs.file_type = uf&.file_type
           end
-          fs.save
         end
 
         def operation_for(user:)

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -4,26 +4,14 @@ module Hyrax
     class CreateWithRemoteFilesActor < Hyrax::Actors::AbstractActor
       attr_accessor :curation_concern
 
-      def create(attributes)
-        if attributes.is_a? Hyrax::Actors::Environment
-          env                   = attributes
-          attributes            = env.attributes
-          self.curation_concern = env.curation_concern
-        end
-
-        remote_files = attributes.delete(:remote_files)
-        next_actor.create(env) && attach_files(remote_files)
+      def create(env)
+        remote_files = env.attributes.delete(:remote_files)
+        next_actor.create(env) && attach_files(env, remote_files)
       end
 
-      def update(attributes)
-        if attributes.is_a? Hyrax::Actors::Environment
-          env                   = attributes
-          attributes            = env.attributes
-          self.curation_concern = env.curation_concern
-        end
-
-        remote_files = attributes.delete(:remote_files)
-        next_actor.update(env) && attach_files(remote_files)
+      def update(env)
+        remote_files = env.attributes.delete(:remote_files)
+        next_actor.update(env) && attach_files(env, remote_files)
       end
 
       def self.needs_attr_accessible?
@@ -32,31 +20,57 @@ module Hyrax
 
       protected
 
+        def whitelisted_ingest_dirs
+          Hyrax.config.whitelisted_ingest_dirs
+        end
+
+        # @param uri [URI] the uri fo the resource to import
+        def validate_remote_url(uri)
+          if uri.scheme == 'file'
+            path = File.absolute_path(CGI.unescape(uri.path))
+            whitelisted_ingest_dirs.any? do |dir|
+              path.start_with?(dir) && path.length > dir.length
+            end
+          else
+            # TODO: It might be a good idea to validate other URLs as well.
+            #       The server can probably access URLs the user can't.
+            true
+          end
+        end
+
         # @param [HashWithIndifferentAccess] remote_files
         # @return [TrueClass]
-        def attach_files(remote_files)
+        def attach_files(env, remote_files)
           return true unless remote_files
           remote_files.each do |file_info|
             next if file_info.blank? || file_info[:url].blank?
-            create_file_from_url(file_info[:url], file_info[:file_name])
+            # Escape any space characters, so that this is a legal URI
+            uri = URI.parse(Addressable::URI.escape(file_info[:url]))
+            unless validate_remote_url(uri)
+              Rails.logger.error "User #{env.user.user_key} attempted to ingest file from url #{file_info[:url]}, which doesn't pass validation"
+              return false
+            end
+            auth_header = file_info.fetch(:auth_header, {})
+            create_file_from_url(env, uri, file_info[:file_name], auth_header)
           end
           true
         end
 
         # Generic utility for creating FileSet from a URL
         # Used in to import files using URLs from a file picker like browse_everything
-        def create_file_from_url(url, file_name)
-          ::FileSet.new(import_url: url, label: file_name) do |fs|
-            actor = Hyrax::Actors::FileSetActor.new(fs, user)
-            actor.create_metadata(visibility: curation_concern.visibility)
-            actor.attach_file_to_work(curation_concern)
-            apply_saved_metadata(fs, curation_concern)
+        def create_file_from_url(env, uri, file_name, _auth_header = {})
+          ::FileSet.new(import_url: uri.to_s, label: file_name) do |fs|
+            actor = Hyrax::Actors::FileSetActor.new(fs, env.user)
+            actor.create_metadata(visibility: env.curation_concern.visibility)
+            actor.attach_to_work(env.curation_concern)
+            apply_saved_metadata(fs, env.curation_concern)
             fs.save!
-            uri = URI.parse(URI.encode(url))
             if uri.scheme == 'file'
-              IngestLocalFileJob.perform_later(fs, URI.decode(uri.path), user)
+              # Turn any %20 into spaces.
+              file_path = CGI.unescape(uri.path)
+              IngestLocalFileJob.perform_later(fs, file_path, env.user)
             else
-              ImportUrlJob.perform_later(fs, operation_for(user: user))
+              ImportUrlJob.perform_later(fs, operation_for(user: actor.user))
             end
           end
         end
@@ -72,14 +86,14 @@ module Hyrax
         # @param [Work] curation_concern
         def apply_saved_metadata(fs, curation_concern)
           uf = ::Hyrax::UploadedFile.where(browse_everything_url: fs.import_url).first
-          if uf.pcdm_use == ::FileSet::PRIMARY
+          if uf&.pcdm_use == ::FileSet::PRIMARY
             fs.pcdm_use = ::FileSet::PRIMARY
             fs.title = curation_concern.title
           else
             fs.pcdm_use = ::FileSet::SUPPLEMENTAL
-            fs.title = Array.wrap(uf.title)
-            fs.description = Array.wrap(uf.description)
-            fs.file_type = uf.file_type
+            fs.title = Array.wrap(uf&.title)
+            fs.description = Array.wrap(uf&.description)
+            fs.file_type = uf&.file_type
           end
           fs.save
         end

--- a/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Hyrax::Actors::CreateWithRemoteFilesActor do
+describe Hyrax::Actors::CreateWithRemoteFilesActor, :clean do
   subject(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
       middleware.use described_class
@@ -8,25 +8,49 @@ describe Hyrax::Actors::CreateWithRemoteFilesActor do
     stack.build(terminator)
   end
 
-  let(:ability)    { ::Ability.new(FactoryBot.create(:user)) }
+  let(:ability)    { ::Ability.new(user) }
   let(:attributes) { {} }
   let(:etd)        { FactoryBot.build(:etd) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user)       { FactoryBot.create(:user) }
   let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
 
   describe '#create' do
     it 'is not an error' do
-      expect { middleware.update(env) }.not_to raise_error
+      expect { middleware.create(env) }.not_to raise_error
     end
 
     context 'with a remote file' do
       let(:attributes) do
-        { remote_files: [{ url: 'http://example.com/moomin.pdf',
-                           file_name: 'moomin.pdf' }] }
+        { remote_files: [{ url: import_url, file_name: 'moomin.pdf' },
+                         { url: supplement_url, file_name: 'supplement.csv' }] }
       end
 
-      it do
-        expect { middleware.update(env) }.not_to raise_error
+      let(:import_url)     { 'http://example.com/moomin.pdf' }
+      let(:supplement_url) { 'http://example.com/supplement.csv' }
+
+      before do
+        FactoryBot.create :remote_uploaded_file,
+                          browse_everything_url: import_url,
+                          user_id: user.id,
+                          pcdm_use: FileSet::PRIMARY
+
+        FactoryBot.create :remote_uploaded_file,
+                          browse_everything_url: supplement_url,
+                          user_id: user.id,
+                          pcdm_use: FileSet::SUPPLEMENTARY
+      end
+
+      it 'attaches a file' do
+        expect { middleware.create(env) }
+          .to change { etd.file_sets.map(&:import_url) }
+          .to contain_exactly(import_url, supplement_url)
+      end
+
+      it 'sets pcdm_use' do
+        expect { middleware.create(env) }
+          .to change { etd.file_sets.map(&:pcdm_use) }
+          .to contain_exactly(FileSet::SUPPLEMENTARY, FileSet::PRIMARY)
       end
     end
   end

--- a/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
+++ b/spec/actors/hyrax/actors/create_with_remote_files_actor_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe Hyrax::Actors::CreateWithRemoteFilesActor do
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  let(:ability)    { ::Ability.new(FactoryBot.create(:user)) }
+  let(:attributes) { {} }
+  let(:etd)        { FactoryBot.build(:etd) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
+
+  describe '#create' do
+    it 'is not an error' do
+      expect { middleware.update(env) }.not_to raise_error
+    end
+
+    context 'with a remote file' do
+      let(:attributes) do
+        { remote_files: [{ url: 'http://example.com/moomin.pdf',
+                           file_name: 'moomin.pdf' }] }
+      end
+
+      it do
+        expect { middleware.update(env) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#update' do
+    it 'is not an error' do
+      expect { middleware.update(env) }.not_to raise_error
+    end
+  end
+
+  describe '#destroy' do
+    it 'is not an error' do
+      expect { middleware.destroy(env) }.not_to raise_error
+    end
+  end
+end

--- a/spec/factories/uploaded_file.rb
+++ b/spec/factories/uploaded_file.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
 
     factory :primary_uploaded_file, traits: [:primary]
 
+    factory :remote_uploaded_file do
+      browse_everything_url 'http://example.com/remote/file.pdf'
+    end
+
     factory :supplementary_uploaded_file, traits: [:supplementary] do
       file { Rack::Test::UploadedFile.new("#{::Rails.root}/spec/fixtures/miranda/image.tif") }
       description { 'Description of the supplementary file' }


### PR DESCRIPTION
This actor is modified from the Hyrax version. It has previously been untested,
and was significantly out of date. The status quo would have failed anytime a
remote file was sent to the Actor Stack. This updates the actor to reflect
changes in the Hyrax version and puts in rudimenary testing.