### PR TITLE
Completed commitee member UI

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -1,8 +1,8 @@
 <template>
-  <div>
+  <div data-turbolinks="false">
     <ul class="nav navtabs">
-      <li v-for="(value,index) in form.tabs" v-bind:key="value.label">
-        <a href="#" data-turbolinks="false" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}</a>
+      <li v-for="(value, index) in form.tabs" v-bind:key="index">
+        <a href="#" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}</a>
       </li>
     </ul>
     <form role="form" id="vue_form" :action="form.getUpdateRoute()" method="patch" @submit.prevent="onSubmit">

--- a/app/javascript/CommitteeMember.vue
+++ b/app/javascript/CommitteeMember.vue
@@ -1,44 +1,49 @@
 <template>
     <div>
-        <div v-for="chair in committeeChairs" v-bind:value="chair.name" v-bind:key='chair.id'>
-            <label>Committee Chair/Thesis Advisor's Affliation</label>
-            <select :name="chairAffiliationTypeAttr(chair)" class="form-control">
+        <div v-for="chair in sharedState.committeeChairs" v-bind:value="chair.name" v-bind:key='chair.id'>
+            <div class="well">
+            <h4>Committee Chair/Thesis Advisor</h4>
+            <label :for="chairId(chair)">Committee Chair/Thesis Advisor's Affliation</label>
+            <select v-model="chair.affiliation" :id="chairId(chair)" :name="chairAffiliationTypeAttr(chair)" class="form-control">
                 <option disabled selected>
                     Select an affiliation
                 </option>
                 <option>Emory University</option>
                 <option>Non-Emory</option>
             </select>
-            <label>Committee Chair/Thesis Advisor's Name</label>
-            <input :name="chairNameAttr(chair)" type="text" class="form-control" />
+            <label :for="chairNameId(chair)">Committee Chair/Thesis Advisor's Name</label>
+            <input :id="chairNameId(chair)" :name="chairNameAttr(chair)" type="text" class="form-control" />
 
-           
-            <label>Affiliation</label> 
-            <input :name="chairAffiliationAttr(chair)" type="text" class="form-control" />
-
-             <a class="btn btn-default" href="#" data-turbolinks="false" @click="removeChair(chair)">Remove Chair or Advisor</a>
+           <div v-if="chair.affiliation === 'Non-Emory'">
+            <label :for="chairAffiliationId(chair)">Affiliation</label> 
+            <input :id="chairAffiliationId(chair)" :name="chairAffiliationAttr(chair)" type="text" class="form-control" />
+           </div>
+             <button type="button" class="btn btn-default" @click="removeChair(chair)"><span class="glyphicon glyphicon-trash"></span> Remove This Chair or Advisor</button>
+             </div>
         </div>
-        <p>
-        <a href="#" class="btn btn-default" data-turbolinks="false" @click="addChair">Add Another Chair or Advisor</a>
-        </p>
-         <div v-for="member in committeeMembers" v-bind:value="member.name" v-bind:key='member.id'>
-            <label>Committee Member's Affiliation</label>
-            <select :name="memberAffiliationTypeAttr(member)" class="form-control">
+        <button type="button" class="btn btn-default" @click="addChair"><span class="glyphicon glyphicon-plus"></span> Add a Chair or Advisor</button>
+         <div v-for="member in sharedState.committeeMembers" v-bind:value="member.name" v-bind:key='member.id'>
+            <div class="well">
+            <h4>Committee Member</h4>
+            <label :for="memberId(member)">Committee Member's Affiliation</label>
+            <select :id="memberId(member)" v-model="member.affiliation" :name="memberAffiliationTypeAttr(member)" class="form-control">
                 <option disabled selected>
                     Select an affiliation
                 </option>
                 <option>Emory University</option>
                 <option>Non-Emory</option>
             </select>
