### PR TITLE
Use update route for updating InProgressEtd record.  Part of story #1285

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -5,7 +5,7 @@
         <a href="#" data-turbolinks="false" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}</a>
       </li>
     </ul>
-    <form role="form" id="vue_form" action="/concern/etds/new" method="post" @submit.prevent="onSubmit">
+    <form role="form" id="vue_form" :action="form.getUpdateRoute()" method="patch" @submit.prevent="onSubmit">
       <div v-for="value in form.tabs" v-bind:key="value.label">
         <div class="tab-content form-group" v-if="value.currentStep">
           <h1> {{ value.label }} </h1>

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -9,7 +9,7 @@ export default class SaveAndSubmit {
   }
   saveTab(){
     axios
-      .post("/in_progress_etds", this.formData, {
+      .patch(this.formStore.getUpdateRoute(), this.formData, {
         config: { headers: { "Content-Type": "multipart/form-data" } }
       })
       .then(response => {
@@ -26,8 +26,7 @@ export default class SaveAndSubmit {
       })
   }
   reviewTabs(){
-    //TODO: will this always be 1? confirm
-    axios.get('/in_progress_etds/7', { config: { headers: { "Content-Type": "application/json" } } })
+    axios.get(this.formStore.getUpdateRoute(), { config: { headers: { "Content-Type": "application/json" } } })
     .then(response => {
       this.formStore.showSavedData(response.data)
       // for now fake that user got here naturally
@@ -41,8 +40,7 @@ export default class SaveAndSubmit {
   }
   submitEtd(){
     // TODO: change text of submit button to say submit for publication
-    // TODO: use real in_progress_etds/id: 1? confirm
-    axios.get('/in_progress_etds/7', { config: { headers: { "Content-Type": "application/json" } } })
+    axios.get(this.formStore.getUpdateRoute(), { config: { headers: { "Content-Type": "application/json" } } })
     .then(response => {
       document.getElementById('saved_data').dataset.in_progress_etd = response.data
       // populate form in order to use its inputs

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -114,6 +114,15 @@ export var formStore = {
       fields: {}
     }
   },
+  // The ID of the InProgressEtd record that we are editing (relational database ID).
+  // This will help us build the URL for the form submit.
+  ipeId: '',
+  setIpeId(id){
+    this.ipeId = id;
+  },
+  getUpdateRoute(){
+    return `/in_progress_etds/${this.ipeId}`
+  },
   copyrightQuestions: [{
     'label': 'Fair Use',
     'text': `Does your thesis or dissertation contain any thirdy-party text, audiovisual content or other material which is beyond a fair use and would require permission?`,
@@ -277,13 +286,15 @@ export var formStore = {
       this.subfields = response.data
     })
   },
-  loadSavedData(data){
+  loadSavedData(){
     var el = document.getElementById('saved_data');
     var savedData = {}
     if (el && el.hasAttribute("data-in-progress-etd")){
       savedData = JSON.parse(el.dataset.inProgressEtd);
     }
     if (Object.keys(savedData).length > 0){
+      this.setIpeId(savedData['ipe_id'])
+
       for (var tab in this.tabs){
          if (!this.tabs[tab].disabled){
            var input_keys = Object.keys(this.tabs[tab].inputs)

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -1,4 +1,6 @@
 class InProgressEtd < ApplicationRecord
+  after_create :add_id_to_data_store
+
   # custom validators check for presence of tab-determined set of fields based on presence of tab-identifying data
   validates_with AboutMeValidator
   validates_with MyProgramValidator
@@ -17,5 +19,12 @@ class InProgressEtd < ApplicationRecord
     resulting_data = existing_data.merge(new_data)
     self.data = resulting_data.to_json
     resulting_data
+  end
+
+  # Store this record's ID for the javascript form to use.
+  def add_id_to_data_store
+    return unless id
+    add_data('ipe_id' => id)
+    save
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -136,6 +136,22 @@ describe InProgressEtd do
     end
   end
 
+  describe '#add_id_to_data_store' do
+    let(:in_progress_etd) { described_class.new }
+    let(:parsed_data) { JSON.parse(in_progress_etd.data) }
+
+    context "a record that has been saved" do
+      before do
+        in_progress_etd.save!
+        in_progress_etd.reload
+      end
+
+      it 'has the ID in the data' do
+        expect(parsed_data).to eq('ipe_id' => in_progress_etd.id)
+      end
+    end
+  end
+
   describe '#add_data' do
     let(:in_progress_etd) { described_class.new(data: old_data.to_json) }
 


### PR DESCRIPTION
* The previous code was performing updates to the record in the controller's `create` action.  I moved that code into the `update` action, so that we would be using conventional Rails-style RESTful routes with our Vue form.

* In order to build the update route, the javascript needs to know the record ID.  I added a method to the model that will add the ID to the JSON data store when the record is created, so that the ID will be available to the javascript.

* The `new` action in the controller just does a find_or_create, and once the record has been created, it redirects to the `edit` action to render the form so the user can start editing.