### PR TITLE
displaying valid tabs and handling mismatch between school and dept

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -29,7 +29,7 @@ class InProgressEtdsController < ApplicationController
 
     if @in_progress_etd.save
       @data = @in_progress_etd.data
-      render json: { in_progress_etd: @data, lastCompletedStep: current_step, tab_name: tab_name }, status: 200
+      render json: { in_progress_etd: @data, lastCompletedStep: current_step(@data), tab_name: tab_name }, status: 200
     else
       render json: { errors: @in_progress_etd.errors.messages }, status: 422
     end
@@ -45,9 +45,9 @@ class InProgressEtdsController < ApplicationController
 
   private
 
-    def current_step
-      etd = request.parameters.fetch(:etd)
-      etd.fetch(:currentStep, 0)
+    def current_step(data)
+      saved_data = JSON.parse(data)
+      saved_data['currentStep']
     end
 
     def tab_name

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -26,6 +26,9 @@
               <section class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
+              <section class='errorMessage' v-if="sharedState.hasError('schoolDeptMismatch')">
+                  <p>You have not saved the school that is currently selected in 'About Me'. No departments are available.</p>
+              </section>
             </div>
             <div v-else-if="input.label === 'subfield'">
               <subfield></subfield>
@@ -217,6 +220,8 @@ export default {
     // this executes only the first time the page is loaded (before adding it to the dom), so we need the freshest saved data we have, and we use it to set the state of the tabs.
     this.sharedState.loadSavedData()
     this.sharedState.loadTabs()
+    this.sharedState.loadDepartments()
+    // load schools?
   },
   beforeMount () {
     // this is loaded every time the form changes (whenever the component changes and before the native DOM is updated)

--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -23,14 +23,25 @@ export default {
   },
 
   watch: {
-    selected() {
-      this.sharedState.clearDepartment()
-      this.sharedState.clearSubfields()
-      this.sharedState.setSelectedDepartment(this.selected)
-      this.sharedState.getSubfields()
+    selected () {
+      if (this.sharedState.getSavedDepartment() !== undefined) {
+        this.sharedState.loadDepartments()
+        this.sharedState.setSelectedDepartment(this.selected)
+        this.sharedState.getSubfields()
+      } else {
+        this.sharedState.clearDepartment()
+        this.sharedState.clearSubfields()
+      }
     }
   },
-  mounted: function(){
+  beforeMount: function(){
+    if (!this.sharedState.savedAndSelectedSchoolsMatch()){
+      this.sharedState.clearDepartments()
+      this.sharedState.clearDepartment()
+      this.sharedState.clearSubfields()
+    }
+  },
+  mounted: function (){
     this.$nextTick(function () {
       this.selected = this.sharedState.getSavedDepartment()
     })

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -21,9 +21,9 @@ export default class SaveAndSubmit {
         // populate form in order to use its inputs
         this.formStore.loadSavedData()
 
-        this.formStore.nextStepIsCurrent(response.data.lastCompletedStep)
+        //this.formStore.nextStepIsCurrent(response.data.lastCompletedStep)
         this.formStore.setComplete(response.data.tab_name)
-        this.formStore.enableTabs()
+        this.formStore.loadTabs()
       })
       .catch(error => {
         this.formStore.errored = true
@@ -39,7 +39,7 @@ export default class SaveAndSubmit {
         // for now fake that user got here naturally
         this.formStore.nextStepIsCurrent(6)
         this.formStore.setComplete('embargo')
-        this.formStore.enableTabs()
+        this.formStore.loadTabs()
       })
       .catch(error => {
         console.log('an error', error)

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -37,7 +37,8 @@ export default {
   },
   mounted: function(){
     this.$nextTick(function () {
-      var selected = this.sharedState.getSchoolOptionValue()
+      //this needs to be saved or selected
+      var selected = this.sharedState.getSavedOrSelectedSchool()
       if(selected === undefined){
         selected = ''
       }
@@ -48,6 +49,9 @@ export default {
     selected() {
       //this executes when the component is rendered the first time and when the change event fires (user selects something)
       this.fetchData();
+      if (!this.sharedState.savedAndSelectedSchoolsMatch()){
+        this.sharedState.errors.push({"schoolDeptMismatch": ''})
+      }
     }
   }
 };

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -290,15 +290,15 @@ export var formStore = {
       }
     }
   },
-  nextStepIsCurrent (lastCompletedStep) {
-    for (var tab in this.tabs) {
-      if (this.tabs[tab].step === parseInt(lastCompletedStep) + 1) {
-        this.tabs[tab].currentStep = true
-      } else {
-        this.tabs[tab].currentStep = false
-      }
-    }
-  },
+  // nextStepIsCurrent (lastCompletedStep) {
+  //   for (var tab in this.tabs) {
+  //     if (this.tabs[tab].step === parseInt(lastCompletedStep) + 1) {
+  //       this.tabs[tab].currentStep = true
+  //     } else {
+  //       this.tabs[tab].currentStep = false
+  //     }
+  //   }
+  // },
   hasError (inputKey) {
     var hasError = false
     _.forEach(this.errors, function (error) {
@@ -321,11 +321,25 @@ export var formStore = {
   /* Getters & Setters */
 
   /* Schools, Departments & Subfields */
+  // our 'messy state' flag
+  // from here, you should be able to save the new school selection
+  // but your program and embargo tabs are now invalid. you can navigate to the program tab, but maybe you get an error message next to departments (and embargoes) and it tells you to save your school.
+  savedAndSelectedSchoolsMatch(){
+    return this.schools.selected === this.savedData['school']
+  },
 
   getSelectedSchool () {
     return this.schools.selected
   },
-  getSchoolOptionValue () {
+
+  getSavedOrSelectedSchool () {
+    if (this.selectedSchool === undefined) {
+      this.selectedSchool = ''
+    }
+    return this.selectedSchool.length === 0 ?
+    this.savedData['school'] : this.schools.selected
+  },
+  getSavedSchool () {
     return this.savedData['school']
   },
   setSelectedSchool (school) {
@@ -333,6 +347,10 @@ export var formStore = {
   },
 
   getSelectedDepartment () {
+    return this.selectedDepartment
+  },
+
+  getSavedOrSelectedDepartment () {
     return this.selectedDepartment.length === 0 ? this.savedData['department'] : this.selectedDepartment
   },
 
@@ -347,10 +365,19 @@ export var formStore = {
     this.selectedDepartment = ''
     this.savedData['department'] = ''
   },
+  clearDepartments(){
+    this.departments = []
+  },
   getDepartments (selectedSchool) {
     axios.get(selectedSchool).then(response => {
       this.departments = response.data
     })
+  },
+  loadDepartments () {
+    if (this.savedData['department'] !== undefined){
+      var school_endpoint = '/authorities/terms/local/' + this.savedData['school'] + '_programs'
+      this.getDepartments (school_endpoint)
+    }
   },
   getSelectedSubfield(){
     if (this.selectedSubfield === undefined) {
@@ -419,6 +446,7 @@ export var formStore = {
   formData: undefined,
   setFormData (formElement) {
     var formData = new FormData(formElement)
+    //these needs to be whatever is current
     formData.append(this.etdPrefix('school'), this.getSelectedSchool())
     formData.append(this.etdPrefix('department'), this.getSelectedDepartment())
     this.formData = formData

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -35,21 +35,24 @@ describe('App.vue', () => {
       wrapper.vm.$data.sharedState.tabs.my_files.currentStep = false
       wrapper.vm.$data.sharedState.tabs.embargo.currentStep = false
 
-      wrapper.vm.$data.sharedState.enableTabs()
+      wrapper.vm.$data.sharedState.loadTabs()
     });
 
     it('enables the completed and current tabs', () => {
       const wrapper = shallowMount(App, {
       })
+      wrapper.vm.$data.sharedState.savedData['currentStep'] = 1
       wrapper.vm.$data.sharedState.tabs.about_me.complete = true
       wrapper.vm.$data.sharedState.tabs.my_program.complete = true
       wrapper.vm.$data.sharedState.tabs.my_advisor.currentStep = true
-
-      wrapper.vm.$data.sharedState.enableTabs()
+      wrapper.vm.$data.sharedState.currentStep = 1
+      wrapper.vm.$data.sharedState.loadTabs()
 
       expect(wrapper.vm.$data.sharedState.tabs.about_me.disabled).toBe(false)
       expect(wrapper.vm.$data.sharedState.tabs.my_program.disabled).toBe(false)
       expect(wrapper.vm.$data.sharedState.tabs.my_advisor.disabled).toBe(false)
+
+      wrapper.vm.$data.sharedState.savedData['currentStep'] = undefined
     })
 
     it('can set the complete property of a tab', () => {
@@ -64,24 +67,18 @@ describe('App.vue', () => {
       const wrapper = shallowMount(App, {
       })
       // user has completed About Me tab, and My Program is current tab
+      wrapper.vm.$data.sharedState.savedData['currentStep'] = 1
       wrapper.vm.$data.sharedState.tabs.about_me.complete = true
       wrapper.vm.$data.sharedState.tabs.about_me.currentStep = false
       wrapper.vm.$data.sharedState.tabs.my_program.currentStep = true
-      wrapper.vm.$data.sharedState.enableTabs()
+      wrapper.vm.$data.sharedState.loadTabs()
       expect(wrapper.vm.$data.sharedState.tabs.about_me.currentStep).toBe(false)
 
       //find and click first tab
       wrapper.find('a.tab').trigger('click')
 
       expect(wrapper.vm.$data.sharedState.tabs.about_me.currentStep).toBe(true)
-    })
-
-    it('determines the next current tab', () => {
-      const wrapper = shallowMount(App, {
-      })
-      wrapper.vm.$data.sharedState.nextStepIsCurrent(3)
-
-      expect(wrapper.vm.$data.sharedState.tabs.keywords.currentStep).toBe(true)
+      wrapper.vm.$data.sharedState.savedData['currentStep'] = undefined
     })
 
     it('prevents a user from navigating to disabled tabs', () => {

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -43,7 +43,7 @@ class InProgressEtd < ApplicationRecord
 
     new_data = add_no_embargoes(new_data)
     existing_data = remove_stale_embargo_data(existing_data, new_data)
-
+    new_data = keep_last_completed_step(existing_data, new_data)
     resulting_data = existing_data.merge(new_data)
     self.data = resulting_data.to_json
     resulting_data
@@ -64,6 +64,11 @@ class InProgressEtd < ApplicationRecord
     existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:embargo_length] != 'None - open access immediately'
     existing_data.delete('embargo_type') if new_data[:embargo_length] == 'None - open access immediately' && existing_data.keys.include?('embargo_type')
     existing_data
+  end
+
+  def keep_last_completed_step(existing_data, new_data)
+    new_data[:currentStep] = existing_data['currentStep'] if existing_data.keys.include?('currentStep') && existing_data['currentStep'] >= new_data[:currentStep]
+    new_data
   end
 
   # Store this record's ID for the javascript form to use.

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -182,6 +182,36 @@ describe InProgressEtd do
       end
     end
 
+    context 'with a lower new currentStep than the old currentStep' do
+      let(:new_data) { { 'currentStep': '0' } }
+      let(:old_data) { { 'currentStep': '4' } }
+      it 'preserves the highest currentStep' do
+        expect(resulting_data).to eq({
+          'currentStep' => '4'
+        })
+      end
+    end
+
+    context 'with a higher new currentStep than the old currentStep' do
+      let(:new_data) { { 'currentStep': '3' } }
+      let(:old_data) { { 'currentStep': '1' } }
+      it 'preserves the highest currentStep' do
+        expect(resulting_data).to eq({
+          'currentStep' => '3'
+        })
+      end
+    end
+
+    context 'with the same new currentStep as the old currentStep' do
+      let(:new_data) { { 'currentStep': '2' } }
+      let(:old_data) { { 'currentStep': '2' } }
+      it 'preserves the highest currentStep' do
+        expect(resulting_data).to eq({
+          'currentStep' => '2'
+        })
+      end
+    end
+
     context 'with updated data (symbol vs string keys)' do
       let(:old_data) { { title: 'The Old Title' } }
       let(:new_data) { { 'title': 'The New Title' } }


### PR DESCRIPTION
This commit ensures the next tab the user should see is displayed. This is accomplished by storing the currentStep property, which is a record of a valid tab save, and comparing each new currentStep against it in the model. When a user has four valid tabs, and edits the first, and saves it, the 'currentStep' should not become the first tab; we ensure the tab that displays is the fifth in that case.

It also handles the case where a user has saved school and department data, and changes their school selection and navigates to the program tab without saving their newly selected school. An error message is displayed next to the Department field and no options are loaded. In a future commit the tab(s) will reflect this messy/dirty state so that students can easily see which tabs are valid (saved) and which tabs have new but unsaved information in them.