### PR TITLE
Set embargo and visibility on FileSet when adding to a work

### DIFF
--- a/app/actors/hyrax/actors/file_visibility_attributes_actor.rb
+++ b/app/actors/hyrax/actors/file_visibility_attributes_actor.rb
@@ -1,0 +1,33 @@
+module Hyrax
+  module Actors
+    class FileVisibilityAttributesActor < AbstractActor
+      def create(env)
+        next_actor.create(env) && attributes_for_file_sets(env)
+      end
+
+      def update(env)
+        next_actor.update(env) && attributes_for_file_sets(env)
+      end
+
+      private
+
+        # Set embargo visibility to 'private' for file sets;
+        # otherwise set visibility visibility to 'open' and don't set embargo for files
+        def attributes_for_file_sets(env)
+          if env.curation_concern.files_embargoed
+            env.attributes[:visibility] =
+              Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+            env.attributes[:visibility_during_embargo] =
+              Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+          else
+            env.attributes.except!(:visibility, :embargo_release_date)
+
+            env.attributes[:visibility] =
+              Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          end
+
+          true
+        end
+    end
+  end
+end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -8,8 +8,8 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
     validate_files!(uploaded_files)
     depositor = proxy_or_depositor(work)
     user = User.find_by_user_key(depositor)
-    work_permissions = work.permissions.map(&:to_hash)
     metadata = visibility_attributes(work_attributes)
+
     uploaded_files.each do |uploaded_file|
       virus_check!(uploaded_file)
       actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
@@ -23,8 +23,7 @@ class AttachFilesToWorkJob < Hyrax::ApplicationJob
         actor.file_set.description = Array.wrap(uploaded_file.description)
         actor.file_set.file_type   = uploaded_file.file_type
       end
-      actor.attach_to_work(work)
-      actor.file_set.permissions_attributes = work_permissions
+      actor.attach_to_work(work, metadata)
       uploaded_file.update(file_set_uri: actor.file_set.uri)
     end
   rescue VirusDetectedError

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -273,4 +273,5 @@ module Hyrax
 end
 
 Hyrax::CurationConcern.actor_factory.insert_after(Hyrax::Actors::TransactionalRequest, PrimaryFileTitleActor)
+Hyrax::CurationConcern.actor_factory.insert_after(Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::FileVisibilityAttributesActor)
 Hyrax::CurationConcern.actor_factory.insert_before(Hyrax::Actors::InterpretVisibilityActor, Hyrax::Actors::PregradEmbargo)

--- a/spec/actors/hyrax/actors/file_visibility_attributes_actor_spec.rb
+++ b/spec/actors/hyrax/actors/file_visibility_attributes_actor_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe Hyrax::Actors::FileVisibilityAttributesActor do
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  let(:ability)    { ::Ability.new(FactoryBot.create(:user)) }
+  let(:attributes) { { visibility: embargo, embargo_release_date: Time.zone.today } }
+  let(:etd)        { FactoryBot.build(:etd) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
+
+  let(:open) do
+    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  end
+
+  let(:embargo) do
+    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+  end
+
+  let(:restricted) do
+    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+  end
+
+  describe '#create' do
+    it 'sets the file set visibility to open' do
+      expect { middleware.create(env) }
+        .to change { env.attributes }
+        .to include visibility: open
+    end
+
+    context 'when files_embargoed is true' do
+      let(:etd) { FactoryBot.build(:etd, files_embargoed: true) }
+
+      it 'sets file set visibility attributes' do
+        expect { middleware.create(env) }
+          .to change { env.attributes }
+          .to include visibility: embargo,
+                      visibility_during_embargo: restricted
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:etd) { FactoryBot.create(:etd) }
+
+    it 'sets the file set visibility to open' do
+      expect { middleware.update(env) }
+        .to change { env.attributes }
+        .to include visibility: open
+    end
+
+    context 'when files_embargoed is true' do
+      let(:etd) { FactoryBot.create(:etd, files_embargoed: true) }
+
+      it 'sets file set visibility attributes' do
+        expect { middleware.update(env) }
+          .to change { env.attributes }
+          .to include visibility: embargo,
+                      visibility_during_embargo: restricted
+      end
+    end
+  end
+
+  describe '#destroy' do
+    it 'is not an error' do
+      expect { middleware.destroy(env) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
When attaching a file to a work, Hyrax sets an embargo on the FileSet, matching
the work's permissions. However, we need to determine and set the FileSet
embargo based on the work's status, not simply its visibility. Specifically:

  - we do not want to set FileSet embargo when `work.files_embargoed` is false
  - when we *do* set an embargo, we want to set the FileSet visibility to
    `restricted`/Private, instead of `open`.