### PR TITLE
adding validity display to tabs and school component

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -4,7 +4,7 @@
       <h1>Submit Your Thesis or Dissertation</h1>
     <ul class="nav navtabs" v-if="allowTabSave()">
       <li v-for="(value, index) in sharedState.tabs" v-bind:key="index">
-        <a href="#" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}</a>
+        <a href="#" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }} <font-awesome-icon icon="check-circle" v-show="sharedState.isValid(index)"></font-awesome-icon></a>
       </li>
     </ul>
     <form role="form" id="vue_form" :action="sharedState.getUpdateRoute()" method="patch" @submit.prevent="onSubmit">
@@ -124,7 +124,7 @@
             </div>
             <div v-else>
               <label :for="input.label">{{ input.label }}</label>
-              <input :id="input.label" class="form-control" :ref="index" :name="sharedState.etdPrefix(index)" v-model="input.value">
+              <input :id="input.label" class="form-control" :ref="index" :name="sharedState.etdPrefix(index)" v-model="input.value" v-on:change="sharedState.setValid(value.label, false)">
               <section role="alert" class='errorMessage' v-if="sharedState.hasError(index)">
                   <p>{{ input.label }} is required</p>
               </section>
@@ -148,6 +148,11 @@
 
 <script>
 import _ from "lodash"
+import { library } from '@fortawesome/fontawesome-svg-core'
+/* 'coffee' is just an example */
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { dom } from '@fortawesome/fontawesome-svg-core'
 import { formStore } from "./formStore"
 import School from "./School"
 import Department from './Department'
@@ -178,6 +183,10 @@ var token = document
   .querySelector('meta[name="csrf-token"]')
   .getAttribute("content")
 
