### PR TITLE
Remove confusing menu items from admin dashboard

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -42,10 +42,4 @@
       <% end %>
     <% end %>
 
-    <% if can?(:manage, Sipity::WorkflowResponsibility) %>
-      <%= menu.nav_link(hyrax.admin_users_path) do %>
-        <span class="fa fa-cog"></span>
-        <span class="sidebar-action-text">Manage Users</span>
-      <% end %>
-    <% end # end of configuration block %>
   <% end %>

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -1,0 +1,19 @@
+<li class="h5"><%= t('hyrax.admin.sidebar.tasks') %></li>
+
+  <% if can? :review, :submissions %>
+    <%= menu.nav_link(hyrax.admin_workflows_path) do %>
+      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_review') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :manage, Sipity::WorkflowResponsibility %>
+    <%= menu.nav_link(hyrax.admin_users_path) do %>
+      <span class="fa fa-user"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.users') %></span>
+    <% end %>
+  <% end %>
+
+  <% if can? :read, :admin_dashboard %>
+    <%= menu.nav_link(hyrax.embargoes_path) do %>
+      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
+    <% end %>
+  <% end %>

--- a/spec/features/workflow_approval_spec.rb
+++ b/spec/features/workflow_approval_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Dashboard workflow', :clean, integration: true do
     click_on 'Review Submissions'
 
     expect(page).to have_content etd.title.first
-    expect(page).to have_content depositing_user.user_key
+    expect(page).to have_content etd.contributor.first
     expect(page).to have_content 'pending_approval'
   end
 end


### PR DESCRIPTION
Removing Manage Leases because this application doesn't use
leases.

Moving Manage Users back to the Tasks menu, which is where it
was originally. 

Closes #1166 