### PR TITLE
Workaround ActiveFedora's non-persistence of nested attributes

### DIFF
--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -1,8 +1,19 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
 module Hyrax
   module Actors
     class EtdActor < Hyrax::Actors::BaseActor
+      private
+
+        def apply_save_data_to_curation_concern(env)
+          super
+
+          # ActiveFedora fails to propgate changes to nested attributes to
+          # `#resource` when indexed nested attributes are used. We force the
+          # issue here to work around for form edits.
+          (env.attributes.keys && [:committee_members_attributes]).each do |attribute_key|
+            attribute = attribute_key.to_s.gsub('_attributes', '').to_sym
+            env.curation_concern.send(attribute).each { |member| member.try(:persist!) }
+          end
+        end
     end
   end
 end

--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -1,6 +1,9 @@
 module Hyrax
   module Actors
     class EtdActor < Hyrax::Actors::BaseActor
+      KNOWN_NESTED_ATTRIBUTES = [:committee_members_attributes,
+                                 :committee_chair_attributes].freeze
+
       private
 
         def apply_save_data_to_curation_concern(env)
@@ -9,7 +12,7 @@ module Hyrax
           # ActiveFedora fails to propgate changes to nested attributes to
           # `#resource` when indexed nested attributes are used. We force the
           # issue here to work around for form edits.
-          (env.attributes.keys && [:committee_members_attributes]).each do |attribute_key|
+          (env.attributes.keys && KNOWN_NESTED_ATTRIBUTES).each do |attribute_key|
             attribute = attribute_key.to_s.gsub('_attributes', '').to_sym
             env.curation_concern.send(attribute).each { |member| member.try(:persist!) }
           end

--- a/spec/features/edit_etd_spec.rb
+++ b/spec/features/edit_etd_spec.rb
@@ -284,9 +284,7 @@ RSpec.feature 'Edit an existing ETD',
         expect(current_path.gsub('?locale=en', '')).to eq hyrax_etd_path(etd)
         expect(page).to have_content 'Department Chemistry'
         expect(page).not_to have_content 'Subfield'
-        # I can't figure out why this last bit is failing, but this form is being
-        # replaced anyway so I'm not going to spend more time on it.
-        # expect(page).to have_content 'Committee Members Betty'
+        expect(page).to have_content 'Committee Members Betty'
       end
     end
   end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -174,9 +174,15 @@ RSpec.describe Etd do
       expect(etd.committee_members_names).to contain_exactly("Craighead, W Edward", "Manns, Joseph")
       cm = etd.committee_members.select { |m| m.name.first.match(/Manns/) }.first
       cm.name = ['New Name']
+      cm.persist!
+      etd.send(:attribute_will_change!, :committee_members)
       etd.save!
       etd.reload # Make sure the new data is persisted
-      expect(etd.committee_members_names).to contain_exactly("Craighead, W Edward", "New Name")
+
+      expect(etd.committee_members.map(&:name).flatten)
+        .to contain_exactly(["Craighead, W Edward"], ["New Name"])
+      expect(etd.committee_members_names)
+        .to contain_exactly("Craighead, W Edward", "New Name")
     end
 
     it "updates committee_chair_name when committee_chair is edited" do


### PR DESCRIPTION
ActiveFedora fails to persist when using indexed nested attributes like:

    { my_property_attributes: { '0' => { name: ['moomin'] } } }

The library does not propagate changes made in this way to `#resource` which
prevents them from being added to the `ActiveFedora::ChangeSet` and sent to
Fedora. As a work-around, we call `persist!` manually on known nested attributes
in the actor stack. This ensures that updates made through the form (and only
those made through the form) are properly saved.

We also change an existing test to document a workable procedure for changing
nested attributes directly using the models.

Fixes #1376