### PR TITLE
Ensure the form is keyboard accessible

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -39,8 +39,7 @@
             </div>
             <div v-else-if="input.label === 'Table of Contents'">
               <label>{{ input.label }}</label>
-               <quill-editor ref="myTextEditor"
-                v-model="input.value[0]">
+               <quill-editor :options="editorOptions" ref="myTextEditor"  v-model="input.value[0]">
                </quill-editor>
                <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />
                <section class='errorMessage' v-if="form.hasError(index)">
@@ -49,8 +48,7 @@
             </div>
             <div v-else-if="input.label === 'Abstract'">
                <label>{{ input.label }}</label>
-               <quill-editor ref="myTextEditor"
-                v-model="input.value[0]">
+               <quill-editor :options="editorOptions" ref="myTextEditor" v-model="input.value[0]">
                </quill-editor>
                <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />
                <section class='errorMessage' v-if="form.hasError(index)">
@@ -148,7 +146,8 @@ import CopyrightQuestions from './CopyrightQuestions'
 import Embargo from './Embargo'
 import Keywords from './Keywords'
 import SaveAndSubmit from './SaveAndSubmit'
-
+import quillToolbarOptions  from './quillToolbarOptions'
+import quillKeyboardBindings from './quillKeyboardBindings'
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -163,6 +162,12 @@ export default {
       files: [],
       deleteableFiles: [],
       editorOptions: {
+        modules: {
+        toolbar: quillToolbarOptions(),
+        keyboard: {
+          bindings: quillKeyboardBindings()
+          }
+        }
       },
       lastCompletedStep: 0
     }
