### PR TITLE
Use VisibilityTranslator to determine and set `Etd#visibility`

### DIFF
--- a/README_embargoes.md
+++ b/README_embargoes.md
@@ -15,15 +15,22 @@ In Laevigata the expected embargo behavior is:
   * `toc_embargoed`
   * `abstract_embargoed`
 
+  These correspond to three custom Etd visibility values for use with items under embargo:
+  * `"all_restricted"`: when an embargo is active and `#abstract_embargoed` is `true`
+  * `"toc_restricted"`: when an embargo is active, `#toc_embargoed` is `true`, but  `#abstract_embargoed` is `false`
+  * `"files_restricted"`: when an embargo is active, but `#toc_embargoed` and  `#abstract_embargoed` are both `false`
+
 1. A depositing user can choose the length of time of embargo, within certain parameters defined by their school. Laney Graduate School allows embargoes of up to 6 years. All schools and departments (including Laney) allow embargoes of 6 months, 1 year, and 2 years. This value is recorded in the `embargo_length` field.
 
-1. The time specified in the `embargo_length` does not begin until the student has graduated. So, given an embargo length of 6 months, the embargo should end *not* 6 months after the work was deposited, but instead 6 months after the student's graduation. However, at deposit time, we do not know when a student will graduate. Therefore, at the time of deposit, we create an Embargo object and set the expiration date to a placeholder value of `Time.zone.today + 6.years`. This happens in `Hyrax::Actors::InterpretVisibilityActor`, which Laevigata overrides from Hyrax.
+1. The time specified in the `embargo_length` does not begin until the student has graduated. So, given an embargo length of 6 months, the embargo should end *not* 6 months after the work was deposited, but instead 6 months after the student's graduation. However, at deposit time, we do not know when a student will graduate. Therefore, at the time of deposit, we create an Embargo object and set the expiration date to a placeholder value of `Time.zone.today + 6.years`. This happens in `Hyrax::Actors::PregradEmbargo`, which modifies the attributes passed to `Hyrax::Actors::InterpretVisibilityActor`.
 
 1. An automated job will later run, which will check for a student's graduation. Upon graduation, the work will be released for viewing, and the work's `embargo_release_date` will be re-set to `Time.zone.today + embargo_length`
 
 1. Hyrax runs automated jobs to check for the expiration of an embargo, and remove it automatically when the date has been reached. We also plan to send out automated alerts telling people when their embargo is about to expire.
 
-1. During embargo, a record is visible to the public. This is another departure from expected `Embargoable` behavior. The work's `visibility` will be set to `open`, in contrast to setting it to `embargoed`, which would be the usual pattern. Instead, `etd_presenter` and the relevant views check for the existence of an embargo and the authorization of the current user, and display embargoed fields accordingly.
+1. During embargo, a record is visible to the public. This is another departure from expected `Embargoable` behavior. The work's `visibility` will be set as described above, in contrast to setting it to `restricted`, which would be the usual pattern. Instead, `etd_presenter` and the relevant views check for the existence of an embargo and the authorization of the current user, and display embargoed fields accordingly.
+
+1. Embargo of files is derived from Etd visibility through `Hyrax::Actors::FileVisibilityAttributesActor`. This ensures that `FileSet` permissions (and e.g. download access) are maintained on files as ACLs, independent of our specific application logic.
 
 Resources:
 

--- a/app/actors/hyrax/actors/file_visibility_attributes_actor.rb
+++ b/app/actors/hyrax/actors/file_visibility_attributes_actor.rb
@@ -14,17 +14,15 @@ module Hyrax
         # Set embargo visibility to 'private' for file sets;
         # otherwise set visibility visibility to 'open' and don't set embargo for files
         def attributes_for_file_sets(env)
-          if env.curation_concern.files_embargoed
-            env.attributes[:visibility] =
-              Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
-            env.attributes[:visibility_during_embargo] =
-              Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-          else
-            env.attributes.except!(:visibility, :embargo_release_date)
+          visibility_attributes =
+            FileSetVisibilityAttributeBuilder
+              .new(work: env.curation_concern)
+              .build
 