-            <label>Committee Member's Name</label>
-            <input :name="memberNameAttr(member)" type="text" class="form-control" />
-            <label>Affiliation</label> 
-            <input :name="memberAffiliationAttr(member)" type="text" class="form-control" />
-            <a href="#" class="btn btn-default" data-turbolinks="false" @click="removeMember(member)">Remove Committee Member</a>
-            <br>
+            <label :for="memberNameId(member)">Committee Member's Name</label>
+            <input :id="memberNameId(member)" :name="memberNameAttr(member)" type="text" class="form-control" />
+            <div v-if="member.affiliation === 'Non-Emory'">
+                {{ member.affliation }}
+            <label :for="memberAfilliationId(member)">Affiliation</label> 
+            <input :id="memberAffiliationId(member)" :name="memberAffiliationAttr(member)" type="text" class="form-control" />
+            </div>
+            <button type="button" class="btn btn-default" @click="removeMember(member)"><span class="glyphicon glyphicon-trash"></span> Remove Committee Member</button>
         </div>
-        <br>
-        <a href="#" class="btn btn-default" data-turbolinks="false" @click="addMember">Add Another Committee Member</a>
+        </div>
+        <button type="button" class="btn btn-default" @click="addMember"><span class="glyphicon glyphicon-plus"></span> Add a Committee Member</button>
     </div>
 </template>
 
