### PR TITLE
Never create a blank user object

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,6 +60,23 @@ RSpec.describe User, :clean do
         .not_to change { described_class.count }
     end
   end
+  context "invalid shibboleth data" do
+    let(:invalid_auth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: 'shibboleth',
+        uid: '',
+        info: {
+          display_name: '',
+          uid: ''
+        }
+      )
+    end
+    it "does not create a new user" do
+      # do not create a new user if uid is blank
+      expect { described_class.from_omniauth(invalid_auth_hash) }
+        .not_to change { described_class.count }
+    end
+  end
   context "user factories" do
     it "makes a user with expected shibboleth fields" do
       user = FactoryBot.create(:user)


### PR DESCRIPTION
Empty user objects cause problems on many
display screens. They can get created by
accident if Shibboleth sends us empty or
malformed data, which seems to happen
occasionally. Guard against this and just
make the user log in again if this happens.
Log that the error occurred so we can
provide feedback to Emory systems about
how often this is happening.

Fixes #1152 