### PR TITLE
Add a class to perform Box uploads

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -138,7 +138,7 @@
 
           <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
-          <button v-if="allowTabSave()" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
+          <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
         </div>
       </div>
     </form>

--- a/app/javascript/lib/BoxFileUploader.js
+++ b/app/javascript/lib/BoxFileUploader.js
@@ -2,14 +2,14 @@ export default class BoxFileUploader {
   constructor (options) {
     this.boxAccessToken = options.boxAccessToken
     this.event = options.event
-    this.crsfToken = options.crsfToken
+    this.csrfToken = options.csrfToken
     this.sharedState = options.formStore
   }
 
   getUrlFromBox () {
     var xhr = new XMLHttpRequest()
     xhr.open('POST', '/file/box')
-    xhr.setRequestHeader('X-CSRF-Token', this.crsfToken)
+    xhr.setRequestHeader('X-CSRF-Token', this.csrfToken)
     xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8')
     xhr.send(JSON.stringify({ id: this.event[0].id, token: this.boxAccessToken }))
     xhr.onreadystatechange = () => {
@@ -26,7 +26,7 @@ export default class BoxFileUploader {
     formData.set('remote_url', boxResponse.location)
     var xhr = new XMLHttpRequest()
     xhr.open('POST', '/uploads')
-    xhr.setRequestHeader('X-CSRF-Token', this.crsfToken)
+    xhr.setRequestHeader('X-CSRF-Token', this.csrfToken)
     xhr.send(formData)
     xhr.onreadystatechange = () => {
       if (xhr.readyState === XMLHttpRequest.DONE) {

--- a/app/javascript/lib/BoxFileUploader.js
+++ b/app/javascript/lib/BoxFileUploader.js
@@ -1,0 +1,39 @@
+export default class BoxFileUploader {
+  constructor (options) {
+    this.boxAccessToken = options.boxAccessToken
+    this.event = options.event
+    this.crsfToken = options.crsfToken
+    this.sharedState = options.formStore
+  }
+
+  getUrlFromBox () {
+    var xhr = new XMLHttpRequest()
+    xhr.open('POST', '/file/box')
+    xhr.setRequestHeader('X-CSRF-Token', this.crsfToken)
+    xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8')
+    xhr.send(JSON.stringify({ id: this.event[0].id, token: this.boxAccessToken }))
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        this.postToUploads(JSON.parse(xhr.responseText))
+      }
+    }
+  }
+
+  postToUploads (boxResponse) {
+    const formData = new FormData()
+    formData.set('primary_files', [this.event[0].name])
+    formData.set('filename', [this.event[0].name])
+    formData.set('remote_url', boxResponse.location)
+    var xhr = new XMLHttpRequest()
+    xhr.open('POST', '/uploads')
+    xhr.setRequestHeader('X-CSRF-Token', this.crsfToken)
+    xhr.send(formData)
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        this.sharedState.files.push(
+          JSON.parse(xhr.responseText).files
+        )
+      }
+    }
+  }
+}

--- a/app/javascript/test/lib/BoxFileUploader.test.js
+++ b/app/javascript/test/lib/BoxFileUploader.test.js
@@ -1,0 +1,41 @@
+/* global test */
+/* global expect */
+/* global jest */
+
+import BoxFileUploader from '../../lib/BoxFileUploader'
+import { formStore } from '../../formStore'
+const mockXhr = {
+  open: jest.fn(),
+  send: jest.fn(),
+  setRequestHeader: jest.fn(),
+  readyState: XMLHttpRequest.DONE,
+  responseText: JSON.stringify({ 'location': 'http://example.com' })
+}
+const event = [{
+  id: 'testid',
+  name: 'something.txt'
+}]
+
+window.XMLHttpRequest = jest.fn(() => mockXhr)
+
+test('that you can get the url from box', () => {
+  var boxFileUploader = new BoxFileUploader({
+    boxAccessToken: 'accesstoken',
+    event: event,
+    crsfToken: 'longstring',
+    formStore: formStore
+  })
+  boxFileUploader.getUrlFromBox()
+  expect(window.XMLHttpRequest).toHaveBeenCalledTimes(1)
+})
+
+test('that you can post to uploads', () => {
+  var boxFileUploader = new BoxFileUploader({
+    boxAccessToken: 'accesstoken',
+    event: event,
+    crsfToken: 'longstring',
+    formStore: formStore
+  })
+  boxFileUploader.postToUploads({location: 'http://example.com'})
+  expect(window.XMLHttpRequest).toHaveBeenCalledTimes(2)
+})

--- a/app/javascript/test/lib/BoxFileUploader.test.js
+++ b/app/javascript/test/lib/BoxFileUploader.test.js
@@ -22,7 +22,7 @@ test('that you can get the url from box', () => {
   var boxFileUploader = new BoxFileUploader({
     boxAccessToken: 'accesstoken',
     event: event,
-    crsfToken: 'longstring',
+    csrfToken: 'longstring',
     formStore: formStore
   })
   boxFileUploader.getUrlFromBox()
@@ -33,7 +33,7 @@ test('that you can post to uploads', () => {
   var boxFileUploader = new BoxFileUploader({
     boxAccessToken: 'accesstoken',
     event: event,
-    crsfToken: 'longstring',
+    csrfToken: 'longstring',
     formStore: formStore
   })
   boxFileUploader.postToUploads({location: 'http://example.com'})


### PR DESCRIPTION
This commit introduces a JS class that
can be used to perform uploads from box. This is a
two step process that involves making a request
to box to get the URL of the file and then posting
the result of that to the `/uploads` controller.

Related to #1198