### PR TITLE
Fix white screen during initial form load

### DIFF
--- a/app/javascript/packs/root.js
+++ b/app/javascript/packs/root.js
@@ -8,12 +8,15 @@ import VueAxios from 'vue-axios'
 Vue.use(TurbolinksAdapter, axios, VueAxios)
 
 document.addEventListener('turbolinks:load', () => {
-  let token = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-  axios.defaults.headers.common['X-CSRF-Token'] = token
+  var element = document.getElementById('root')
+  if (element != null) {
+    let token = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    axios.defaults.headers.common['X-CSRF-Token'] = token
 
-  const app = new Vue({
-    el: '#root',
-    data: formStore,
-    components: { App }
-  })
+    var app = new Vue({
+      el: element,
+      data: formStore,
+      components: { App }
+    })
+  }
 })


### PR DESCRIPTION
This was caused by Turbolinks. This changes
the initilization a little bit to make
sure that it is loaded in the correct way.

Related to #1353