-            env.attributes[:visibility] =
-              Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-          end
+          env.attributes.merge!(visibility_attributes)
+
+          env.attributes.except!(:embargo_release_date) unless
+            env.curation_concern.files_embargoed
 
           true
         end

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -2,4 +2,30 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+
+  ##
+  # override behavior from `Hyrax::AbilityHelper`
+  def visibility_options(variant)
+    options = [
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+      VisibilityTranslator::FILES_EMBARGOED,
+      VisibilityTranslator::TOC_EMBARGOED,
+      VisibilityTranslator::ALL_EMBARGOED,
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    ]
+
+    case variant
+    when :restrict
+      options.delete_at(0)
+      options.reverse!
+    when :loosen
+      options = [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC]
+    end
+
+    options.map { |value| [visibility_text(value), value] }
+  end
+
+  def visibility_badge(value)
+    EtdPermissionBadge.new(value).render
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,10 +5,15 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
+    can [:read, :edit], String if can_review_submissions?
     return unless admin?
     can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
     can [:destroy], ActiveFedora::Base
     can [:read], Schools::School
+  end
+
+  def test_download(id)
+    super || can_review_submissions?
   end
 
   def ipe_permissions

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,8 +5,18 @@ class Ability
 
   # Define any customized permissions here.
   def custom_permissions
-    can [:read, :edit], String if can_review_submissions?
+    if can_review_submissions?
+      can [:manage], String do |id|
+        approver_for?(admin_set: ActiveFedora::Base.find(id)&.admin_set)
+      end
+
+      can [:manage], ActiveFedora::Base do |obj|
+        approver_for?(admin_set: obj.admin_set)
+      end
+    end
+
     return unless admin?
+
     can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
     can [:destroy], ActiveFedora::Base
     can [:read], Schools::School
@@ -14,6 +24,16 @@ class Ability
 
   def test_download(id)
     super || can_review_submissions?
+  end
+
+  def curation_concerns_permissions
+    alias_action :versions, to: :update
+    alias_action :file_manager, to: :update
+
+    return if admin? || can_review_submissions?
+
+    cannot :index, Hydra::AccessControls::Embargo
+    cannot :index, Hydra::AccessControls::Lease
   end
 
   def ipe_permissions
@@ -42,4 +62,18 @@ class Ability
   def display_share_button?
     true
   end
+
+  private
+
+    def approver_for?(admin_set:)
+      return false unless admin_set
+
+      workflow = admin_set.active_workflow
+      Hyrax::Workflow::PermissionQuery
+        .scope_processing_workflow_roles_for_user_and_workflow(user:     @user,
+                                                               workflow: workflow)
+        .pluck(:role_id)
+        .map { |id| Sipity::Role.find(id).name }
+        .include?('approving')
+    end
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -1,6 +1,5 @@
 require 'workflow_setup'
-# Generated via
-#  `rails generate hyrax:work Etd`
+
 class Etd < ActiveFedora::Base
   include ::ProquestBehaviors
   include ::Hyrax::WorkBehavior
@@ -15,6 +14,24 @@ class Etd < ActiveFedora::Base
 
   after_initialize :set_defaults, unless: :persisted?
   before_save :set_research_field_ids, :index_committee_chair_name, :index_committee_members_names
+
+  ##
+  # @!attribute [rw] visibility_translator_class
+  #   @return [VisibilityTranslatorClass]
+  attr_writer :visibility_translator_class
+
+  def visibility_translator_class
+    @visibility_translator_class ||= VisibilityTranslator
+  end
+
+  ##
+  # @return [VisibilityTranslator]
+  def visibility_translator
+    visibility_translator_class.new(obj: self)
+  end
+
+  delegate :visibility,  to: :visibility_translator
+  delegate :visibility=, to: :visibility_translator
 
   # Get all attached file sets that are "primary"
   def primary_file_fs

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -18,6 +18,12 @@ class FileSet < ActiveFedora::Base
     index.as :facetable
   end
 
+  ##
+  # @return [AdminSet, nil]
+  def admin_set
+    parent&.admin_set
+  end
+
   def original?
     pcdm_use == ORIGINAL
   end

--- a/app/presenters/etd_file_set_presenter.rb
+++ b/app/presenters/etd_file_set_presenter.rb
@@ -14,4 +14,8 @@ class EtdFileSetPresenter < Hyrax::FileSetPresenter
   def permission_badge
     ""
   end