@@ -49,27 +54,48 @@ import { formStore } from "./formStore";
 
 export default {
   data() {
-    return {
-      committeeChairs: [],
-      committeeMembers: [],
-      selectedAffiliation: [],
+    return { 
       sharedState: formStore,
-    };
+      options:'',
+      selected: ''
+    }
   },
   methods: {
       addMember () {
-          this.committeeMembers.push({id: this.committeeMembers.length + 1, affiliation: '', name: ''})
+          this.sharedState.committeeMembers.push({id: this.sharedState.committeeMembers.length + 1, affiliation: '', name: ''})
       },
       removeMember(member) {
-          const filteredMembers = this.committeeMembers.filter((member) => member.id !== member.id)
-          this.committeeMembers = filteredMembers
+          const filteredMembers = this.sharedState.committeeMembers.filter((member) => member.id !== member.id)
+          this.sharedState.committeeMembers = filteredMembers
       },
       addChair () {
-          this.committeeChairs.push({id: this.committeeChairs.length + 1, affiliation: '', name: ''})
+          this.sharedState.committeeChairs.push({id: this.sharedState.committeeChairs.length + 1, affiliation: '', name: ''})
       },
       removeChair(chair) {
-          const filteredChairs = this.committeeChairs.filter((chair) => chair.id !== chair.id)
-          this.committeeChairs = filteredChairs
+          const filteredChairs = this.sharedState.committeeChairs.filter((chair) => chair.id !== chair.id)
+          this.sharedState.committeeChairs = filteredChairs
+      },
+      changeAffiliation(chair) {
+          chair.affiliation = this.selectedAffiliation
+          console.log(chair)
+      },
+      chairId (chair) {
+          return `chair-${chair.id}`
+      },
+      memberId (member) {
+          return `member-${member.id}`
+      },
+      chairAffiliationId (chair) {
+          return `chair-affiliation-${chair.id}`
+      },
+      memberAfilliationId (member) {
+          return `member-affiliation-${member.id}`
+      },
+      chairNameId (chair) {
+          return `chair-name-${chair.id}`
+      },
+      memberNameId (member) {
+          return `member-name-${member.id}`
       },
       chairNameAttr(chair) {
           return `etd[committee_chair_attributes][${chair.id}][name][]`
@@ -96,7 +122,14 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
+
+.btn {
+    margin: 0;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
 select {
   margin-bottom: 1em;
 }

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -34,8 +34,8 @@
                   {{ file.size }}
                 </td>
                 <td>
-                  <a href="#" class="btn btn-danger delete" data-turbolinks="false" @click="deleteFile(file.deleteUrl)">
-                  <span class="glyphicon glyphicon-trash"></span> Remove this file</a>
+                  <button type="button" class="btn btn-danger delete" @click="deleteFile(file.deleteUrl)">
+                  <span class="glyphicon glyphicon-trash"></span> Remove this file</button>
                 </td>
               </tr>
             </tbody>
@@ -48,7 +48,7 @@
       <label class="btn btn-primary" for="add-file"><span class='glyphicon glyphicon-plus'></span>
       Add your thesis or dissertation file from your computer
       </label>
-      <a class="btn btn-primary" :href="boxOAuthUrl()" data-turbolinks="false"><span class="glyphicon glyphicon-plus"></span> Add your thesis or dissertation file from Box</a>
+      <button class="btn btn-primary" :href="boxOAuthUrl()"><span class="glyphicon glyphicon-plus"></span> Add your thesis or dissertation file from Box</button>
     </div>
     
     </section>
@@ -89,8 +89,8 @@
             </td>
             <td> 
               {{ files.deleteUrl }}
-              <a class="btn btn-danger remove-btn" data-turbolinks="false" @click="deleteSupplementalFile(files.deleteUrl)">
-              <span class="glyphicon glyphicon-trash"></span> Remove this file</a>
+              <button type="button" class="btn btn-danger remove-btn" @click="deleteSupplementalFile(files.deleteUrl)">
+              <span class="glyphicon glyphicon-trash"></span> Remove this file</button>
             </td>
           </tr>
         </tbody>
@@ -100,7 +100,7 @@
       <label class="btn btn-primary" for="add-supplemental-file"><span class='glyphicon glyphicon-plus'></span>
       Add a supplemental file from your computer
       </label>
-      <a class="btn btn-primary" href="#" data-turbolinks="false"><span class="glyphicon glyphicon-plus"></span> Add a supplemental file from Box</a>
+      <button type="button" class="btn btn-primary"><span class="glyphicon glyphicon-plus"></span> Add a supplemental file from Box</button>
       <input class="input-file btn-primary" id="add-supplemental-file" name="supplemental_files[]" type="file" ref="fileInput" @change="onSupplementalFileChange"/>
     </div>
     </section>

--- a/app/javascript/Keywords.vue
+++ b/app/javascript/Keywords.vue
@@ -3,11 +3,11 @@
     <label>Keywords</label>
     <div class="form-inline keyword" v-for="(keyword, index) in sharedState.keywords" v-bind:key="index">
       <input class="form-control" name="etd[keyword][]" />
-      <a data-turbolinks="false" class="btn btn-default" href="#" @click="sharedState.removeKeyword(index)">Remove This Keyword</a>
+      <button type="button" class="btn btn-default" @click="sharedState.removeKeyword(index)">Remove This Keyword</button>
       <br/>
     </div>
     <br/>
-    <a data-turbolinks="false" class="btn btn-default" @click="sharedState.addKeyword('')" href="#"><span class="glyphicon glyphicon-plus"></span> Add a Keyword</a>
+    <button type="button" class="btn btn-default" @click="sharedState.addKeyword('')"><span class="glyphicon glyphicon-plus"></span> Add a Keyword</button>
   </div>
 </template>
 

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -141,6 +141,7 @@ export var formStore = {
     'name': 'etd[patents]'
   }],
   committeeChairs: [],
+  committeeMembers: [],
   files: [],
   supplementalFiles: [],
   departments: [],

--- a/app/javascript/test/CommitteeMember.spec.js
+++ b/app/javascript/test/CommitteeMember.spec.js
@@ -9,12 +9,6 @@ describe('CommitteeMember.vue', () => {
   it('renders two links to start with', () => {
     const wrapper = shallowMount(CommitteeMember, {
     })
-    expect(wrapper.findAll('a')).toHaveLength(2)
-  })
-
-  it('has the correct html', () => {
-    const wrapper = shallowMount(CommitteeMember, {
-    })
-    expect(wrapper.html()).toEqual('<div> <p><a href="#" data-turbolinks="false" class="btn btn-default">Add Another Chair or Advisor</a></p>  <br> <a href="#" data-turbolinks="false" class="btn btn-default">Add Another Committee Member</a></div>')
+    expect(wrapper.findAll('button')).toHaveLength(2)
   })
 })

--- a/app/javascript/test/Files.spec.js
+++ b/app/javascript/test/Files.spec.js
@@ -10,7 +10,7 @@ describe('Files.vue', () => {
   it('has 4 buttons when rendered', () => {
     const wrapper = shallowMount(Files, {
     })
-    expect(wrapper.findAll('a')).toHaveLength(4)
+    expect(wrapper.findAll('button')).toHaveLength(2)
   })
 
   it('has two labels ', () => {


### PR DESCRIPTION
This completes the UI for committee members. If
you select Emory as the affiliation, you will not
be prompeted to enter the affiliation.

This also changes some of the buttons in UI that
were links to actually use the `<button>` tag,
which is more semantic. It also avoids issues that
might arise because of Turbolinks.

Related to #1349
Related to #1056