### PR TITLE
Add `VisibilityTranslator` as alternate collaborator for `#visibility`

### DIFF
--- a/app/services/visibility_translator.rb
+++ b/app/services/visibility_translator.rb
@@ -1,0 +1,65 @@
+##
+# Determines visibily for a given Etd.
+#
+# Etd visibility is extended from `Hyrax` and `Hydra::AccessControls` to
+# include three additional visibility levels:
+#
+#   - `VisibilityTranslator::FILES_EMBARGOED`: indicates that the work is
+#     under embargo, but that it is discoverable (not `restricted`/private).
+#     FileSets that are members of the work should be under a parallel embargo,
+#     making tthem private until the embargo end date.
+#   - `VisibilityTranslator::TOC_EMBARGOED`: indicates that the work is
+#     under embargo, as described above, and that the table of contents should
+#     be suppressed for the duration of the embargo.
+#   - `VisibilityTranslator::ALL_EMBARGOED`: indicates that the work is
+#     under embargo, as described above, and that the table of contents *and*
+#     abstract should be suppressed for the duration of the embargo.
+#
+# @see Hydra::AccessControls::Visibility
+class VisibilityTranslator
+  ALL_EMBARGOED   = 'embargo; all'.freeze
+  FILES_EMBARGOED = 'embargo; file'.freeze
+  TOC_EMBARGOED   = 'embargo; toc + file'.freeze
+
+  attr_accessor :obj
+
+  def initialize(obj:)
+    self.obj = obj
+  end
+
+  def self.visibility(obj:)
+    new(obj: obj).visibility
+  end
+
+  def visibility
+    return VisibilityProxy.new(obj).visibility unless obj.under_embargo?
+    return ALL_EMBARGOED                       if     obj.abstract_embargoed
+    return TOC_EMBARGOED                       if     obj.toc_embargoed
+
+    FILES_EMBARGOED
+  end
+
+  ##
+  # Determines the value of the default `#visibility` method as implemented in
+  # `Hydra::AccessControls::Visibility` for the provided `source`. Since we
+  # expect this method to be overridden in `pcdm_object`s passed to
+  # `VisibilityTranslator`, we need a proxy object to ensure we can access the
+  # original implementation.
+  #
+  # @example
+  #   my_model = ModelWithCustomVisibility.new
+  #   my_model.visibility # => 'some custom value`
+  #   VisibilityTranslator::VisibilityProxy.new(my_model).visibility # => 'open'
+  #
+  # @see Hydra::AccessControls::Visibility
+  class VisibilityProxy
+    extend Forwardable
+    include Hydra::AccessControls::Visibility
+
+    def_delegator :@original, :read_groups
+
+    def initialize(original)
+      @original = original
+    end
+  end
+end

--- a/spec/services/visibility_translator_spec.rb
+++ b/spec/services/visibility_translator_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe VisibilityTranslator do
+  subject(:translator) { described_class.new(obj: obj) }
+
+  let(:obj) { FactoryBot.create(:etd, visibility: open) }
+
+  let(:embargo)    { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO }
+  let(:open)       { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  let(:restricted) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+
+  describe '.visibility' do
+    it 'passes through to an instance' do
+      expect(described_class.visibility(obj: obj))
+        .to eq translator.visibility
+    end
+  end
+
+  describe '#visibility' do
+    it 'is open' do
+      expect(translator.visibility).to eq open
+    end
+
+    context 'when under full embargo' do
+      let(:obj) { FactoryBot.create(:sample_data_with_everything_embargoed) }
+
+      it 'is embargo (all)' do
+        expect(translator.visibility).to eq described_class::ALL_EMBARGOED
+      end
+    end
+
+    context 'when under file-only embargo' do
+      let(:obj) { FactoryBot.create(:sample_data_with_only_files_embargoed) }
+
+      it 'is embargo (file)' do
+        expect(translator.visibility).to eq described_class::FILES_EMBARGOED
+      end
+    end
+
+    context 'when under toc embargo' do
+      let(:obj) do
+        FactoryBot.create(:sample_data_with_only_files_embargoed, toc_embargoed: true)
+      end
+
+      it 'is embargo (toc + file)' do
+        expect(translator.visibility).to eq described_class::TOC_EMBARGOED
+      end
+    end
+
+    context 'when restricted' do
+      let(:obj) { FactoryBot.create(:etd, visibility: restricted) }
+
+      it 'is restricted' do
+        expect(translator.visibility).to eq restricted
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to extend `Etd#visibility` to provide new visibility levels:

   - `VisibilityTranslator::FILES_EMBARGOED`: indicates that the work is
     under embargo, but that it is discoverable (not `restricted`/private).
     FileSets that are members of the work should be under a parallel embargo,
     making tthem private until the embargo end date.
   - `VisibilityTranslator::TOC_EMBARGOED`: indicates that the work is
     under embargo, as described above, and that the table of contents should
     be suppressed for the duration of the embargo.
   - `VisibilityTranslator::ALL_EMBARGOED`: indicates that the work is
     under embargo, as described above, and that the table of contents *and*
     abstract should be suppressed for the duration of the embargo.

This adds a `VisibilityTranslator` interface and base implementation (as
described above) that can be used as a replacement for the default `#visibility`
method on any `Hydra::AccessControl::Visibility` object. Objects implementing
this interface are intended to be injected as collaborators to allow swappable
`#visibility` implementations.

The end goal of this work is to allow administrators and approvers to edit
existing embargoes. This requires being able to select an appropriate visibility
as the "during embargo" and "after embargo" values at edit time.

Connected to #1206.