### PR TITLE
Set visibility private for hidden objects

### DIFF
--- a/app/services/hyrax/workflow/hide_object.rb
+++ b/app/services/hyrax/workflow/hide_object.rb
@@ -8,6 +8,11 @@ module Hyrax
     module HideObject
       def self.call(target:, **)
         target.hidden = true
+        target.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        target.members.each do |fs|
+          fs.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+          fs.save
+        end
       end
     end
   end

--- a/app/services/hyrax/workflow/unhide_object.rb
+++ b/app/services/hyrax/workflow/unhide_object.rb
@@ -7,6 +7,11 @@ module Hyrax
     module UnhideObject
       def self.call(target:, **)
         target.hidden = false
+        target.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        target.members.each do |fs|
+          fs.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          fs.save
+        end
       end
     end
   end


### PR DESCRIPTION
When an object is marked "hidden" set its visibility to
private. When it is unhidden, set visibility back to open.

Also apply hidden visibility to attached file sets.

Fixes #1408 
Fixes #303

@no-reply This is the solution we talked about today. I think it's not great that "un-hiding" a work sets it and its files back to "open", but I'm hoping it's good enough for now. Can we just explain that if you decide to "un-hide" something, but you still want to embargo part of it, you'll need to go set the embargo separately? 