### PR TITLE
displaying next incomplete tab based on saved completion status

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -215,7 +215,13 @@ export default {
     submit: Submit,
     userAgreement: UserAgreement
   },
-  mounted (){
+  created () {
+    // this executes only the first time the page is loaded (before adding it to the dom), so we need the freshest saved data we have, and we use it to set the state of the tabs.
+    this.sharedState.loadSavedData()
+    this.sharedState.loadTabs()
+  },
+  beforeMount () {
+    // this is loaded every time the form changes (whenever the component changes and before the native DOM is updated)
     this.sharedState.loadSavedData()
     this.sharedState.token = token
   },

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -50,7 +50,7 @@ export default class SaveAndSubmit {
     // submit as form data
     this.formStore.savedData['school'] = this.formStore.getSchoolText(this.formStore.savedData['school'])
     axios.defaults.headers.common['X-CSRF-Token'] = this.formStore.token
-    var savedDataToSubmit = { 'etd': this.formStore.savedData } 
+    var savedDataToSubmit = { 'etd': this.formStore.savedData }
     axios.post('/concern/etds', savedDataToSubmit)
       .then(response => {
         window.location = response.request.responseURL

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -248,6 +248,29 @@ export var formStore = {
     this.keywords = savedKeywords
     }
   },
+  getNextStep () {
+    return parseInt(this.savedData['currentStep']) + 1
+  },
+  loadTabs () {
+    // first time form has ever been loaded, start at the beginning
+    if (this.savedData['currentStep'] === undefined){
+      this.tabs.about_me.currentStep = true
+    } else {
+      // we want to display the next tab the student has not completed, which will be the tab's step index in the saved currentStep property, plus 1.
+      for (var tab in this.tabs) {
+        if (this.tabs[tab].step === this.getNextStep()){
+          this.tabs[tab].currentStep = true
+        } else {
+          this.tabs[tab].currentStep = false
+        }
+        if (this.tabs[tab].step <= this.getNextStep()) {
+          this.tabs[tab].disabled = false
+        } else {
+          this.tabs[tab].disabled = true
+        }
+      }
+    }
+  },
   setComplete (tabName) {
     for (var tab in this.tabs) {
       if (this.tabs[tab].label === tabName) {

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -101,6 +101,31 @@ describe('App.vue', () => {
     })
   })
 
+  describe('Tabs reflect saved progress', () => {
+    beforeEach(() => {
+      const wrapper = shallowMount(App, {
+      })
+      // simulate completion of first two tabs
+      wrapper.vm.$data.sharedState.savedData['currentStep'] = 1
+    })
+
+    it('displays the 3rd tab if the saved currentStep = 2nd', () => {
+      const wrapper = shallowMount(App, {
+      })
+      expect(wrapper.vm.$data.sharedState.tabs.about_me.disabled).toBe(false)
+      expect(wrapper.vm.$data.sharedState.tabs.my_program.disabled).toBe(false)
+      expect(wrapper.vm.$data.sharedState.tabs.my_advisor.disabled).toBe(false)
+
+      expect(wrapper.vm.$data.sharedState.tabs.my_etd.disabled).toBe(true)
+      expect(wrapper.vm.$data.sharedState.tabs.keywords.disabled).toBe(true)
+      expect(wrapper.vm.$data.sharedState.tabs.my_files.disabled).toBe(true)
+      expect(wrapper.vm.$data.sharedState.tabs.embargo.disabled).toBe(true)
+
+      expect(wrapper.vm.$data.sharedState.tabs.my_advisor.currentStep).toBe(true)
+    })
+
+  })
+
   describe('Edit form:', () => {
     it('with an associated ETD record, renders the form without tabs', () => {
       const wrapper = shallowMount(App, { })


### PR DESCRIPTION
This commit adds some code to the create and beforeMounted Vue lifecycle hooks to find out which tab is the last valid saved one. Each tab has a step property, an integer. When a tab is validated on the backend, its step property is returned to the front end as 'currentStep' and is accessible from the formStore's savedData. When the form loads now, in its create hook it checks the savedData for a defined 'currentStep', and if it doesn't find one, displays the form in its default beginning state, with the first tab enabled. If it finds a currentStep, it enables all tabs whose step property is less than or equal to itself, and displays the tab whose step property equals itself plus 1.