### PR TITLE
Add partnering agencies and refactor keywords

### DIFF
--- a/app/javascript/Keywords.vue
+++ b/app/javascript/Keywords.vue
@@ -2,14 +2,15 @@
   <div>
     <label for="keywords">Keywords</label>
     <div id="keywords">
-      <div class="form-inline keyword" v-for="(keyword, index) in sharedState.keywords" v-bind:key="index">
-        <input class="form-control" :value="getVal(keyword)" name="etd[keyword][]" />
-        <a data-turbolinks="false" class="btn btn-default"  href="#" @click="sharedState.removeKeyword(index)">Remove This Keyword</a>
+      <div class="form-inline keyword" v-for="keyword in sharedState.keywords.keywords()">
+        <input type="text" class="form-control" name="etd[keyword][]" v-model="keyword.value"/>
+        <button type="button" class="btn btn-default" @click="sharedState.keywords.remove(keyword)">
+          <span class="glyphicon glyphicon-trash"></span>  Remove This Keyword</button>
         <br/>
       </div>
     </div>
     <br/>
-    <button type="button" class="btn btn-default" @click="sharedState.addKeyword('')"><span class="glyphicon glyphicon-plus"></span> Add a Keyword</button>
+    <button type="button" class="btn btn-default" @click="sharedState.keywords.addEmpty()"><span class="glyphicon glyphicon-plus"></span> Add a Keyword</button>
   </div>
 </template>
 
@@ -23,15 +24,13 @@ export default {
       sharedState: formStore
     }
   },
-  methods:{
-    getVal(keyword){
-      var val = ''
-      if (_.isString(keyword)){
-        val = keyword
-      }
-      return val
-    }
-  }
+   mounted() {
+    this.$nextTick(() => {
+      this.sharedState.keywords.load(
+        this.sharedState.savedData["keyword"]
+      )
+    })
+  },
 }
 </script>
 

--- a/app/javascript/PartneringAgency.vue
+++ b/app/javascript/PartneringAgency.vue
@@ -1,12 +1,19 @@
 <template>
 <div>
   <div v-if="sharedState.getSelectedSchool() === 'rollins'">
-    <label for="partneringAgency">Partnering Agency</label>
-    <select name="etd[partnering_agency][]" id="partneringAgency" class="form-control" @change="showSelected" v-model="selected">
-      <option v-for="partneringAgency in this.sharedState.partneringAgencies" v-bind:key="partneringAgency.id">
-        {{ partneringAgency.id }}
+    <label>Partnering Agency
+    <div v-for="parnterningAgency in sharedState.partneringAgencies.partneringAgencies()">
+    <select name="etd[partnering_agency][]" class="form-control" v-model="parnterningAgency.value">
+      <option v-for="agency in sharedState.partneringAgencyChoices">
+        {{ agency.id }}
       </option>
     </select>
+    <button type="button" class="btn btn-default" @click="sharedState.partneringAgencies.remove(parnterningAgency)">
+      <span class="glyphicon glyphicon-trash"></span> Remove This Partnering Agency</button>
+    </div>
+    </label>
+    <button type="button" class="btn btn-default" @click="sharedState.partneringAgencies.addEmpty()">
+      <span class="glyphicon glyphicon-plus"></span> Add Another Partnering Agency</button>
   </div>
   <div v-else>
     <input name="etd[partnering_agency][]" type="hidden" value="No partnering agency." />
@@ -16,29 +23,23 @@
 
 <script>
 import { formStore } from './formStore'
+import PartneringAgencyList from './lib/PartneringAgencyList'
+import PartneringAgency from './lib/PartneringAgency'
 
 export default {
   data() {
     return {
-      sharedState: formStore,
-      selected: ''
+      sharedState: formStore
     }
   },
-  mounted: function () {
- 
-  this.sharedState.getPartneringAgencies()
-  this.$nextTick(() => {
-           if (this.sharedState.getPartneringAgenciesOptionValue()) {
-          this.selected = this.sharedState.getPartneringAgenciesOptionValue()[0]
-      }
-      this.sharedState.getPartneringAgenciesOptionValue()
-  })
-},
-methods: {
-    showSelected: (e) => {
-        //console.log(this.sharedState.getPartneringAgenciesOptionValue())
-    }
-}
+ mounted() {
+    this.$nextTick(() => {
+      this.sharedState.getPartneringChoices()
+      this.sharedState.partneringAgencies.load(
+        this.sharedState.savedData['partnering_agency']
+      )
+    })
+  }
 }
 </script>
 

