### PR TITLE
js/display saved embargo

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -56,7 +56,6 @@ class InProgressEtdsController < ApplicationController
       # uploaded_files = Hyrax::UploadedFile.id
       # add_uploaded_file_data(new_data)
       add_agreement_data(new_data)
-      add_embargo_data(new_data)
       add_subfield(new_data)
       # Add the new data to the existing persisted data
       @in_progress_etd.add_data(new_data)
@@ -74,10 +73,6 @@ class InProgressEtdsController < ApplicationController
 
     def add_agreement_data(etd)
       etd["agreement"] = "1"
-    end
-
-    def add_embargo_data(etd)
-      etd["no_embargoes"] = "1"
     end
 
     def add_subfield(etd)

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -124,7 +124,7 @@
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
           <button type="submit" class="btn btn-default" autofocus>Save and Continue</button>
         </div>
-        </transition>  
+        </transition>
       </div>
     </form>
     </section>
@@ -236,7 +236,6 @@ export default {
     addComponents(formData){
       formData.append(this.etdPrefix('school'), this.form.getSelectedSchool())
       formData.append(this.etdPrefix('department'), this.form.getSelectedDepartment())
-
       return formData
     },
     saveTab(){

--- a/app/javascript/Embargo.vue
+++ b/app/javascript/Embargo.vue
@@ -8,8 +8,8 @@
     </select>
   <div v-if="selectedEmbargo != 'None - open access immediately'">
     <label for="content-to-embargo">Content to Embargo</label>
-    <select name="embargo_type" class="form-control" id="content-to-embargo">
-      <option v-for="content in contents" :value="content.value" :disabled="content.disabled">
+    <select name="etd[embargo_type]" v-model="selectedContent" class="form-control" id="content-to-embargo">
+      <option v-for="content in contents" :value="content.value" :disabled="content.disabled" :selected="content.selected">
         {{ content.text }}
       </option>
     </select>
@@ -21,21 +21,54 @@
 <script>
 import Vue from "vue"
 import { formStore } from './formStore'
+import _ from 'lodash'
 
 export default {
   data() {
     return {
-      selectedEmbargo: 'None - open access immediately'
+      selectedEmbargo: 'None - open access immediately',
+      selectedContent: ''
+    }
+  },
+  methods: {
+    setSelected(collection, selected){
+      var match = false
+      //ensuring we have this item in our current school's lengths and types
+      if (selected !== undefined) {
+        _.forEach(collection, function(item) {
+          if (item.value === selected){
+            match = true
+            item.selected = 'selected'
+          }
+        });
+      }
+      if (match === true) {
+        return selected
+      }
     }
   },
   computed: {
     lengths () {
-      return formStore.getEmbargoLengths()
+      var lengths = formStore.getEmbargoLengths()
+      var selected = formStore.savedData['embargo_length']
+      var selectedLength = this.setSelected(lengths, selected)
+
+      if (selectedLength  !== undefined){
+        this.selectedEmbargo = selectedLength
+      }
+      return lengths
     },
     contents () {
-      return formStore.getEmbargoContents()
+      var contents = formStore.getEmbargoContents()
+      var selected = formStore.savedData['embargo_type']
+      var selectedContent = this.setSelected(contents, selected)
+
+      if (selectedContent !== undefined){
+        this.selectedContent = selectedContent
+      }
+      return contents
     }
- }
+  }
 }
 </script>
 

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -70,6 +70,7 @@ export default class SaveAndSubmit {
   }
   getEtdData(){
     //TODO: might need to remove other params
+    // TODO: embargo content types need to be sent like this for publication. '[:files_embargoed]', '[:files_embargoed, :toc_embargoed]', '[:files_embargoed, :toc_embargoed, :abstract_embargoed]'
     this.formData.delete('etd[currentTab]')
     return this.formData
   }

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -183,31 +183,27 @@ export var formStore = {
       { text: 'Rollins School of Public Health', value: 'rollins' }
     ]
   },
