### PR TITLE
Let a user see their works in My Works

### DIFF
--- a/app/search_builders/hyrax/my/works_search_builder.rb
+++ b/app/search_builders/hyrax/my/works_search_builder.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  # Added to allow for the Hyrax::My::WorksController to show only things I have deposited
+  # If the work went through mediated deposit, I may no longer have edit access to it.
+  class My::WorksSearchBuilder < My::SearchBuilder
+    include Hyrax::FilterByType
+
+    # We remove the access controls filter, because some of the works a user has
+    # deposited may have gone through a workflow which has removed their ability
+    # to edit the work.
+
+    self.default_processor_chain -= [:filter_models]
+    self.default_processor_chain -= [:add_access_controls_to_solr_params]
+
+    def only_works?
+      true
+    end
+  end
+end

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -21,11 +21,15 @@ RSpec.feature 'Laney Graduate School two step approval workflow',
       w.setup
       attributes_for_actor = { uploaded_files: [file.id] }
       env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), attributes_for_actor)
-      middleware = Hyrax::DefaultMiddlewareStack.build_stack.build(Hyrax::Actors::Terminator.new)
-      middleware.create(env)
+      Hyrax::CurationConcern.actor.create(env)
     end
 
     scenario "an approver reviews and approves a work" do
+      # A user can search for their work immediately after depositing it
+      login_as depositing_user
+      visit("/dashboard/my/works")
+      expect(page).to have_content etd.title.first
+
       expect(etd.active_workflow.name).to eq "laney_graduate_school"
       expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_review"
 


### PR DESCRIPTION
A user should always be able to see their
own deposits in My Works, even if they
haven't been approved yet.