### PR TITLE
Add components for submission tab

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -3,12 +3,12 @@
     <section aria-labelledby="form-label">
       <h1>Submit Your Thesis or Dissertation</h1>
     <ul class="nav navtabs">
-      <li v-for="(value, index) in form.tabs" v-bind:key="index">
+      <li v-for="(value, index) in sharedState.tabs" v-bind:key="index">
         <a href="#" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}</a>
       </li>
     </ul>
-    <form role="form" id="vue_form" :action="form.getUpdateRoute()" method="patch" @submit.prevent="onSubmit">
-      <div v-for="value in form.tabs" v-bind:key="value.label">
+    <form role="form" id="vue_form" :action="sharedState.getUpdateRoute()" method="patch" @submit.prevent="onSubmit">
+      <div v-for="value in sharedState.tabs" v-bind:key="value.label">
         <transition name="fade">
         <div class="tab-content form-group" v-if="value.currentStep">
           <h2> {{ value.label }} </h2>
@@ -18,25 +18,25 @@
           <div v-for="(input, index) in value.inputs" v-bind:key="index">
             <div v-if="input.label === 'School'">
               <school></school>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'Department'">
               <department></department>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'subfield'">
               <subfield></subfield>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'files'">
               <files></files>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
@@ -45,7 +45,7 @@
                <quill-editor :options="editorOptions" ref="myTextEditor"  v-model="input.value[0]">
                </quill-editor>
                <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />
-               <section class='errorMessage' v-if="form.hasError(index)">
+               <section class='errorMessage' v-if="sharedState.hasError(index)">
                    <p>{{ input.label }} is required</p>
                </section>
             </div>
@@ -54,37 +54,37 @@
                <quill-editor :options="editorOptions" ref="myTextEditor" v-model="input.value[0]">
                </quill-editor>
                <input class="quill-hidden-field" :name="etdPrefix(index)" v-model="input.value" />
-               <section class='errorMessage' v-if="form.hasError(index)">
+               <section class='errorMessage' v-if="sharedState.hasError(index)">
                    <p>{{ input.label }} is required</p>
                </section>
             </div>
              <div v-else-if="input.label === 'Graduation Date'">
               <graduationDate></graduationDate>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'Submitting Type'">
               <submittingType></submittingType>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'Committee Member'">
               <committeeMember></committeeMember>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'Degree'">
               <degree></degree>
-              <section class='errorMessage' v-if="form.hasError(index)">
+              <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
             <div v-else-if="input.label === 'Research Field'">
               <researchField></researchField>
-              <section role="alert" class='errorMessage' v-if="form.hasError(index)">
+              <section role="alert" class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
@@ -102,14 +102,17 @@
             </div>
             <div v-else-if="input.label === 'Language'">
               <language></language>
-              <section role="alert" class='errorMessage' v-if="form.hasError(index)">
+              <section role="alert" class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
+            </div>
+            <div v-else-if="input.label === 'Submit'">
+              <submit></submit>
             </div>
             <div v-else>
               <label :for="input.label">{{ input.label }}</label>
               <input :id="input.label" class="form-control" :ref="index" :name="etdPrefix(index)" v-model="input.value">
-              <section role="alert" class='errorMessage' v-if="form.hasError(index)">
+              <section role="alert" class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
             </div>
@@ -157,6 +160,8 @@ import SaveAndSubmit from './SaveAndSubmit'
 import quillToolbarOptions  from './quillToolbarOptions'
 import quillKeyboardBindings from './quillKeyboardBindings'
 import PartneringAgency from './PartneringAgency.vue';
+import Submit from './Submit'
+import AboutMe from './components/submit/AboutMe'
 
 let token = document
   .querySelector('meta[name="csrf-token"]')
