### PR TITLE
Fix upload of supplemental files from box

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -154,16 +154,23 @@ module Hyrax
     def merge_selected_files_hashes(params)
       selected_files = {}
       be_files = params.fetch('selected_files', false)
-
+      return unless be_files
       count_of_files = 0
       index = 0
 
-      # Get count of all browse-everything selected_files
-      be_files[0].each_key { |k| count_of_files += be_files[0][k].size }
+      # Ideally, we would whitelist all these params and not have to use
+      # `to_unsafe_h`. However, afaict, the names of the params are unpredictable
+      # in this case, so I think `to_unsafe_h` is our best option
+      params_hash = be_files[0].to_unsafe_h
 
-      # Populate the selected_files hash with all of the browse-everything files, with keys in the structure the rest of the application will expect: their indexes converted to strings
-      be_files[0].each_key do |k|
-        be_files[0][k].each do |ke, va| # rubocop:disable HashEachMethods
+      # Get count of all browse-everything selected_files
+      params_hash&.each_key { |k| count_of_files += params_hash[k].size }
+
+      # Populate the selected_files hash with all of the browse-everything files,
+      # with keys in the structure the rest of the application will expect:
+      # their indexes converted to strings
+      params_hash&.each_key do |k|
+        params_hash[k].each do |ke, va| # rubocop:disable HashEachMethods
           if index < count_of_files
             selected_files[index.to_s] = va
             index += 1

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -40,7 +40,7 @@ class ImportUrlJob < ActiveJob::Base
       # when IngestFileJob is invoked. If it was asynchronous the IngestFileJob may be invoked
       # on a machine that did not have this temp file on it's file system.
       # NOTE: The return status may be successful even if the content never attaches.
-      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f, 'original_file', false)
+      if Hyrax::Actors::FileSetActor.new(file_set, user).create_content(f)
         # send message to user on download success
         Hyrax.config.callback.run(:after_import_url_success, file_set, user)
         operation.success!


### PR DESCRIPTION
The ability to attach metadata to browse-everything
uploaded supplemental files seems to have broken
during a recent upgrade, which included a change requiring
params to be whitelisted. This PR allows us to fetch
the required params hash even if they have not been specifically
whitelisted. Ideally, we would whitelist them, but afaict
the names of the params are not predictable.

Unfortunately, we don't have automated testing for browse
everything because it requires integration with an
external service.

Fixes #1347 