### PR TITLE
Ensure use can only select PDFs for thesis

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div v-if="sharedState.files.length === 0" class="form-inline">
-      <input class="input-file" id="add-file" name="primary_files[]" type="file" ref="fileInput" @change="onFileChange"/>
+      <input class="input-file" id="add-file" name="primary_files[]" type="file" accept=".pdf, application/pdf"  ref="fileInput" @change="onFileChange"/>
       <label class="btn btn-primary" for="add-file"><span class='glyphicon glyphicon-plus'></span>
       Add your thesis or dissertation file from your computer
       </label>


### PR DESCRIPTION
This uses the accept attribute on the file input
control to ensure that the user can only select
PDFs. This technique works in IE 10+ and Firefox,
Safari, etc.

Related to #1354