### PR TITLE
Added a catchall route for the new UI edit form in case we missed any edit links in the UI

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
   if Rails.application.config_for('new_ui').fetch('enabled', false)
     resources :in_progress_etds, except: :create
     get '/concern/etds/new', to: redirect('in_progress_etds/new')
+    # Just in case we missed any edit links anywhere in the app, this redirect should make sure we always have the form from the new UI when we try to edit an ETD.
+    get '/concern/etds/:id/edit', to: redirect('in_progress_etds/new?etd_id=%{id}')
   else
     get '/concern/etds/new', to: 'hyrax/etds#new'
   end


### PR DESCRIPTION
We've already changed all the known edit links to use the new form, but there may be some edit links lurking in hyrax that we don't know about (or that are added in the future), so this route will redirect them to the new edit form.