### PR TITLE
Edit an ETD after it has been submitted. Story #1192

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ AllCops:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/GuardClause:
+  Exclude:
+    - 'app/controllers/hyrax/etds_controller.rb'
+
 Style/NumericPredicate:
   Enabled: false
 

--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -27,9 +27,24 @@ module Hyrax
     def update
       sanitize_input(params)
       merge_selected_files_hashes(params) if params["selected_files"]
-      update_supplemental_files
-      update_committee_members
-      super
+
+      if Rails.application.config_for(:new_ui).fetch('enabled', false)
+        new_ui_update_behavior
+      else # old_ui behavior
+        update_supplemental_files
+        update_committee_members
+        super
+      end
+    end
+
+    def new_ui_update_behavior
+      if actor.update(actor_environment)
+        path = main_app.hyrax_etd_path(curation_concern)
+        render json: { redirectPath: path }, status: :ok
+      else
+        raise "TODO: Error path is not implemented yet"
+        # render json: { errors: curation_concern.errors.messages }, status: 422
+      end
     end
 
     # Override from Hyrax:app/controllers/concerns/hyrax/curation_concern_controller.rb

--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -2,7 +2,12 @@ class InProgressEtdsController < ApplicationController
   # TODO: this needs to be authorized - all controller actions
 
   def new
-    @in_progress_etd = InProgressEtd.find_or_create_by(user_ppid: current_user.ppid)
+    @in_progress_etd = if params[:etd_id]
+                         InProgressEtd.find_or_create_by(etd_id: params[:etd_id])
+                       else
+                         InProgressEtd.find_or_create_by(user_ppid: current_user.ppid)
+                       end
+
     # Now that the record has been created, render the form so student can edit it:
     redirect_to action: :edit, id: @in_progress_etd.id
   end
@@ -11,7 +16,8 @@ class InProgressEtdsController < ApplicationController
 
   def edit
     @in_progress_etd = InProgressEtd.find(params[:id])
-    @data = @in_progress_etd.data unless @in_progress_etd.data.nil?
+    @in_progress_etd.refresh_from_etd!
+    @data = @in_progress_etd.data
   end
 
   # The Vue.js form uses this action to update the record.

--- a/app/helpers/etd_form_helper.rb
+++ b/app/helpers/etd_form_helper.rb
@@ -7,4 +7,14 @@ module EtdFormHelper
         ": #{attrs_hash['name'].first} (#{attrs_hash['affiliation'].first})"
     end
   end
+
+  # If we're using the old UI, just use the regular path from Hyrax for editing Etd record.
+  # If we're using the new UI, use the path for the InProgressEtdsController.
+  def etd_edit_link(presenter)
+    if Rails.application.config_for('new_ui').fetch('enabled', false)
+      link_to 'Edit', main_app.new_in_progress_etd_path(etd_id: presenter.id), class: 'btn btn-default', data: { turbolinks: false }
+    else
+      link_to 'Edit', edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default'
+    end
+  end
 end

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -60,4 +60,18 @@ export default class SaveAndSubmit {
         console.log('an error', e)
       })
   }
+  updateEtd () {
+    axios.defaults.headers.common['X-CSRF-Token'] = this.formStore.token
+    var form = document.getElementById('vue_form')
+    var formData = new FormData(form)
+
+    axios.patch(`/concern/etds/${this.formStore.etdId}`, formData)
+      .then(response => {
+        window.location = response.data.redirectPath
+      })
+      .catch(e => {
+        // this.errors.push(e)
+        console.log('an error', e)
+      })
+  }
 }

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -3,6 +3,7 @@
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
 import App from 'App'
+import { quillEditor } from 'vue-quill-editor'
 import axios from 'axios'
 jest.mock('axios')
 
