### PR TITLE
Fix for blank page when clicking Submit My Etd

### DIFF
--- a/app/views/hyrax/homepage/_submit_my_etd.html.erb
+++ b/app/views/hyrax/homepage/_submit_my_etd.html.erb
@@ -1,7 +1,7 @@
 <div class="home_share_work row">
   <div class="col-sm-12 text-center">
     <%= link_to new_polymorphic_path([main_app, Etd]),
-        class: 'btn btn-primary' do %>
+        class: 'btn btn-primary', data: { turbolinks: false } do %>
     <i class="glyphicon glyphicon-upload"></i> <%= t('hyrax.share_button') %>
     <% end %>
     <p><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path %></p>


### PR DESCRIPTION
Turbolinks conflicts with the loading of the new form, this
just turns off turbolinks for that link. When you click
it you will go to form without it being loaded by Turbolinks.

This changes this for both the old form and the new form, but won't
have any negative consquences. The page will be loaded using
normal browser nagivation (there won't be a loading bar across
the screen when clicking the link).

For #1385