### PR TITLE
Fix quill on edit screen

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -47,22 +47,17 @@
             </div>
             <div v-else-if="input.label === 'Table of Contents'">
               <label>{{ input.label }}</label>
-               <quill-editor :options="editorOptions" ref="myTextEditor" v-model="input.value" v-on:change="sharedState.setValid('My Etd', false)">
-               </quill-editor>
-               <input class="quill-hidden-field" :name="sharedState.etdPrefix(index)" v-model="input.value" />
-               <section class='errorMessage' v-if="sharedState.hasError(index)">
-                   <p>{{ input.label }} is required</p>
-               </section>
+              <richTextEditor :parentLabel="input.label" 
+              v-bind:parentValue="input.value" :parentIndex="input.index" 
+              parentName="etd[table_of_contents]"></richTextEditor>
             </div>
             <div v-else-if="input.label === 'Abstract'">
-               <label>{{ input.label }}</label>
-               <quill-editor :options="editorOptions" ref="myTextEditor" v-model="input.value" v-on:change="sharedState.setValid('My Etd', false)">
-               </quill-editor>
-               <input class="quill-hidden-field" :name="sharedState.etdPrefix(index)" v-model="input.value" />
-               <section class='errorMessage' v-if="sharedState.hasError(index)">
-                   <p>{{ input.label }} is required</p>
-               </section>
+              <label>{{ input.label }}</label>
+              <richTextEditor :parentLabel="input.label" 
+              v-bind:parentValue="input.value" :parentIndex="input.index" 
+              parentName="etd[abstract]"></richTextEditor>
             </div>
+
              <div v-else-if="input.label === 'Graduation Date'">
               <graduationDate></graduationDate>
               <section class='errorMessage' v-if="sharedState.hasError(index)">
@@ -159,10 +154,6 @@ import { dom } from '@fortawesome/fontawesome-svg-core'
 import { formStore } from "./formStore"
 import School from "./School"
 import Department from './Department'
-import { quillEditor } from 'vue-quill-editor'
-import 'quill/dist/quill.core.css'
-import 'quill/dist/quill.snow.css'
-import 'quill/dist/quill.bubble.css'
 import SubmittingType from './SubmittingType'
 import Degree from "./Degree"
 import ResearchField from "./ResearchField"
@@ -175,13 +166,11 @@ import CopyrightQuestions from './CopyrightQuestions'
 import Embargo from './Embargo'
 import Keywords from './Keywords'
 import SaveAndSubmit from './SaveAndSubmit'
-import quillToolbarOptions  from './quillToolbarOptions'
-import quillKeyboardBindings from './quillKeyboardBindings'
 import PartneringAgency from './PartneringAgency.vue';
 import Submit from './Submit'
 import UserAgreement from './components/submit/UserAgreement'
 import AboutMe from './components/submit/AboutMe'
-
+import RichTextEditor from './components/RichTextEditor'
 var token = document
   .querySelector('meta[name="csrf-token"]')
   .getAttribute("content")
@@ -197,21 +186,12 @@ export default {
       tabInputs: [],
       files: [],
       deleteableFiles: [],
-      editorOptions: {
-        modules: {
-        toolbar: quillToolbarOptions(),
-        keyboard: {
-          bindings: quillKeyboardBindings()
-          }
-        }
-      },
       lastCompletedStep: 0
     }
   },
   components: {
     fontAwesomeIcon: FontAwesomeIcon,
     school: School,
-    quillEditor: quillEditor,
     submittingType: SubmittingType,
     degree: Degree,
     researchField: ResearchField,
@@ -227,7 +207,8 @@ export default {
     saveAndSubmit: SaveAndSubmit,
     partneringAgency: PartneringAgency,
     submit: Submit,
-    userAgreement: UserAgreement
+    userAgreement: UserAgreement,
+    richTextEditor: RichTextEditor
   },
   created () {
     // this executes only the first time the page is loaded (before adding it to the dom), so we need the freshest saved data we have, and we use it to set the state of the tabs.
@@ -380,13 +361,6 @@ ul li button:hover {
 
 input {
   margin-bottom: 1em;
-}
-.quill-hidden-field {
-  display: none;
-}
-.quill-editor {
-  height: 10em;
-  margin-bottom: 7em;
 }
 
 .errorMessage {

--- a/app/javascript/components/RichTextEditor.vue
+++ b/app/javascript/components/RichTextEditor.vue
@@ -1,0 +1,54 @@
+  <template>
+    <div> 
+        <div v-if="typeof parentValue === 'String' || 'string' || 'undefined'">
+          <quill-editor :options="editorOptions" ref="myTextEditor" v-model="inputValue" v-on:change="sharedState.setValid('My Etd', false)">
+          </quill-editor>
+          <input type="hidden" class="quill-hidden-field" :name="parentName" v-model="inputValue" />
+        </div>
+        <div v-else>
+          <quill-editor :options="editorOptions" ref="myTextEditor" v-model="inputValue[0]" v-on:change="sharedState.setValid('My Etd', false)">
+          </quill-editor>
+        <input type="hidden" class="quill-hidden-field" :name="parentName" v-model="inputValue[0]" />
+        <section class='errorMessage' v-if="sharedState.hasError(parentIndex)">
+           <p>{{parentLabel}} is required</p>
+        </section>
+        </div>
+    </div>
+  </template>
+
+  <script>
+  import { formStore } from '../formStore'
+  import { quillEditor } from 'vue-quill-editor'
+  import 'quill/dist/quill.core.css'
+  import 'quill/dist/quill.snow.css'
+  import 'quill/dist/quill.bubble.css'
+  import quillToolbarOptions  from '../quillToolbarOptions'
+  import quillKeyboardBindings from '../quillKeyboardBindings' 
+
+  export default {
+    data() {
+      return {
+        inputValue: this.parentValue,
+        sharedState: formStore,
+        editorOptions: {
+        modules: {
+        toolbar: quillToolbarOptions(),
+        keyboard: {
+          bindings: quillKeyboardBindings()
+          }
+        }
+      },
+      }
+    },
+    props: ['parentValue','parentName', 'parentLabel', 'parentIndex'],
+    components: {
+      quillEditor: quillEditor
+    }
+  }
+  </script>
+<style>
+  .quill-editor {
+   height: 10em;
+   margin-bottom: 7em;
+  }
+</style>  

--- a/app/javascript/lib/quillKeyboardBindings.js
+++ b/app/javascript/lib/quillKeyboardBindings.js
@@ -1,0 +1,5 @@
+export default function quillKeyboardBindings () {
+  return {
+    tab: false
+  }
+}

--- a/app/javascript/lib/quillToolbarOptions.js
+++ b/app/javascript/lib/quillToolbarOptions.js
@@ -1,0 +1,19 @@
+export default function quillToolbarOptions () {
+  return [
+    ['bold', 'italic', 'underline', 'strike'], // toggled buttons
+    ['blockquote', 'code-block'],
+
+    [{ 'header': 1 }, { 'header': 2 }], // custom button values
+    [{ 'list': 'ordered' }, { 'list': 'bullet' }],
+    [{ 'script': 'sub' }, { 'script': 'super' }], // superscript/subscript
+    [{ 'indent': '-1' }, { 'indent': '+1' }], // outdent/indent
+    [{ 'direction': 'rtl' }], // text direction
+
+    [{ 'size': ['small', false, 'large', 'huge'] }], // custom dropdown
+    [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+
+    [{ 'align': [] }],
+
+    ['clean'] // remove formatting button
+  ]
+}


### PR DESCRIPTION
When you load the editing screen for an object the
values returned are arrays. This changes those components
so that they can handle both cases.