+/* Font Awesome functions; dom.watch() provides the transformations to svg */
+library.add(faCheckCircle)
+dom.watch()
+
 export default {
   data() {
     return {
@@ -197,6 +206,7 @@ export default {
     }
   },
   components: {
+    fontAwesomeIcon: FontAwesomeIcon,
     school: School,
     quillEditor: quillEditor,
     submittingType: SubmittingType,

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -21,11 +21,12 @@ export default class SaveAndSubmit {
         // populate form in order to use its inputs
         this.formStore.loadSavedData()
 
-        //this.formStore.nextStepIsCurrent(response.data.lastCompletedStep)
+        this.formStore.setValid(response.data.tab_name, true)
         this.formStore.setComplete(response.data.tab_name)
         this.formStore.loadTabs()
       })
       .catch(error => {
+        this.formStore.setValid(response.data.tab_name, false)
         this.formStore.errored = true
         this.formStore.errors = []
         this.formStore.errors.push(error.response.data.errors)

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <label for="school">School</label>
-    <select id="school" class="form-control" v-model="selected" aria-required="true" v-on:change="clearDepartmentAndSubfields">
+    <select id="school" class="form-control" v-model="selected" aria-required="true" v-on:change="clearDepartmentAndSubfields, sharedState.setValid('About Me', false, ['My Program', 'Embargoes'])">
       <option v-for="school in this.sharedState.schools.options" v-bind:value="school.value" v-bind:key='school.value' :selected='school.selected' :disabled='school.disabled'>
         {{ school.text }}
       </option>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -10,7 +10,7 @@ export var formStore = {
       label: 'About Me',
       help_text: `It's time to submit your thesis or dissertation! Let's begin with some basic information.`,
       disabled: false,
-      selected: true,
+      valid: true,
       completed: false,
       currentStep: true,
       step: 0,
@@ -25,7 +25,7 @@ export var formStore = {
       label: 'My Program',
       help_text: 'Tell us a little bit more about the specifics of your program.',
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 1,
@@ -44,7 +44,7 @@ export var formStore = {
       are not affiliated with Emory, select 'Non-Emory' and enter their organization.`,
       description: '',
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 2,
@@ -57,7 +57,7 @@ export var formStore = {
       label: 'My Etd',
       help_text: 'Please describe your primary submission document.',
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 3,
@@ -72,7 +72,7 @@ export var formStore = {
       label: 'Keywords',
       help_text: 'Please provide some additional information about your submission.',
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 4,
@@ -86,7 +86,7 @@ export var formStore = {
       label: 'My Files',
       help_text: '',
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 5,
@@ -98,7 +98,7 @@ export var formStore = {
       label: 'Embargo',
       help_text: 'You have the option to restrict access to your thesis or dissertation for a limited time. First, select whether you would like to apply an embargo and how long you would like it to apply. Then select which parts of your record to include in the embargo. If you are unsure whether to embargo your ETD, consult with your thesis advisor or committee chair.',
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 6,
@@ -111,7 +111,7 @@ export var formStore = {
       help_text: `Please take a moment to review all your answers before submitting your document(s) to your department or school for approval.
        Afer you submit your document(s), your school will be notified and staff will review your submission for acceptance.`,
       disabled: true,
-      selected: false,
+      valid: false,
       completed: false,
       currentStep: false,
       step: 7,
@@ -230,6 +230,23 @@ export var formStore = {
       {value: '1 Year'}, {value: '2 Years'}, {value: '6 Years'}],
     rollins: [{value: 'None - open access immediately', selected: 'selected'},
       {value: '6 Months'}, {value: '1 Year'}, {value: '2 Years'}]
+  },
+  isValid(tab){
+    return this.tabs[`${tab}`].valid
+  },
+  setValid(tab, validity, otherTabs){
+    _.forEach(this.tabs, (t) => {
+      // passing in the object or the label is ok
+      if (t === tab || t.label === tab) {
+        t.valid = validity
+      }
+    })
+    // this is for the case where a change in an input renders other tabs invalid. those inputs call this function with an array of tab labels that should be marked invalid now.
+    if (otherTabs) {
+      _.forEach(otherTabs, (othertab) => {
+        this.setValid(othertab, false)
+      })
+    }
   },
   getSchoolText (schoolKey) {
     var school = _.find(this.schools.options, (school) => { return school.value === schoolKey })

--- a/app/javascript/packs/root.js
+++ b/app/javascript/packs/root.js
@@ -5,6 +5,7 @@ import { formStore } from '../formStore'
 import axios from 'axios'
 
 Vue.use(TurbolinksAdapter)
+Vue.config.productionTip = false
 
 document.addEventListener('turbolinks:load', () => {
   var element = document.getElementById('root')

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.2",
+    "@fortawesome/free-solid-svg-icons": "^5.2.0",
+    "@fortawesome/vue-fontawesome": "^0.1.1",
     "@rails/webpacker": "3.5",
     "axios": "^0.18.0",
     "babel-core": "^6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,26 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@fortawesome/fontawesome-common-types@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.2.tgz#7fd64eacf7f64e4d7619d21b0b2f2467f5a70611"
+
+"@fortawesome/fontawesome-svg-core@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.2.tgz#b431e7efb3e3a1887e596daa6ed0d241d2d1aea5"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.2"
+
+"@fortawesome/free-solid-svg-icons@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.2.0.tgz#b51c1d49278ef538a97c0ce9575a1b54cc1a52dc"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.2"
+
+"@fortawesome/vue-fontawesome@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.1.tgz#f54cad4028213a011c6ecb10eaf2b99dbd4a8496"
+
 "@rails/webpacker@3.5":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-3.5.3.tgz#8be7f4bfb1ce6f00c3456cbbe3dc363ca72bafc8"


### PR DESCRIPTION
This commit displays the validity of a tab to students via icons in the tabs. When a student saves a tab, its valid property is set to true and the checked icon appears in the tab. When a user interacts with inputs in a valid tab, the tab is in a messy/dirty/invalid state and the icon disappears. This functionality has been implemented for the default inputs and school components. In the case of the school component, when the school select is interacted with, it sets the Program and Embargo tabs to invalid as well. The other components will be implemented if this approach is approved. The valid properties need to be saved so that they can be preserved across sessions, in a future commit also.