### PR TITLE
Remove font-awesome libraries from JS pack

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -5,8 +5,7 @@
     <ul class="nav navtabs" v-if="allowTabSave()">
       <li v-for="(value, index) in sharedState.tabs" v-bind:key="index">
         <button type="button" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }} 
-          <font-awesome-icon class="check-circle" icon="check-circle" v-show="sharedState.isValid(index)">
-          </font-awesome-icon>
+         <i class="fa fa-check-circle" aria-hidden="true" v-if="sharedState.isValid(index)" ></i>
         </button>
       </li>
     </ul>
@@ -151,11 +150,6 @@
 
 <script>
 import _ from "lodash"
-import { library } from '@fortawesome/fontawesome-svg-core'
-/* 'coffee' is just an example */
-import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { dom } from '@fortawesome/fontawesome-svg-core'
 import { formStore } from "./formStore"
 import School from "./School"
 import Department from './Department'
@@ -186,10 +180,6 @@ var token = document
   .querySelector('meta[name="csrf-token"]')
   .getAttribute("content")
 
-/* Font Awesome functions; dom.watch() provides the transformations to svg */
-library.add(faCheckCircle)
-dom.watch()
-
 export default {
   data() {
     return {
@@ -209,7 +199,6 @@ export default {
     }
   },
   components: {
-    fontAwesomeIcon: FontAwesomeIcon,
     school: School,
     quillEditor: quillEditor,
     submittingType: SubmittingType,
@@ -355,8 +344,8 @@ ul li button:hover {
   background: #cdcdcd
 }
 
-.check-circle {
-  color: steelblue;
+.fa-check-circle {
+  color: #002878;
   margin-right: .2em;
   margin-left: .2em;
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.2",
-    "@fortawesome/free-solid-svg-icons": "^5.2.0",
-    "@fortawesome/vue-fontawesome": "^0.1.1",
     "@rails/webpacker": "3.5",
     "axios": "^0.18.0",
     "babel-core": "^6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,26 +16,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.2.tgz#7fd64eacf7f64e4d7619d21b0b2f2467f5a70611"
-
-"@fortawesome/fontawesome-svg-core@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.2.tgz#b431e7efb3e3a1887e596daa6ed0d241d2d1aea5"
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.2"
-
-"@fortawesome/free-solid-svg-icons@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.2.0.tgz#b51c1d49278ef538a97c0ce9575a1b54cc1a52dc"
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.2"
-
-"@fortawesome/vue-fontawesome@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.1.tgz#f54cad4028213a011c6ecb10eaf2b99dbd4a8496"
-
 "@rails/webpacker@3.5":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-3.5.3.tgz#8be7f4bfb1ce6f00c3456cbbe3dc363ca72bafc8"


### PR DESCRIPTION
These assests are already included with Hyrax. We
don't need to have these included via a JS library.