--- a/app/javascript/components/submit/Keywords.vue
+++ b/app/javascript/components/submit/Keywords.vue
@@ -2,11 +2,11 @@
   <section>   
     <h4>Keywords</h4>
     <h5>Research Fields</h5>
-    <div v-for="(researchField, index) in sharedState.savedData.research_field" v-bind:key="index">
+    <div v-for="(researchField, index) in sharedState.savedData.research_field">
       <div> {{ researchField }} </div>
     </div>
     <h5>Keywords</h5>
-    <div v-for="(keyword, index) in sharedState.savedData.keyword" v-bind:key="index">
+    <div v-for="(keyword, index) in sharedState.savedData.keyword">
       <div> {{ keyword }} </div>
     </div>
    <h5>Copyright Questions</h5>

--- a/app/javascript/lib/Keyword.js
+++ b/app/javascript/lib/Keyword.js
@@ -1,0 +1,5 @@
+export default class Keyword {
+  constructor (options) {
+    this.value = options.value
+  }
+}

--- a/app/javascript/lib/KeywordList.js
+++ b/app/javascript/lib/KeywordList.js
@@ -1,0 +1,32 @@
+import Keyword from './Keyword'
+import _ from 'lodash'
+
+export default class KeywordList {
+  constructor () {
+    this.keywordList = []
+  }
+  add (keyword) {
+    this.keywordList.push(keyword)
+  }
+
+  addEmpty () {
+    const keyword = new Keyword({value: ''})
+    this.add(keyword)
+  }
+
+  remove (keyword) {
+    this.keywordList = this.keywordList.filter((key) => { return key !== keyword })
+  }
+
+  keywords () {
+    return this.keywordList
+  }
+
+  load (attributes) {
+    this.keywordList = []
+    _.each(attributes, (keyword) => {
+      const loadedKeyword = new Keyword({value: keyword})
+      this.add(loadedKeyword)
+    })
+  }
+}

--- a/app/javascript/lib/PartneringAgency.js
+++ b/app/javascript/lib/PartneringAgency.js
@@ -1,0 +1,5 @@
+export default class PartneringAgency {
+  constructor (options) {
+    this.value = options.value
+  }
+}

--- a/app/javascript/lib/PartneringAgencyList.js
+++ b/app/javascript/lib/PartneringAgencyList.js
@@ -1,0 +1,34 @@
+import PartneringAgency from './PartneringAgency'
+import _ from 'lodash'
+import axios from 'axios'
+import { formStore } from '../formStore'
+
+export default class PartneringAgencyList {
+  constructor () {
+    this.partneringAgencyList = []
+  }
+  add (partneringAgency) {
+    this.partneringAgencyList.push(partneringAgency)
+  }
+
+  addEmpty () {
+    const partneringAgency = new PartneringAgency({value: ''})
+    this.add(partneringAgency)
+  }
+
+  remove (partneringAgency) {
+    this.partneringAgencyList = this.partneringAgencyList.filter((agency) => { return agency !== partneringAgency })
+  }
+
+  partneringAgencies () {
+    return this.partneringAgencyList
+  }
+
+  load (attributes) {
+    this.partneringAgencyList = []
+    _.each(attributes, (partneringAgency) => {
+      const loadedPartneringAgency = new PartneringAgency({value: partneringAgency})
+      this.add(loadedPartneringAgency)
+    })
+  }
+}

--- a/app/javascript/test/components/submit/Embargo.spec.js
+++ b/app/javascript/test/components/submit/Embargo.spec.js
@@ -4,7 +4,7 @@
 import { shallowMount } from '@vue/test-utils'
 import Embargo from '../../../components/submit/Embargo'
 import axios from 'axios'
-jest.mock('axios')
+jest.mock('')
 
 describe('Embargo.vue', () => {
   it('has the correct label', () => {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -29,14 +29,4 @@ describe('formStore', () => {
     }
     ])
   })
-
-  it('allows you to add a keyword', () => {
-    formStore.addKeyword('testing')
-    expect(formStore.keywords).toEqual([{index: 0, value: 'testing'}])
-  })
-
-  it('allows you to remove a keyword', () => {
-    formStore.removeKeyword(0)
-      expect(formStore.keywords.length).toEqual(0)
-  })
 })

