### PR TITLE
Set FileSet visibility on embargoed works

### DIFF
--- a/lib/tasks/embargo_enforcement.rake
+++ b/lib/tasks/embargo_enforcement.rake
@@ -1,0 +1,14 @@
+namespace :emory do
+  desc "Enforce FileSet embagro for embargoed Etds."
+  task :embargo_enforcement do
+    Hyrax::EmbargoService.assets_under_embargo.each do |presenter|
+      etd = presenter.model_name.name.constantize.find(presenter.id)
+      next unless etd.is_a? Etd
+
+      etd.file_sets.each do |fs|
+        fs.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        fs.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
All works that are under embargo should have their fileset's visibility set to
`"private"`. This task agressively sets that status in the event that it falls
out of sync.

This was already merged to the 1.x branch, and we need it on 2.x as well.