### PR TITLE
When displaying active embargoes search only Etd embargoes

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -4,6 +4,12 @@ module HyraxHelper
   include Hyrax::HyraxHelperBehavior
 
   ##
+  # override behavior from `Hyrax::EmbargoHelper`
+  def assets_under_embargo
+    @assets_under_embargo ||= EtdEmbargoService.assets_under_embargo
+  end
+
+  ##
   # override behavior from `Hyrax::AbilityHelper`
   def visibility_options(variant)
     options = [

--- a/app/search_builders/etd_embargo_search_builder.rb
+++ b/app/search_builders/etd_embargo_search_builder.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class EtdEmbargoSearchBuilder < Hyrax::EmbargoSearchBuilder
+  self.default_processor_chain =
+    [:with_pagination, :with_sorting, :only_active_embargoes,
+     :only_etd_embargoes]
+
+  def only_etd_embargoes(params)
+    params[:fq] += ' has_model_ssim:Etd'
+  end
+end

--- a/app/services/etd_embargo_service.rb
+++ b/app/services/etd_embargo_service.rb
@@ -1,0 +1,7 @@
+class EtdEmbargoService < Hyrax::EmbargoService
+  class << self
+      def assets_under_embargo
+        presenters(EtdEmbargoSearchBuilder.new(self))
+      end
+  end
+end


### PR DESCRIPTION
The purpose of this filter is to avoid showing FileSet/File embargoes when
showing the embargo index.

The normal reason to view the embargo index is to edit embargoes from the
dashboard. In the usual case for this application we don't want users editing
embargoes for FileSets/Files, since these are meant to be derived from the
embargo on the `Etd`. Indeed, we can safely consider file embargoes to be
"behind the scenes"; they have more to do with permission management than user
facing funcionality. To avoid confusion, we simply decline to list these
embargoes in the index view.

If additional, non-`Etd` work types are added, this may need to be updated to
filter in a different way.

Closes #1404.