@@ -166,7 +171,7 @@ axios.defaults.headers.common["X-CSRF-Token"] = token
 export default {
   data() {
     return {
-      form: formStore,
+      sharedState: formStore,
       tabInputs: [],
       files: [],
       deleteableFiles: [],
@@ -197,10 +202,11 @@ export default {
     embargo: Embargo,
     keywords: Keywords,
     saveAndSubmit: SaveAndSubmit,
-    partneringAgency: PartneringAgency
+    partneringAgency: PartneringAgency,
+    submit: Submit
   },
   mounted(){
-    this.form.loadSavedData();
+    this.sharedState.loadSavedData();
   },
   methods: {
     isComplete(tab) {
@@ -208,19 +214,19 @@ export default {
     },
     allTabsComplete(){
       var complete = [];
-      for (var tab in this.form.tabs){
-        complete.push(this.form.tabs[tab].completed)
+      for (var tab in this.sharedState.tabs){
+        complete.push(this.sharedState.tabs[tab].completed)
       }
       return complete.every(this.isComplete);
     },
     setCurrentStep(tab_label, event){
       // display current tab unless click comes from disabled tab
       if (!event.target.classList.contains("disabled")){
-        for (var tab in this.form.tabs){
-          if (this.form.tabs[tab].label == tab_label){
-            this.form.tabs[tab].currentStep = true
+        for (var tab in this.sharedState.tabs){
+          if (this.sharedState.tabs[tab].label == tab_label){
+            this.sharedState.tabs[tab].currentStep = true
           } else {
-            this.form.tabs[tab].currentStep = false
+            this.sharedState.tabs[tab].currentStep = false
           }
         }
       }
@@ -236,6 +242,9 @@ export default {
     addComponents(formData){
       formData.append(this.etdPrefix('school'), this.form.getSelectedSchool())
       formData.append(this.etdPrefix('department'), this.form.getSelectedDepartment())
+      formData.append(this.etdPrefix('school'), this.sharedState.getSelectedSchool())
+      formData.append(this.etdPrefix('department'), this.sharedState.getSelectedDepartment())
+
       return formData
     },
     saveTab(){
@@ -253,7 +262,7 @@ export default {
     readyForReview(){
       // probably will not need this, save will go from embargo tab to review tab naturally
       // all tabs are complete but user has not checked agreement
-      return this.allTabsComplete() && this.form.agreement == false
+      return this.allTabsComplete() && this.sharedState.agreement == false
     },
     reviewTabs(){
       var form = document.getElementById("vue_form")
@@ -266,7 +275,7 @@ export default {
       saveAndSubmit.reviewTabs()
     },
     readyForSubmission(){
-      return this.allTabsComplete() && this.form.agreement == true
+      return this.allTabsComplete() && this.sharedState.agreement == true
     },
     submitForPublication(){
       var form = document.getElementById("vue_form")

--- a/app/javascript/CommitteeMember.vue
+++ b/app/javascript/CommitteeMember.vue
@@ -5,7 +5,7 @@
             You have not selected a chair or committee members. Please 
             use the buttons below to add them to your submission. 
         </div> 
-        <div v-for="chair in sharedState.committeeChairs" v-bind:value="chair.name" v-bind:key='chair.id'>
+        <div v-for="chair in sharedState.committeeChairs" v-bind:value="chair.name" v-bind:key="chairId(chair)">
             <div class="well" aria-live="polite">
             <h4>Committee Chair/Thesis Advisor</h4>
             <label :for="chairId(chair)">Committee Chair/Thesis Advisor's Affliation</label>
@@ -27,7 +27,7 @@
              </div>
         </div>
         <button type="button" class="btn btn-default" @click="addChair"><span class="glyphicon glyphicon-plus"></span> Add a Chair or Advisor</button>
-         <div v-for="member in sharedState.committeeMembers" v-bind:value="member.name" v-bind:key='member.id'>
+         <div v-for="member in sharedState.committeeMembers" v-bind:value="member.name" v-bind:key="memberId(member)">
             <div class="well">
             <h4>Committee Member</h4>
             <label :for="memberId(member)">Committee Member's Affiliation</label>

--- a/app/javascript/Submit.vue
+++ b/app/javascript/Submit.vue
@@ -1,0 +1,54 @@
+<template>
+  <section>   
+    <aboutMe></aboutMe>
+    <myProgram></myProgram>
+    <myAdvisor></myAdvisor>
+    <myEtd></myEtd>
+    <keywords></keywords>
+    <myFiles></myFiles>
+    <embargo></embargo>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from './formStore'
+import AboutMe from './components/submit/AboutMe'
+import MyProgram from './components/submit/MyProgram'
+import MyAdvisor from './components/submit/MyAdvisor'
+import MyEtd from './components/submit/MyEtd'
+import Keywords from './components/submit/Keywords'
+import MyFiles from './components/submit/MyFiles'
+import Embargo from './components/submit/Embargo'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  },
+  components: {
+    aboutMe: AboutMe,
+    myProgram: MyProgram,
+    myAdvisor: MyAdvisor,
+    myEtd: MyEtd,
+    Keywords: Keywords,
+    myFiles: MyFiles,
+    embargo: Embargo
+  }
+}
+</script>
+
+<style scoped>
+.submit-heading {
+   font-weight: 800;
+ }
+
+ section > section {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+  border-radius: 1px;
+  transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+  padding: 2em;
+  margin-bottom: 1.5em;
+ }
+</style>

--- a/app/javascript/components/submit/AboutMe.vue
+++ b/app/javascript/components/submit/AboutMe.vue
@@ -1,0 +1,36 @@
+<template>
+  <section>   
+    <h4>About Me</h4>
+    <h5 class="submit-heading">Student Name</h5>
+    <div> {{ sharedState.savedData.creator }} </div>
+    <h5>School</h5>
+    <div> {{ sharedState.savedData.school }} </div>
+    <h5>Graduation Date</h5>
+    <div> {{ sharedState.savedData.graduation_date }} </div>
+    <h5>Post-Graduation Email</h5>
+    <div> {{ sharedState.savedData.post_graduation_email }} </div>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from '../../formStore'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+</style>

--- a/app/javascript/components/submit/Embargo.vue
+++ b/app/javascript/components/submit/Embargo.vue
@@ -1,0 +1,29 @@
+<template>
+  <section>   
+    <h4>Embargoes</h4>
+    <h5>Embargo Length</h5>
+    <div>{{ sharedState.savedData.embargo_length }}</div>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from '../../formStore'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+</style>

--- a/app/javascript/components/submit/Keywords.vue
+++ b/app/javascript/components/submit/Keywords.vue
@@ -1,0 +1,45 @@
+<template>
+  <section>   
+    <h4>Keywords</h4>
+    <h5>Research Fields</h5>
+    <div v-for="(researchField, index) in sharedState.savedData.research_field" v-bind:key="index">
+      <div> {{ researchField }} </div>
+    </div>
+    <h5>Keywords</h5>
+    <div v-for="(keyword, index) in sharedState.savedData.keyword" v-bind:key="index">
+      <div> {{ keyword }} </div>
+    </div>
+   <h5>Copyright Questions</h5>
+    <ul>
+      <li>Additional copyrights: {{ sharedState.savedData.additional_copyrights }}</li>
+      <li>Requires Permission: {{ sharedState.savedData.requires_permission }} </li>
+      <li>Patents: {{ sharedState.savedData.patents }}</li>
+    </ul>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from '../../formStore'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+
+ul {
+  padding-left: 1em;
+}
+</style>

--- a/app/javascript/components/submit/MyAdvisor.vue
+++ b/app/javascript/components/submit/MyAdvisor.vue
@@ -1,0 +1,50 @@
+<template>
+  <section>   
+    <h4>My Advisor</h4>
+    <div v-for="(chair, index) in sharedState.savedData.committee_chair_attributes">
+      <ul>
+        <li>
+        Chair name: {{ chair.name[0] }}
+        </li>
+        <li> 
+        Affiliation: {{ chair.affiliation_type }}
+        </li>
+      </ul>
+    </div>
+       <div v-for="(member, index) in sharedState.savedData.committee_members_attributes">
+      <ul>
+        <li>
+        Member Name: {{ member.name[0] }}
+        </li>
+        <li> 
+        Affiliation: {{ member.affiliation_type }}
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from "../../formStore"
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+ul {
+  padding-left: 1em;
+}
+</style>

--- a/app/javascript/components/submit/MyEtd.vue
+++ b/app/javascript/components/submit/MyEtd.vue
@@ -1,0 +1,45 @@
+<template>
+  <section>   
+    <h4>My Thesis or Dissertation</h4>
+    <h5>Title</h5>
+    <div>{{ sharedState.savedData.title }}</div>
+    <h5>Language</h5>
+    <div>{{ sharedState.savedData.language }}</div>
+    <!-- TODO: think about how to render the abstract and toc without HTML tags.  -->
+    <h5>Abstract</h5>
+    <div>{{ sharedState.savedData.abstract }}</div>
+    <h5>Table of Contents</h5>
+    <div>{{ sharedState.savedData.table_of_contents }}</div>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from '../../formStore'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+</style>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+</style>

--- a/app/javascript/components/submit/MyFiles.vue
+++ b/app/javascript/components/submit/MyFiles.vue
@@ -1,0 +1,28 @@
+<template>
+  <section>   
+    <h4>My Files</h4>
+    <!-- TODO: We need some kind of info about the files in sharedState.savedData -->
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from '../../formStore'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+</style>

--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -1,0 +1,37 @@
+<template>
+  <section>   
+    <h4>My Program</h4>
+    <h5>Department</h5>
+    <div> {{ sharedState.getSelectedDepartment() }} </div>
+    <div v-if="sharedState.getSubfields()">
+          <h5>Subfield</h5>
+      <div> {{ sharedState.getSubfields() }} </div>
+    </div>
+    <h5>Degree</h5>
+    <div> {{ sharedState.getSavedDegree() }} </div>
+    <h5>Submission Type</h5>
+    <div> {{ sharedState.getSubmittingType() }} </div>
+  </section>
+</template>
+
+<script>
+import Vue from "vue"
+import { formStore } from '../../formStore'
+
+export default {
+  data() {
+    return {
+      sharedState: formStore
+    }
+  }
+}
+</script>
+<style scoped>
+h4 {
+  margin-bottom: 2em;
+}
+h5 {
+  font-weight: 700;
+  font-family: sans-serif;
+}
+</style>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -111,7 +111,9 @@ export var formStore = {
       completed: false,
       currentStep: false,
       step: 7,
-      fields: {}
+      inputs: {
+        submit: { label: 'Submit', value: [] }
+      }
     }
   },
   // The ID of the InProgressEtd record that we are editing (relational database ID).
@@ -281,11 +283,11 @@ export var formStore = {
   getSubmittingType () {
     return this.savedData['submitting_type']
   },
-  getSavedResearchFields(){
-    return this.savedData["research_field"] === undefined ? ["", "", ""] : this.savedData["research_field"]
+  getSavedResearchFields () {
+    return this.savedData['research_field'] === undefined ? ['', '', ''] : this.savedData['research_field']
   },
-  getSavedResearchField(index){
-    return this.savedData["research_field"] === undefined ? ["", "", ""] : this.savedData["research_field"]
+  getSavedResearchField (index) {
+    return this.savedData['research_field'] === undefined ? ['', '', ''] : this.savedData['research_field']
   },
   getEmbargoLengths () {
     return this.embargoLengths[this.schools.selected]

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -17,69 +17,70 @@ describe('App.vue', () => {
     beforeEach(() => {
       const wrapper = shallowMount(App, {
       })
-      wrapper.vm.$data.form.tabs.about_me.complete = false
-      wrapper.vm.$data.form.tabs.my_program.complete = false
-      wrapper.vm.$data.form.tabs.my_advisor.complete = false
-      wrapper.vm.$data.form.tabs.my_etd.complete = false
-      wrapper.vm.$data.form.tabs.keywords.complete = false
-      wrapper.vm.$data.form.tabs.my_files.complete = false
-      wrapper.vm.$data.form.tabs.embargo.complete = false
 
-      wrapper.vm.$data.form.tabs.about_me.currentStep = true
-      wrapper.vm.$data.form.tabs.my_program.currentStep = false
-      wrapper.vm.$data.form.tabs.my_advisor.currentStep = false
-      wrapper.vm.$data.form.tabs.my_etd.currentStep = false
-      wrapper.vm.$data.form.tabs.keywords.currentStep = false
-      wrapper.vm.$data.form.tabs.my_files.currentStep = false
-      wrapper.vm.$data.form.tabs.embargo.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.about_me.complete = false
+      wrapper.vm.$data.sharedState.tabs.my_program.complete = false
+      wrapper.vm.$data.sharedState.tabs.my_advisor.complete = false
+      wrapper.vm.$data.sharedState.tabs.my_etd.complete = false
+      wrapper.vm.$data.sharedState.tabs.keywords.complete = false
+      wrapper.vm.$data.sharedState.tabs.my_files.complete = false
+      wrapper.vm.$data.sharedState.tabs.embargo.complete = false
 
-      wrapper.vm.$data.form.enableTabs()
+      wrapper.vm.$data.sharedState.tabs.about_me.currentStep = true
+      wrapper.vm.$data.sharedState.tabs.my_program.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.my_advisor.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.my_etd.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.keywords.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.my_files.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.embargo.currentStep = false
+
+      wrapper.vm.$data.sharedState.enableTabs()
     });
 
     it('enables the completed and current tabs', () => {
       const wrapper = shallowMount(App, {
       })
-      wrapper.vm.$data.form.tabs.about_me.complete = true
-      wrapper.vm.$data.form.tabs.my_program.complete = true
-      wrapper.vm.$data.form.tabs.my_advisor.currentStep = true
+      wrapper.vm.$data.sharedState.tabs.about_me.complete = true
+      wrapper.vm.$data.sharedState.tabs.my_program.complete = true
+      wrapper.vm.$data.sharedState.tabs.my_advisor.currentStep = true
 
-      wrapper.vm.$data.form.enableTabs()
+      wrapper.vm.$data.sharedState.enableTabs()
 
-      expect(wrapper.vm.$data.form.tabs.about_me.disabled).toBe(false)
-      expect(wrapper.vm.$data.form.tabs.my_program.disabled).toBe(false)
-      expect(wrapper.vm.$data.form.tabs.my_advisor.disabled).toBe(false)
+      expect(wrapper.vm.$data.sharedState.tabs.about_me.disabled).toBe(false)
+      expect(wrapper.vm.$data.sharedState.tabs.my_program.disabled).toBe(false)
+      expect(wrapper.vm.$data.sharedState.tabs.my_advisor.disabled).toBe(false)
     })
 
     it('can set the complete property of a tab', () => {
       const wrapper = shallowMount(App, {
       })
-      wrapper.vm.$data.form.setComplete('About Me')
+      wrapper.vm.$data.sharedState.setComplete('About Me')
 
-      expect(wrapper.vm.$data.form.tabs.about_me.complete).toBe(true)
+      expect(wrapper.vm.$data.sharedState.tabs.about_me.complete).toBe(true)
     })
 
     it('sets the current tab property', () => {
       const wrapper = shallowMount(App, {
       })
       // user has completed About Me tab, and My Program is current tab
-      wrapper.vm.$data.form.tabs.about_me.complete = true
-      wrapper.vm.$data.form.tabs.about_me.currentStep = false
-      wrapper.vm.$data.form.tabs.my_program.currentStep = true
-      wrapper.vm.$data.form.enableTabs()
-      expect(wrapper.vm.$data.form.tabs.about_me.currentStep).toBe(false)
+      wrapper.vm.$data.sharedState.tabs.about_me.complete = true
+      wrapper.vm.$data.sharedState.tabs.about_me.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.my_program.currentStep = true
+      wrapper.vm.$data.sharedState.enableTabs()
+      expect(wrapper.vm.$data.sharedState.tabs.about_me.currentStep).toBe(false)
 
       //find and click first tab
       wrapper.find('a.tab').trigger('click')
 
-      expect(wrapper.vm.$data.form.tabs.about_me.currentStep).toBe(true)
+      expect(wrapper.vm.$data.sharedState.tabs.about_me.currentStep).toBe(true)
     })
 
     it('determines the next current tab', () => {
       const wrapper = shallowMount(App, {
       })
-      wrapper.vm.$data.form.nextStepIsCurrent(3)
+      wrapper.vm.$data.sharedState.nextStepIsCurrent(3)
 
-      expect(wrapper.vm.$data.form.tabs.keywords.currentStep).toBe(true)
+      expect(wrapper.vm.$data.sharedState.tabs.keywords.currentStep).toBe(true)
     })
 
     it('prevents a user from navigating to disabled tabs', () => {

--- a/app/javascript/test/Submit.spec.js
+++ b/app/javascript/test/Submit.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Submit from '../Submit'
+
+describe('Submit.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(Submit, {
+    })
+    expect(wrapper.html()).toEqual('<section><aboutme-stub></aboutme-stub> <myprogram-stub></myprogram-stub> <myadvisor-stub></myadvisor-stub> <myetd-stub></myetd-stub> <keywords-stub></keywords-stub> <myfiles-stub></myfiles-stub> <embargo-stub></embargo-stub></section>')
+  })
+})

--- a/app/javascript/test/components/submit/AboutMe.spec.js
+++ b/app/javascript/test/components/submit/AboutMe.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import AboutMe from '../../../components/submit/AboutMe'
+
+describe('AboutMe.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(AboutMe, {
+    })
+    expect(wrapper.html()).toContain('About Me')
+  })
+})

--- a/app/javascript/test/components/submit/Embargo.spec.js
+++ b/app/javascript/test/components/submit/Embargo.spec.js
@@ -1,0 +1,15 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Embargo from '../../../components/submit/Embargo'
+import axios from 'axios'
+jest.mock('axios')
+
+describe('Embargo.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(Embargo, {
+    })
+    expect(wrapper.html()).toContain('Embargo')
+  })
+})

--- a/app/javascript/test/components/submit/Keywords.spec.js
+++ b/app/javascript/test/components/submit/Keywords.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import Keywords from '../../../components/submit/Keywords'
+
+describe('Embargo.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(Keywords, {
+    })
+    expect(wrapper.html()).toContain('Keywords')
+  })
+})