@@ -274,63 +279,63 @@ export default {
 
 <style scoped>
 ul {
-     margin-bottom: 2em;
-     border-bottom: 1px solid #00000029;
-     box-shadow: 0px 2px 6px whitesmoke;
-     width: 100%;
+  margin-bottom: 2em;
+  border-bottom: 1px solid #00000029;
+  box-shadow: 0px 2px 6px whitesmoke;
+  width: 100%;
 }
- li {
-     margin: 0;
-     display: block;
-     float: left;
-     list-style: none;
-     position: relative;
-     margin-bottom: 0;
-     min-width:100px;
-     text-align: center
+li {
+  margin: 0;
+  display: block;
+  float: left;
+  list-style: none;
+  position: relative;
+  margin-bottom: 0;
+  min-width: 100px;
+  text-align: center;
 }
- ul li a {
-     display: block;
-     line-height: 1.3em;
-     font-family: "PT Sans", sans;
-     border: 1px solid rgba(0,0,0,0.15);
-     border-bottom: 0;
-     box-shadow: 1px 1px .5px rgba(0,0,0,0.06);
-     border-top-left-radius: 5px;
-     border-top-right-radius: 5px;
-     padding: 1em;
-     margin-right: 0.5em;
-}
-
- .disabled {
-     color: #cdcdcd;
-     cursor: not-allowed !important;
- }
-
- .tab-content > * {
-     margin-right: 2em;
-     margin-bottom: 1em;
-}
- .tab-content > h1 {
-     padding-left: 0;
-     margin-bottom:0.4em;
-}
- .tab-content > button {
-     margin-bottom:1.5em;
+ul li a {
+  display: block;
+  line-height: 1.3em;
+  font-family: 'PT Sans', sans;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-bottom: 0;
+  box-shadow: 1px 1px 0.5px rgba(0, 0, 0, 0.06);
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  padding: 1em;
+  margin-right: 0.5em;
 }
 
- input {
-     margin-bottom: 1em;
-}
- .quill-hidden-field {
-     display: none;
-}
- .quill-editor {
-     height: 10em;
-     margin-bottom:7em;
+.disabled {
+  color: #cdcdcd;
+  cursor: not-allowed !important;
 }
 
-.errorMessage{
+.tab-content > * {
+  margin-right: 2em;
+  margin-bottom: 1em;
+}
+.tab-content > h1 {
+  padding-left: 0;
+  margin-bottom: 0.4em;
+}
+.tab-content > button {
+  margin-bottom: 1.5em;
+}
+
+input {
+  margin-bottom: 1em;
+}
+.quill-hidden-field {
+  display: none;
+}
+.quill-editor {
+  height: 10em;
+  margin-bottom: 7em;
+}
+
+.errorMessage {
   color: red;
 }
 </style>

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -2,7 +2,7 @@
   <div>
     <section class="thesis-file">
     <h2>Add Your Thesis or Dissertation File</h2>
-    <div id="box-picker"></div> 
+    <div id="box-picker"></div>
     <span class="form-instructions">Upload the version of your thesis or dissertation approved by your advisor or committee.
     You can only upload one file to represent your thesis or dissertation. This file should not contain any signatures or other personally identifying
     information. PDF/A is a better version for preservation and for that reason we recommend you upload a PDF/A file, but it is not required.
@@ -50,15 +50,15 @@
       </label>
       <button class="btn btn-primary" :href="boxOAuthUrl()"><span class="glyphicon glyphicon-plus"></span> Add your thesis or dissertation file from Box</button>
     </div>
-    
+
     </section>
     <section class="optional-files">
     <h2>Add Optional Supplemental Files</h2>
     <div class="form-instructions">
-      Uploading supplemental files is not required, but it gives you a way to share more of your research. 
-      These files could be video, research data, securely zipped software, or other materials. Please group your supplemental files 
-      so you can select and upload them all at once. Once uploaded, <strong>you are required to add additional metadata for each</strong>. 
-      You may upload as many supplemental files as you like. No single file should exceed 2.5 GB. 
+      Uploading supplemental files is not required, but it gives you a way to share more of your research.
+      These files could be video, research data, securely zipped software, or other materials. Please group your supplemental files
+      so you can select and upload them all at once. Once uploaded, <strong>you are required to add additional metadata for each</strong>.
+      You may upload as many supplemental files as you like. No single file should exceed 2.5 GB.
       If you have a file larger than 2.5 GB, contact the ETD team at <a href="mailto:etd-help@LISTSERV.CC.EMORY.EDU">etd-help@LISTSERV.CC.EMORY.EDU</a> for help.
     </div>
     <div v-if="sharedState.supplementalFiles.length > 0" class="file-row form-inline">
@@ -74,7 +74,7 @@
         </thead>
         <tbody>
           <tr v-for="(files, key) in sharedState.supplementalFiles" v-bind:key="key">
-            
+
             <td><input  type="text" :value="files.name" class="form-control" disabled /></td>
             <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" /></td>
             <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" /></td>
@@ -87,7 +87,7 @@
                 <option>Software</option>
               </select>
             </td>
-            <td> 
+            <td>
               {{ files.deleteUrl }}
               <button type="button" class="btn btn-danger remove-btn" @click="deleteSupplementalFile(files.deleteUrl)">
               <span class="glyphicon glyphicon-trash"></span> Remove this file</button>
@@ -97,11 +97,11 @@
       </table>
     </div>
     <div class="form-inline">
+      <input class="input-file btn-primary" id="add-supplemental-file" name="supplemental_files[]" type="file" ref="fileInput" @change="onSupplementalFileChange"/>
       <label class="btn btn-primary" for="add-supplemental-file"><span class='glyphicon glyphicon-plus'></span>
       Add a supplemental file from your computer
       </label>
       <button type="button" class="btn btn-primary"><span class="glyphicon glyphicon-plus"></span> Add a supplemental file from Box</button>
-      <input class="input-file btn-primary" id="add-supplemental-file" name="supplemental_files[]" type="file" ref="fileInput" @change="onSupplementalFileChange"/>
     </div>
     </section>
   </div>
@@ -140,11 +140,11 @@ export default {
       logoUrl: 'box',
       canCreateNewFolder: false
     })
-  
+
     filePicker.addListener('choose', (event) => {
       console.log(event)
       var boxRedirect = `/file/box`
-      axios({ 
+      axios({
         method: 'post',
         url: boxRedirect,
         data: {
@@ -253,7 +253,7 @@ export default {
 .file-info {
   list-style-type: none;
   margin:0;
-  padding-left:0; 
+  padding-left:0;
 }
 
 .file-info li {

--- a/app/javascript/quillKeyboardBindings.js
+++ b/app/javascript/quillKeyboardBindings.js
@@ -1,0 +1,5 @@
+export default function quillKeyboardBindings () {
+  return {
+    tab: false
+  }
+}

--- a/app/javascript/quillToolbarOptions.js
+++ b/app/javascript/quillToolbarOptions.js
@@ -1,0 +1,19 @@
+export default function quillToolbarOptions () {
+  return [
+    ['bold', 'italic', 'underline', 'strike'], // toggled buttons
+    ['blockquote', 'code-block'],
+
+    [{ 'header': 1 }, { 'header': 2 }], // custom button values
+    [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+    [{ 'script': 'sub' }, { 'script': 'super' }], // superscript/subscript
+    [{ 'indent': '-1' }, { 'indent': '+1' }], // outdent/indent
+    [{ 'direction': 'rtl' }], // text direction
+
+    [{ 'size': ['small', false, 'large', 'huge'] }], // custom dropdown
+    [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+
+    [{ 'align': [] }],
+
+    ['clean'] // remove formatting button
+  ]
+}


### PR DESCRIPTION
This commit changes some controls in the Files
component and adds additional configuration to
Quill to ensure that the form is fully keyboard
accessible. After this commit it is possible to fill
out the entire form using just the keyboard.

Related to #1056