### PR TITLE
populate the selects, form inputs with saved data after tab save

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -20,8 +20,8 @@ class InProgressEtdsController < ApplicationController
     @in_progress_etd.data = prepare_etd_data.to_json
 
     if @in_progress_etd.save
-      # TODO: we'll want all the json data sent back
-      render json: { in_progress_etd: @in_progress_etd, lastCompletedStep: current_step, tab_name: tab_name }, status: 200
+      @data = @in_progress_etd.data
+      render json: { in_progress_etd: @data, lastCompletedStep: current_step, tab_name: tab_name }, status: 200
     else
       render json: { errors: @in_progress_etd.errors.messages }, status: 422
     end
@@ -58,8 +58,6 @@ class InProgressEtdsController < ApplicationController
       # add_uploaded_file_data(new_data)
       add_agreement_data(new_data)
       add_embargo_data(new_data)
-      add_school_department_subfield(new_data)
-
       # Add the new data to the existing persisted data
       @in_progress_etd.add_data(new_data)
     end
@@ -80,12 +78,6 @@ class InProgressEtdsController < ApplicationController
 
     def add_embargo_data(etd)
       etd["no_embargoes"] = "1"
-    end
-
-    def add_school_department_subfield(etd)
-      etd["school"] = "Emory College"
-      etd["department"] = "Anthropology"
-      etd["subfield"] = "Epidemiology"
     end
 
     # TODO: confirm whether this is not needed

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -221,6 +221,8 @@ export default {
     saveTab(){
       var form = document.getElementById("vue_form")
       var formData = new FormData(form)
+      //TODO: might need to make a function for this bc it might need to be done for all of the select components
+      formData.append(this.etdPrefix('school'), this.form.getSelectedSchool())
 
       var saveAndSubmit = new SaveAndSubmit({
         token: token,

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -15,6 +15,12 @@ export default class SaveAndSubmit {
       .then(response => {
         this.formStore.errored = false
         this.formStore.errors = []
+        // get saved data for populating tabs.
+        document.getElementById('saved_data').dataset.inProgressEtd = response.data.in_progress_etd
+
+        // populate form in order to use its inputs
+        this.formStore.loadSavedData()
+
         this.formStore.nextStepIsCurrent(response.data.lastCompletedStep)
         this.formStore.setComplete(response.data.tab_name)
         this.formStore.enableTabs()
@@ -28,6 +34,7 @@ export default class SaveAndSubmit {
   reviewTabs(){
     axios.get(this.formStore.getUpdateRoute(), { config: { headers: { "Content-Type": "application/json" } } })
     .then(response => {
+      //TODO: confirm this is correct: response.data.in_progress_etd
       this.formStore.showSavedData(response.data)
       // for now fake that user got here naturally
       this.formStore.nextStepIsCurrent(6)
@@ -42,7 +49,8 @@ export default class SaveAndSubmit {
     // TODO: change text of submit button to say submit for publication
     axios.get(this.formStore.getUpdateRoute(), { config: { headers: { "Content-Type": "application/json" } } })
     .then(response => {
-      document.getElementById('saved_data').dataset.in_progress_etd = response.data
+      //TODO: confirm this is correct: response.data.in_progress_etd
+      document.getElementById('saved_data').dataset.inProgressEtd = response.data
       // populate form in order to use its inputs
       this.formStore.loadSavedData()
       // submit as form data

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -30,6 +30,12 @@ export default {
       formStore.getDepartments(selectedSchool)
     }
   },
+  mounted: function(){
+    //This is the right hook in the dom loading sequence to get the saved data
+    this.$nextTick(function () {
+      this.selected = formStore.getSchoolOptionValue()
+    })
+  },
   watch: {
     selected() {
       this.fetchData();

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -276,6 +276,9 @@ export var formStore = {
   getSelectedSchool () {
     return this.schools.selected
   },
+  getSchoolOptionValue(){
+    return this.savedData["school"];
+  },
   getDepartments (selectedSchool) {
     axios.get(selectedSchool).then(response => {
       this.departments = response.data
@@ -286,25 +289,20 @@ export var formStore = {
       this.subfields = response.data
     })
   },
+  savedData: {},
   loadSavedData(){
     var el = document.getElementById('saved_data');
-    var savedData = {}
     if (el && el.hasAttribute("data-in-progress-etd")){
-      savedData = JSON.parse(el.dataset.inProgressEtd);
+      this.savedData = JSON.parse(el.dataset.inProgressEtd);
     }
-    if (Object.keys(savedData).length > 0){
-      this.setIpeId(savedData['ipe_id'])
-
+    if (Object.keys(this.savedData).length > 0){
+      this.setIpeId(this.savedData['ipe_id'])
       for (var tab in this.tabs){
          if (!this.tabs[tab].disabled){
            var input_keys = Object.keys(this.tabs[tab].inputs)
             input_keys.forEach(function(el){
-              if (this.tabs[tab].inputs[el].value.isArray) {
-                //TODO: find best way to mark our value as selected
-                this.tabs[tab].inputs[el].selected = savedData[el]
-              } else {
-                this.tabs[tab].inputs[el].value = savedData[el]
-              }
+              // components load after this function runs, so need to use their mounted and nextTick lifecycle hooks to get data.
+              this.tabs[tab].inputs[el].value = this.savedData[el]
             }, this)
          }
       }


### PR DESCRIPTION
This commit ensures we re-populate the form inputs after saving tabs, and also that the school component always loads with saved value displayed, if it has one. Components load at a later point in the DOM cycle and schools needed to try to get its selected data slightly after mounting, using a hook Vue provides called nextTick. https://vuejs.org/v2/api/#vm-nextTick. It is the first component to meet the criteria in #1301.