--- a/app/javascript/test/components/submit/MyAdvisor.spec.js
+++ b/app/javascript/test/components/submit/MyAdvisor.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import MyAdvisor from '../../../components/submit/MyAdvisor'
+
+describe('MyAdvisor.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(MyAdvisor, {
+    })
+    expect(wrapper.html()).toContain('My Advisor')
+  })
+})

--- a/app/javascript/test/components/submit/MyEtd.spec.js
+++ b/app/javascript/test/components/submit/MyEtd.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import MyEtd from '../../../components/submit/MyEtd'
+
+describe('MyEtd.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(MyEtd, {
+    })
+    expect(wrapper.html()).toContain('My Thesis or Dissertation')
+  })
+})

--- a/app/javascript/test/components/submit/MyFiles.spec.js
+++ b/app/javascript/test/components/submit/MyFiles.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import MyFiles from '../../../components/submit/MyFiles'
+
+describe('MyFiles.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(MyFiles, {
+    })
+    expect(wrapper.html()).toContain('My Files')
+  })
+})

--- a/app/javascript/test/components/submit/MyProgram.spec.js
+++ b/app/javascript/test/components/submit/MyProgram.spec.js
@@ -1,0 +1,13 @@
+/* global describe */
+/* global it */
+/* global expect */
+import { shallowMount } from '@vue/test-utils'
+import MyProgram from '../../../components/submit/MyProgram'
+
+describe('MyProgram.vue', () => {
+  it('has the correct label', () => {
+    const wrapper = shallowMount(MyProgram, {
+    })
+    expect(wrapper.html()).toContain('My Program')
+  })
+})


### PR DESCRIPTION
This introduces additional components that are used
to read from the `sharedState` and from the `savedData` to
render the completed form. There are portions that we will
need to decide how to re-display that are marked with TODOs.

This also has some small refactoring in `App.vue`. The `sharedState`
was called `form` in that file, but not anywhere else. I changed
this to be `sharedState` so as to follow the naming convention in
the other files.

Related to #1190