--- a/app/javascript/test/lib/Keyword.test.js
+++ b/app/javascript/test/lib/Keyword.test.js
@@ -1,0 +1,9 @@
+/* global test */
+/* global expect */
+
+import Keyword from '../../lib/Keyword'
+
+test('that a committee keyword object has an ID, name, and affiliation', () => {
+  var keyword = new Keyword({ value: 'keyword' })
+  expect(keyword.value).toEqual('keyword')
+})

--- a/app/javascript/test/lib/KeywordList.test.js
+++ b/app/javascript/test/lib/KeywordList.test.js
@@ -1,0 +1,34 @@
+/* global test */
+/* global expect */
+
+import Keyword from '../../lib/Keyword'
+import KeywordList from '../../lib/KeywordList'
+
+test('that you can add a committee keyword to the list', () => {
+  var keyword = new Keyword({ value: 'test' })
+  var keywordList = new KeywordList()
+  keywordList.add(keyword)
+
+  expect(keywordList.keywords()[0].value).toEqual('test')
+})
+
+test('that you can remove a Keyword', () => {
+  var keyword = new Keyword({ value: 'test' })
+  var keywordList = new KeywordList()
+  keywordList.add(keyword)
+  keywordList.remove(keyword)
+  expect(keywordList.keywords().length).toEqual(0)
+})
+
+test('that you can load data from attributes in savedData', () => {
+  var attributes =  {'keyword': ['test']} 
+  var keywordList = new KeywordList()
+  keywordList.load(attributes)
+  expect(keywordList.keywords()[0].value[0]).toEqual('test')
+})
+
+test('that you can add an empty keyword', () => {
+  var keywordList = new KeywordList()
+  keywordList.addEmpty()
+  expect(keywordList.keywords().length).toEqual(1)
+})

--- a/app/javascript/test/lib/PartneringAgency.test.js
+++ b/app/javascript/test/lib/PartneringAgency.test.js
@@ -1,0 +1,9 @@
+/* global test */
+/* global expect */
+
+import PartneringAgency from '../../lib/PartneringAgency'
+
+test('that a committee partneringAgency object has an ID, name, and affiliation', () => {
+  var partneringAgency = new PartneringAgency({ value: 'partneringAgency' })
+  expect(partneringAgency.value).toEqual('partneringAgency')
+})

--- a/app/javascript/test/lib/PartneringAgencyList.test.js
+++ b/app/javascript/test/lib/PartneringAgencyList.test.js
@@ -1,0 +1,48 @@
+/* global test */
+/* global expect */
+/* global jest */
+
+import PartneringAgency from '../../lib/PartneringAgency'
+import PartneringAgencyList from '../../lib/PartneringAgencyList'
+import { formStore } from '../../formStore'
+import axios from 'axios'
+jest.mock('axios')
+
+jest.mock('../../formStore', () => {
+  return function () {
+    return {
+      formStore: () => {
+      }
+    }
+  }
+})
+
+test('that you can add a committee partneringAgency to the list', () => {
+  var partneringAgency = new PartneringAgency({ value: 'test' })
+  var partneringAgencyList = new PartneringAgencyList()
+  partneringAgencyList.add(partneringAgency)
+
+  expect(partneringAgencyList.partneringAgencies()[0].value).toEqual('test')
+})
+
+test('that you can remove a PartneringAgency', () => {
+  var partneringAgency = new PartneringAgency({ value: 'test' })
+  var partneringAgencyList = new PartneringAgencyList()
+  partneringAgencyList.add(partneringAgency)
+
+  partneringAgencyList.remove(partneringAgency)
+  expect(partneringAgencyList.partneringAgencies().length).toEqual(0)
+})
+
+test('that you can load data from attributes in savedData', () => {
+  var attributes = { 'partnering_agencies': ['test'] }
+  var partneringAgencyList = new PartneringAgencyList()
+  partneringAgencyList.load(attributes)
+  expect(partneringAgencyList.partneringAgencies()[0].value).toEqual(['test'])
+})
+
+test('that you can add an empty partneringAgency', () => {
+  var partneringAgencyList = new PartneringAgencyList()
+  partneringAgencyList.addEmpty()
+  expect(partneringAgencyList.partneringAgencies().length).toEqual(1)
+})


### PR DESCRIPTION
This commit adds partnering agencies and keywords using
the pattern that was put in place for committee chairs.

This is to ensure that there aren't problems causing with
indexing.

There will need to be additional styling done on these
before release.

Related to #1432