@@ -97,6 +98,26 @@ describe('App.vue', () => {
     })
     it('lets the user submit their data for publication as an ETD', () => {
 
+    })
+  })
+
+  describe('Edit form:', () => {
+    it('with an associated ETD record, renders the form without tabs', () => {
+      const wrapper = shallowMount(App, { })
+      wrapper.vm.$data.sharedState.setEtdId('123')
+      expect(wrapper.html()).toContain('Submit Your Thesis')
+      expect(wrapper.findAll('ul.navtabs').length).toEqual(0)
+      expect(wrapper.html()).toContain('<useragreement-stub></useragreement-stub>')
+      expect(wrapper.html()).not.toContain('<submit-stub></submit-stub>')
+    })
+
+    it('without an associated ETD record, renders the form with tabs', () => {
+      const wrapper = shallowMount(App, { })
+      wrapper.vm.$data.sharedState.setEtdId(undefined)
+      expect(wrapper.html()).toContain('Submit Your Thesis')
+      expect(wrapper.findAll('ul.navtabs').length).toEqual(1)
+      expect(wrapper.html()).not.toContain('<useragreement-stub></useragreement-stub>')
+      expect(wrapper.html()).not.toContain('<submit-stub></submit-stub>')
     })
   })
 })

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,49 @@
+<div class="show-actions">
+  <% if Hyrax.config.analytics? %>
+    <%= link_to "Analytics", presenter.stats_path, id: 'stats', class: 'btn btn-default', data: { turbolinks: false } %>
+  <% end %>
+
+  <% if presenter.editor? %>
+    <%= etd_edit_link(presenter) %>
+    <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
+    <% if presenter.member_presenters.size > 1 %>
+      <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
+    <% end %>
+    <% if presenter.valid_child_concerns.length > 0 %>
+      <div class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Attach Child <span class="caret"></span>
+        </button>
+
+        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+          class: 'btn btn-default submits-batches submits-batches-add',
+          data: { toggle: "modal", target: "#collection-list-container" } %>
+
+        <ul class="dropdown-menu">
+          <% presenter.valid_child_concerns.each do |concern| %>
+            <li>
+              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if presenter.work_featurable? %>
+    <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
+      data: { behavior: 'feature' },
+      class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+
+    <%= link_to "Unfeature", hyrax.featured_work_path(presenter, format: :json),
+      data: { behavior: 'unfeature' },
+      class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
+  <% end %>
+</div>
+
+<!-- COinS hook for Zotero -->
+<span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+<%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
+

--- a/app/views/in_progress_etds/edit.html.erb
+++ b/app/views/in_progress_etds/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render 'form' %>
+<%= render 'in_progress_etds/form' %>

--- a/db/migrate/20180720185001_add_etd_id_to_in_progress_etds.rb
+++ b/db/migrate/20180720185001_add_etd_id_to_in_progress_etds.rb
@@ -1,0 +1,5 @@
+class AddEtdIdToInProgressEtds < ActiveRecord::Migration[5.1]
+  def change
+    add_column :in_progress_etds, :etd_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180627152109) do
+ActiveRecord::Schema.define(version: 20180720185001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,7 @@ ActiveRecord::Schema.define(version: 20180627152109) do
     t.string "subfield"
     t.string "partnering_agency"
     t.string "data"
+    t.string "etd_id"
   end
 
   create_table "job_io_wrappers", id: :serial, force: :cascade do |t|

--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
   end
 
   describe "#update" do
+    before(:all) do
+      new_ui = Rails.application.config_for(:new_ui).fetch('enabled', false)
+      skip("These specs should only be run for the old UI") if new_ui
+    end
+
     let(:default_attrs) do
       { depositor: user.user_key,
         title: ['Another great thesis by Frodo'],


### PR DESCRIPTION
* This code only handles most of the happy path (successful form saves),
 not the error path.  Currently it doesn't handle attached files, but
 should handle most of the metadata fields.

* After the student submits the form, they will be redirected to the Etd
 show page.

* I added an etd_id to the InProgressEtd model so that we can associate
 an InProgressEtd with the Etd record that it represents.

* I added a method to the InProgressEtd model that allows you to refresh
 the JSON data store with the latest data from the Etd record.

* I overrode a view partial from Hyrax so that I could change the 'Edit'
 button to route to the new controller when the new UI is enabled, but
 it should keep the old behavior if new UI is not enabled.
 (app/views/hyrax/base/_show_actions.html.erb)

* I added code in the EtdsController to handle the Etd record update for
 the new UI.