-  embargoContents: [{
-    text: 'Files',
-    value: '[:files_embargoed]',
+  embargoContents: [{ text: 'Files',
+    value: 'files_embargoed',
     disabled: false
   },
-  {
-    text: 'Files and Table of Contents',
-    value: '[:files_embargoed, :toc_embargoed]',
+  { text: 'Files and Table of Contents',
+    value: 'files_embargoed, toc_embargoed',
     disabled: false
   },
-  {
-    text: 'Files and Table of Contents and Abstract',
-    value: '[:files_embargoed, :toc_embargoed, :abstract_embargoed]',
+  { text: 'Files and Table of Contents and Abstract',
+    value: 'files_embargoed, toc_embargoed, abstract_embargoed',
     disabled: false
-  }
-  ],
+  }],
   embargoLengths: {
-    emory: [{ value: 'None - open access immediately', selected: 'selected' },
-      { value: '6 Months' }, { value: '1 Year' }, { value: '2 Years' }],
-    candler: [{ value: 'None - open access immediately', selected: 'selected' },
-      { value: '6 Months' }, { value: '1 Year' }, { value: '2 Years' }],
-    laney: [{ value: 'None - open access immediately', selected: 'selected' }, { value: '6 Months' },
-      { value: '1 year' }, { value: '2 Years' }, { value: '6 years' }],
-    rollins: [{ value: 'None - open access immediately', selected: 'selected' },
-      { value: '6 Months' }, { value: '1 Year' }, { value: '2 Years' }]
+    emory: [{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}],
+    candler: [{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}],
+    laney: [{value: 'None - open access immediately', selected: 'selected'}, {value: '6 Months'},
+      {value: '1 Year'}, {value: '2 Years'}, {value: '6 Years'}],
+    rollins: [{value: 'None - open access immediately', selected: 'selected'},
+      {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}]
   },
   keywordIndex: 0,
   newKeyword: '',
@@ -304,7 +300,6 @@ export var formStore = {
     return this.savedData['school']
   },
   getPartneringAgenciesOptionValue () {
-    console.log(this.savedData)
     return this.savedData['partnering_agency']
   },
   getPartneringAgencies () {

--- a/app/javascript/test/Embargo.spec.js
+++ b/app/javascript/test/Embargo.spec.js
@@ -3,11 +3,26 @@
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
 import Embargo from 'Embargo'
+import { formStore } from '../formStore'
 
 describe('Embargo.vue', () => {
   it('has the correct html', () => {
     const wrapper = shallowMount(Embargo, {
     })
     expect(wrapper.html()).toContain(`<select name="etd[embargo_length]" aria-required="true" id="embargo-length" class="form-control"></select>`)
+  })
+  describe('Embargo saved display', () => {
+    beforeEach(() => {
+      const wrapper = shallowMount(Embargo, {
+      })
+      formStore.schools.selected = 'laney'
+      formStore.savedData['embargo_length'] = '6 Years'
+    })
+
+    it('has the 6 Years option when Laney is the saved School', () => {
+      const wrapper = shallowMount(Embargo, {
+      })
+      expect(wrapper.vm.selectedEmbargo).toBe(`6 Years`)
+    })
   })
 })

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -14,17 +14,17 @@ describe('formStore', () => {
   it('returns the correct embargo contents', () => {
     expect(formStore.getEmbargoContents()).toEqual([{
       text: 'Files',
-      value: '[:files_embargoed]',
+      value: 'files_embargoed',
       disabled: false
     },
     {
       text: 'Files and Table of Contents',
-      value: '[:files_embargoed, :toc_embargoed]',
+      value: 'files_embargoed, toc_embargoed',
       disabled: false
     },
     {
       text: 'Files and Table of Contents and Abstract',
-      value: '[:files_embargoed, :toc_embargoed, :abstract_embargoed]',
+      value: 'files_embargoed, toc_embargoed, abstract_embargoed',
       disabled: false
     }
     ])
@@ -36,7 +36,7 @@ describe('formStore', () => {
   })
 
   it('allows you to remove a keyword', () => {
-    formStore.removeKeyword(0) 
+    formStore.removeKeyword(0)
       expect(formStore.keywords.length).toEqual(0)
   })
 })

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -15,10 +15,30 @@ class InProgressEtd < ApplicationRecord
     json_data = data || {}.to_json
     existing_data = JSON.parse(json_data)
     return existing_data unless new_data
+    new_data = add_no_embargoes(new_data)
+    existing_data = remove_stale_embargo_data(existing_data, new_data)
 
     resulting_data = existing_data.merge(new_data)
     self.data = resulting_data.to_json
     resulting_data
+  end
+
+  # currently the EtdForm uses the boolean param "no_embargoes", so we need to send or remove it (seems a good candidate for refactoring in EtdForm)
+
+  def add_no_embargoes(new_data)
+    resulting_data = new_data[:embargo_length] == 'None - open access immediately' ? new_data.merge("no_embargoes" => "1") : nil
+
+    resulting_data.nil? ? new_data : resulting_data
+  end
+
+  # Remove embargo_type, if new_data[:embargo_length] == 'None - open access immediately'
+  # Remove no_embargoes if new_data[:embargo_length] != 'None - open access immediately'
+
+  def remove_stale_embargo_data(existing_data, new_data)
+    existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:embargo_length] != 'None - open access immediately'
+
+    existing_data.delete('embargo_type') if new_data[:embargo_length] == 'None - open access immediately' && existing_data.keys.include?('embargo_type')
+    existing_data
   end
 
   # Store this record's ID for the javascript form to use.

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -193,6 +193,57 @@ describe InProgressEtd do
       end
     end
 
+    describe 'no embargoes' do
+      context 'with existing no_embargoes data and new embargo data' do
+        let(:old_data) { { no_embargoes: '1' } }
+        let(:new_data) { { 'embargo_length': '1 Year', 'embargo_type': 'Files' } }
+
+        it "removes the old no_embargoes parameter and adds the new embargo lengths and types" do
+          expect(resulting_data).to eq({
+            'embargo_length' => '1 Year',
+            'embargo_type' => 'Files'
+          })
+        end
+      end
+
+      context 'with existing no_embargoes and new no_embargoes' do
+        let(:old_data) { { no_embargoes: '1' } }
+        let(:new_data) { { 'embargo_length': 'None - open access immediately' } }
+
+        it "preserves the no_embargoes and adds the new embargo_length data" do
+          expect(resulting_data).to eq({
+            'embargo_length' => 'None - open access immediately',
+            'no_embargoes' => '1'
+          })
+        end
+      end
+
+      context 'with existing embargoes and new embargo data' do
+        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
+        let(:new_data) { { 'embargo_length': '2 Years', 'embargo_type': 'files_embargoed, toc_embargoed' } }
+
+        it 'sets new embargo length and type and does not set no_embargoes' do
+          expect(resulting_data).to eq({
+            'embargo_length' => '2 Years',
+            'embargo_type' => 'files_embargoed, toc_embargoed'
+          })
+        end
+      end
+
+      context 'with existing embargoes and new no embargo data' do
+        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
+
+        let(:new_data) { { 'embargo_length': 'None - open access immediately' } }
+
+        it 'removes old embargo lengths and types and sets no_embargoes' do
+          expect(resulting_data).to eq({
+            'embargo_length' => 'None - open access immediately',
+            'no_embargoes' => '1'
+          })
+        end
+      end
+    end
+
     context 'with no new data' do
       let(:new_data) { {} }
 


### PR DESCRIPTION
This commit ensures saved embargo data is displayed to the user, and sets up the embargo flag parameter the  ETD controller current expects. 

If a user selects an embargo length and saves it, then changes their school to one which doesn't provide their saved embargo length, the embargo tab length select displays the 'choose a length' option. 

