### PR TITLE
reverting to old way of getting formData for uploader temp bug fix

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -160,7 +160,7 @@ export default {
         formStore: this.sharedState,
         token: this.sharedState.token,
         event: e,
-        formData: this.sharedState.formData
+        formData: this.getFormData()
       })
       fileUploader.uploadFile()
     },
@@ -169,9 +169,14 @@ export default {
         formStore: this.sharedState,
         token: token,
         event: e,
-        formData: this.sharedState.formData
+        formData: this.getFormData()
       })
       supplementalFileUploader.uploadFile()
+    },
+    getFormData() {
+      var form = document.getElementById('vue_form')
+      var formData = new FormData(form)
+      return formData
     },
     deleteFile(deleteUrl) {
       var fileDelete = new FileDelete({


### PR DESCRIPTION
hey @little9 I doubt this is what you want to do, but getting the formdata in the old way for the uploader fixes the post bug. 