### PR TITLE
Don't display the abstract/TOC as HTML in submit tab

### DIFF
--- a/app/javascript/HtmlStripper.js
+++ b/app/javascript/HtmlStripper.js
@@ -1,0 +1,10 @@
+export default class HtmlStripper {
+  constructor (options) {
+    this.html = options.html
+  }
+
+  strippedHtml () {
+    const doc = new DOMParser().parseFromString(this.html, 'text/html')
+    return doc.body.textContent || ''
+  }
+}

--- a/app/javascript/components/submit/MyEtd.vue
+++ b/app/javascript/components/submit/MyEtd.vue
@@ -5,22 +5,24 @@
     <div>{{ sharedState.savedData.title }}</div>
     <h5>Language</h5>
     <div>{{ sharedState.savedData.language }}</div>
-    <!-- TODO: think about how to render the abstract and toc without HTML tags.  -->
     <h5>Abstract</h5>
-    <div>{{ sharedState.savedData.abstract }}</div>
+    <div>{{ abstract }}</div>
     <h5>Table of Contents</h5>
-    <div>{{ sharedState.savedData.table_of_contents }}</div>
+    <div>{{ tableOfContents }}</div>
   </section>
 </template>
 
 <script>
 import Vue from "vue"
 import { formStore } from '../../formStore'
+import HtmlStripper from '../../HtmlStripper'
 
 export default {
   data() {
     return {
-      sharedState: formStore
+      sharedState: formStore,
+      abstract: new HtmlStripper({ html: formStore.savedData.abstract }).strippedHtml(),
+      tableOfContents: new HtmlStripper({ html: formStore.savedData.table_of_contents }).strippedHtml()
     }
   }
 }

--- a/app/javascript/test/HtmlStripper.spec.js
+++ b/app/javascript/test/HtmlStripper.spec.js
@@ -1,0 +1,15 @@
+/* global describe */
+/* global it */
+/* global expect */
+import HtmlStripper from '../HtmlStripper'
+
+// This needs to check for both cases: visible / not-present
+// now it tests that it isn't present
+describe('HtmlStripper', () => {
+  it('removes HTML tags from a string', () => {
+    var htmlStripper = new HtmlStripper({
+      html: '<p>Testing</p>'
+    })
+    expect(htmlStripper.strippedHtml()).toEqual('Testing')
+  })
+})


### PR DESCRIPTION
This commit adds a class that can be used to strip
the html tags out of the abstract and TOC so that
they can be redisplayed on the final submission tab.

Without this, we'll either need to display the content
as actual HTML which has the potential to break the page,
or show the tags.

Related to #1190