+
+  def link_name
+    first_title
+  end
 end

--- a/app/presenters/etd_permission_badge.rb
+++ b/app/presenters/etd_permission_badge.rb
@@ -1,0 +1,22 @@
+class EtdPermissionBadge < Hyrax::PermissionBadge
+  VISIBILITY_LABEL_CLASS = {
+    authenticated: "label-info",
+    embargo: "label-warning",
+    lease: "label-warning",
+    files_restricted: "label-warning",
+    toc_restricted: "label-warning",
+    all_restricted: "label-warning",
+    open: "label-success",
+    restricted: "label-danger"
+  }.freeze
+
+  def initialize(visibility)
+    @visibility = visibility.to_sym
+  end
+
+  private
+
+    def dom_label_class
+      VISIBILITY_LABEL_CLASS.fetch(@visibility)
+    end
+end

--- a/app/services/file_set_visibility_attribute_builder.rb
+++ b/app/services/file_set_visibility_attribute_builder.rb
@@ -1,0 +1,23 @@
+class FileSetVisibilityAttributeBuilder
+  attr_accessor :work
+
+  def initialize(work:)
+    self.work = work
+  end
+
+  def build
+    attributes = {}
+
+    if work.files_embargoed
+      attributes[:visibility] =
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+      attributes[:visibility_during_embargo] =
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    else
+      attributes[:visibility] =
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    attributes
+  end
+end

--- a/app/services/file_set_visibility_attribute_builder.rb
+++ b/app/services/file_set_visibility_attribute_builder.rb
@@ -13,6 +13,7 @@ class FileSetVisibilityAttributeBuilder
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
       attributes[:visibility_during_embargo] =
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      attributes[:embargo_release_date] = work.embargo_release_date.to_s
     else
       attributes[:visibility] =
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC

--- a/app/services/visibility_translator.rb
+++ b/app/services/visibility_translator.rb
@@ -17,9 +17,9 @@
 #
 # @see Hydra::AccessControls::Visibility
 class VisibilityTranslator
-  ALL_EMBARGOED   = 'embargo; all'.freeze
-  FILES_EMBARGOED = 'embargo; file'.freeze
-  TOC_EMBARGOED   = 'embargo; toc + file'.freeze
+  ALL_EMBARGOED   = 'all_restricted'.freeze
+  FILES_EMBARGOED = 'files_restricted'.freeze
+  TOC_EMBARGOED   = 'toc_restricted'.freeze
   OPEN            = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
   attr_accessor :obj

--- a/app/services/visibility_translator.rb
+++ b/app/services/visibility_translator.rb
@@ -20,6 +20,7 @@ class VisibilityTranslator
   ALL_EMBARGOED   = 'embargo; all'.freeze
   FILES_EMBARGOED = 'embargo; file'.freeze
   TOC_EMBARGOED   = 'embargo; toc + file'.freeze
+  OPEN            = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
   attr_accessor :obj
 
@@ -32,11 +33,58 @@ class VisibilityTranslator
   end
 
   def visibility
-    return VisibilityProxy.new(obj).visibility unless obj.under_embargo?
-    return ALL_EMBARGOED                       if     obj.abstract_embargoed
-    return TOC_EMBARGOED                       if     obj.toc_embargoed
+    return proxy.visibility unless obj.under_embargo?
+    return ALL_EMBARGOED    if     obj.abstract_embargoed
+    return TOC_EMBARGOED    if     obj.toc_embargoed
 
     FILES_EMBARGOED
