### PR TITLE
Routes for new UI. Part of story #1285

### DIFF
--- a/app/views/in_progress_etds/new.html.erb
+++ b/app/views/in_progress_etds/new.html.erb
@@ -1,1 +1,0 @@
-<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,8 @@ Rails.application.routes.draw do
   # While we work on new UI architecture, keep it accessible only when new_ui is true (see config/new_ui.yml).
 
   if Rails.application.config_for('new_ui').fetch('enabled', false)
-    get '/concern/etds/new', to: 'in_progress_etds#new'
-    resources :in_progress_etds
+    resources :in_progress_etds, except: :create
+    get '/concern/etds/new', to: redirect('in_progress_etds/new')
   else
     get '/concern/etds/new', to: 'hyrax/etds#new'
   end


### PR DESCRIPTION
* The `new` route for an ETD will now redirect to the `new` route for
 the proxy `inProgressEtd` record, so that the correct controller is
 reflected in the route in the standard Rails RESTful way.  (The old
 code was hijacking another controller's route.)

* I removed the `new` view, since it won't be used.  The `new` action in
 the controller does a find_or_create and then immediately redirects to
 the `edit` action, so the `new` view should never be needed.  For the
 same reason, I removed the `create` action from the routes.  We won't
 ever need that route.