### PR TITLE
Only import Box file picker CSS if visible

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -3,6 +3,9 @@
     <section class="thesis-file">
     <h2>Add Your Thesis or Dissertation File</h2>
     <div id="box-picker"></div>
+    <div v-if="accessToken">
+      <link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/elements/4.4.0/en-US/picker.css" />
+    </div>
     <span class="form-instructions">Upload the version of your thesis or dissertation approved by your advisor or committee.
     You can only upload one file to represent your thesis or dissertation. This file should not contain any signatures or other personally identifying
     information. PDF/A is a better version for preservation and for that reason we recommend you upload a PDF/A file, but it is not required.
@@ -130,7 +133,8 @@ export default {
       uploadSuccess: false,
       sharedState: formStore,
       uploadError: false,
-      progress: 0
+      progress: 0,
+      accessToken: window.location.search.split('&access_token=')[1]
     }
   },
   mounted () {

--- a/app/views/in_progress_etds/_form.html.erb
+++ b/app/views/in_progress_etds/_form.html.erb
@@ -9,7 +9,6 @@
 <!-- polyfill.io only loads the polyfills your browser needs -->
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=es6,Intl"></script>
 <!-- Latest version of the picker css for your locale -->
-<link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/elements/4.4.0/en-US/picker.css" />
 <script src="https://cdn01.boxcdn.net/platform/elements/4.4.0/en-US/picker.js"></script>
 
 <script>


### PR DESCRIPTION
This commit changes the way the Box file picker CSS is loaded.

If it isn't on the screen the css won't be loaded. This is
needed because the Box css overrides a lot of our custom
Bootstrap styles.

Related to #1455