+  end
+
+  def visibility=(value)
+    case value
+    when FILES_EMBARGOED
+      raise(InvalidVisibilityError.new('Invalid embargo visibility level:', value, obj)) unless
+        obj.under_embargo?
+
+      obj.files_embargoed    = true
+      obj.toc_embargoed      = false
+      obj.abstract_embargoed = false
+      proxy.visibility       = OPEN
+    when TOC_EMBARGOED
+      raise(InvalidVisibilityError.new('Invalid embargo visibility level:', value, obj)) unless
+        obj.under_embargo?
+
+      obj.files_embargoed    = true
+      obj.toc_embargoed      = true
+      obj.abstract_embargoed = false
+      proxy.visibility       = OPEN
+    when ALL_EMBARGOED
+      raise(InvalidVisibilityError.new('Invalid embargo visibility level:', value, obj)) unless
+        obj.under_embargo?
+
+      obj.files_embargoed    = true
+      obj.toc_embargoed      = true
+      obj.abstract_embargoed = true
+      proxy.visibility       = OPEN
+    else
+      proxy.visibility = value
+    end
+  end
+
+  def proxy
+    VisibilityProxy.new(obj)
+  end
+
+  class InvalidVisibilityError < ArgumentError
+    def initialize(msg = 'Invalid visibility level:', level = nil, obj = nil)
+      @level = level
+      @obj   = obj
+      @msg   = msg + " #{level}\nNo embargo is set on #{obj ? obj.id : 'the object'}."
+    end
+
+    def message
+      @msg
+    end
   end
 
   ##
@@ -57,6 +105,7 @@ class VisibilityTranslator
     include Hydra::AccessControls::Visibility
 
     def_delegator :@original, :read_groups
+    def_delegator :@original, :set_read_groups
 
     def initialize(original)
       @original = original

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   <% end %>
 
-  <% if can? :read, :admin_dashboard %>
+  <% if can? :edit, Hydra::AccessControls::Embargo %>
     <%= menu.nav_link(hyrax.embargoes_path) do %>
       <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
     <% end %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -70,6 +70,12 @@ en:
     visibility:
       open:
         text: 'Open Access'
+      all_restricted:
+        text: 'All Restricted'
+      toc_restricted:
+        text: 'Restricted; Files & ToC'
+      files_restricted:
+        text: 'Restricted; Files Only'
     upload:
       browse_everything:
         browse_files_button: "Upload via Box"

--- a/lib/etd_factory.rb
+++ b/lib/etd_factory.rb
@@ -19,7 +19,10 @@ class EtdFactory
 
   def attach_primary_pdf_file
     uf = Hyrax::UploadedFile.create(file: File.open(primary_pdf_file), pcdm_use: FileSet::PRIMARY)
-    AttachFilesToWorkJob.perform_now(etd, [uf])
+
+    AttachFilesToWorkJob
+      .perform_now(etd, [uf], **FileSetVisibilityAttributeBuilder.new(work: etd).build)
+
     primary_file_set = etd.ordered_members.to_a.first
     primary_file_set.embargo = etd.embargo
     primary_file_set.save
@@ -29,7 +32,7 @@ class EtdFactory
     return unless supplemental_files && supplemental_files.count > 0
     supplemental_files.each do |sf|
       uf = Hyrax::UploadedFile.create(file: File.open(sf), pcdm_use: FileSet::SUPPLEMENTARY)
-      AttachFilesToWorkJob.perform_now(etd, [uf])
+      AttachFilesToWorkJob.perform_now(etd, [uf], **FileSetVisibilityAttributeBuilder.new(work: etd).build)
     end
     mark_supplemental_files
   end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -3,7 +3,7 @@ include Warden::Test::Helpers
 
 RSpec.feature 'Admin dashboard',
               integration: true,
-              workflow: { admin_sets_config: 'spec/fixtures/config/emory/epidemiology_admin_sets.yml' } do
+              workflow: { admin_sets_config: 'spec/fixtures/config/emory/candler_admin_sets.yml' } do
 
   context 'as an admin user' do
     let(:user) { FactoryBot.create(:admin) }
@@ -27,6 +27,38 @@ RSpec.feature 'Admin dashboard',
       visit '/dashboard'
       click_on 'Schools'
       expect(page).to have_content 'Candler School of Theology'
