### PR TITLE
Hide Save & Submit button on Submission tab

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -138,7 +138,7 @@
 
           <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
-          <button v-if="allowTabSave()" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
+          <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
This hides the Save and Submit button on the
submission tab. You shouldn't be able to
use that button in that tab.

Related to #1421