+    end
+  end
+
+  context 'as an approving user' do
+    let(:user)     { User.find_by(ppid: 'candleradmin') }
+    let(:etd)      { FactoryBot.build(:sample_data_with_everything_embargoed) }
+    let(:file_set) { FactoryBot.create(:public_pdf) }
+
+    before do
+      etd.ordered_members << file_set
+      etd.representative = file_set
+      etd.save
+
+      login_as user
+    end
+
+    scenario 'editing an embargo' do
+      visit '/dashboard'
+      click_link 'Manage Embargoes'
+      click_link etd.first_title
+      select 'Restricted; Files Only', from: 'etd_visibility_during_embargo'
+      fill_in 'etd_embargo_release_date', with: '2199-01-01'
+      click_button 'Update Embargo'
+
+      etd.reload
+      expect(etd.embargo_release_date).to eq Date.parse('2199-01-01')
+      expect(etd.visibility).to eq VisibilityTranslator::FILES_EMBARGOED
+
+      expect(etd.representative.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      expect(etd.representative.embargo_release_date)
+        .to eq Date.parse('2199-01-01')
     end
   end
 end

--- a/spec/lib/etd_factory_spec.rb
+++ b/spec/lib/etd_factory_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe EtdFactory, :clean do
     it "copies the embargo to the pdf file if files_embargoed == true" do
       expect(attached_etd.files_embargoed).to eq true
       expect(primary_pdf_fs.embargo_id).to eq attached_etd.embargo_id
-      expect(primary_pdf_fs.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      expect(primary_pdf_fs.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
     it "marks the primary_pdf as primary" do
       expect(primary_pdf_fs.pcdm_use).to eq FileSet::PRIMARY
@@ -66,8 +67,10 @@ RSpec.describe EtdFactory, :clean do
     end
     it "copies the embargo to the supplemental_files if files_embargoed == true" do
       expect(attached_etd.files_embargoed).to eq true
-      expect(attached_etd.supplemental_files_fs.first.embargo_id).to eq attached_etd.embargo_id
-      expect(attached_etd.supplemental_files_fs.first.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      expect(attached_etd.supplemental_files_fs.first.embargo_id)
+        .to eq attached_etd.embargo_id
+      expect(attached_etd.supplemental_files_fs.first.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe FileSet do
+  subject(:file_set) { described_class.new }
+
+  describe '#admin_set' do
+    it 'has no admin_set of its own' do
+      expect(file_set.admin_set).to be_nil
+    end
+
+    context 'when it belongs to a work' do
+      let(:etd)       { FactoryBot.build(:etd, admin_set: admin_set) }
+      let(:admin_set) { FactoryBot.create(:admin_set) }
+
+      before do
+        etd.ordered_members << file_set
+        etd.save
+      end
+
+      it 'gives the admin_set for the parent work' do
+        expect(file_set.admin_set).to eq admin_set
+      end
+    end
+  end
+
   context 'with a new FileSet' do
     its(:pcdm_use) { is_expected.to be_nil }
     its(:embargo_length) { is_expected.to be_nil }

--- a/spec/presenters/etd_file_set_presenter_spec.rb
+++ b/spec/presenters/etd_file_set_presenter_spec.rb
@@ -2,13 +2,11 @@
 require 'rails_helper'
 
 describe EtdFileSetPresenter do
+  let(:ability) { Ability.new(FactoryBot.build(:user)) }
+  let(:etd)     { FactoryBot.build(:etd) }
+
   context "delegate_methods" do
     subject { presenter }
-    let :etd do
-      FactoryBot.build(:etd)
-    end
-
-    let(:ability) { Ability.new(FactoryBot.build(:user)) }
 
     let(:presenter) do
       described_class.new(SolrDocument.new(etd.to_solr), ability)
@@ -20,6 +18,47 @@ describe EtdFileSetPresenter do
 
     it "returns an array with an empty string from permission_badge" do
       expect(presenter.permission_badge).to eq ""
+    end
+  end
+
+  describe '#link_name' do
+    subject(:presenter) { described_class.new(solr_document, ability) }
+    let(:solr_document) { SolrDocument.new(etd.primary_file_fs.first.to_solr) }
+
+    let(:etd) do
+      etd = FactoryBot.create(:sample_data_with_everything_embargoed,
+                              school: ["Candler School of Theology"])
+      primary_pdf_file = "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"
+      etd_factory      = EtdFactory.new
+      etd_factory.etd  = etd
+
+      etd_factory.primary_pdf_file = primary_pdf_file
+      etd_factory.attach_primary_pdf_file
+
+      etd.save
+      etd
+    end
+
+    it 'is the title' do
+      expect(presenter.link_name).to eq etd.title.first
+    end
+
+    context 'when under embargo' do
+      subject(:presenter) { described_class.new(solr_document, ability) }
+      let(:solr_document) { SolrDocument.new(etd.primary_file_fs.first.to_solr) }
+
+      it 'is the title' do
+        expect(presenter.link_name).to eq  etd.title.first
+      end
+
+      context 'and viewing as an approver' do
+        let(:ability)  { Ability.new(approver) }
+        let(:approver) { User.where(ppid: 'candleradmin').first }
+
+        it 'is the title' do
+          expect(presenter.link_name).to eq etd.title.first
+        end
+      end
     end
   end
 end

--- a/spec/services/embargo_expiration_service_spec.rb
+++ b/spec/services/embargo_expiration_service_spec.rb
@@ -98,7 +98,7 @@ describe EmbargoExpirationService, :clean do
     it "changes the embargo permissions" do
       expect { service.expire_embargoes }
         .to change { etd.reload.visibility }
-        .from(etd.visibility_during_embargo)
+        .from(etd.visibility)
         .to(etd.visibility_after_embargo)
     end
 
@@ -108,7 +108,7 @@ describe EmbargoExpirationService, :clean do
       it 'does not deactivate embargo' do
         expect { service.expire_embargoes }
           .not_to change { etd.visibility }
-          .from(etd.visibility_during_embargo)
+          .from(etd.visibility)
 
         expect(etd.under_embargo?).to be_truthy
       end

--- a/spec/services/visibility_translator_spec.rb
+++ b/spec/services/visibility_translator_spec.rb
@@ -55,4 +55,59 @@ describe VisibilityTranslator do
       end
     end
   end
+
+  describe '#visibility=' do
+    let(:obj) { FactoryBot.create(:etd, visibility: restricted) }
+
+    it 'can set visibility of object to open' do
+      expect { translator.visibility = open }
+        .to change { obj.visibility }
+        .to open
+    end
+
+    context 'when the work has no embargo' do
+      it 'cannot set visibility of object to file restricted level' do
+        expect { translator.visibility = described_class::FILES_EMBARGOED }
+          .to raise_error ArgumentError
+      end
+
+      it 'cannot set visibility of object to toc restricted level' do
+        expect { translator.visibility = described_class::TOC_EMBARGOED }
+          .to raise_error ArgumentError
+      end
+
+      it 'cannot set visibility of object to all restricted level' do
+        expect { translator.visibility = described_class::ALL_EMBARGOED }
+          .to raise_error ArgumentError
+      end
+    end
+
+    context 'when the work is under embargo' do
+      let(:obj) do
+        FactoryBot.create(:tomorrow_expiration,
+                          files_embargoed: false,
+                          toc_embargoed:   false)
+      end
+
+      it 'can set visibility of object to file restricted level' do
+        expect { translator.visibility = described_class::FILES_EMBARGOED }
+          .to change { obj.visibility }
+          .to described_class::FILES_EMBARGOED
+      end
+
+      it 'can set visibility of object to toc restricted level' do
+        expect { translator.visibility = described_class::TOC_EMBARGOED }
+          .to change { obj.visibility }
+          .to described_class::TOC_EMBARGOED
+      end
+
+      it 'can set visibility of object to all restricted level' do
+        translator.visibility = described_class::FILES_EMBARGOED
+
+        expect { translator.visibility = described_class::ALL_EMBARGOED }
+          .to change { obj.visibility }
+          .to described_class::ALL_EMBARGOED
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds three new visibility levels to `Etd`. These are usable when an embargo is
set.

First we add delegation to a settable `#visibility_translator` (defaulting to an
instance of `VisibilityTranslator`). This allows the `Etd` to infer its
embargoed `#visibility` level based on the existing `*_embargoed` flags. We then
add logic to `VisibilityTranslator` for setting visibility to the three new
levels _iff_ an embargo is set on the object.

Future work will shift existing clients to using the visibility setters, instead
of setting `*_embargoed` flags manually and add the new visibility levels to the
embargo edit pages. We may also want to consider replacing the `*_embargoed`
flags with data on the `Embargo` ActiveRecord objects.