### PR TITLE
Update permission/visibility badges for custom embargo visibilities

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -139,4 +139,14 @@ class SolrDocument
   def proquest_submission_date
     self[Solrizer.solr_name('proquest_submission_date')]
   end
+
+  def visibility
+    VisibilityTranslator
+      .new(obj: self)
+      .visibility
+  end
+
+  def under_embargo?
+    embargo_release_date.present?
+  end
 end

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -31,6 +31,15 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     Hyrax::EtdMemberPresenterFactory.new(solr_document, current_ability, request)
   end
 
+  ##
+  # Override `PresentsAttributes` to Use the custom `EtdPermissionBadge` class,
+  # adding view support for custom Etd visibilities (embargo levels).
+  #
+  # @return [Class]
+  def permission_badge_class
+    EtdPermissionBadge
+  end
+
   # Given an ARK in the identifier field, return an Emory permanent_url
   def permanent_url
     return nil unless identifier && identifier.first && identifier.first.match(/^ark/)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -23,4 +23,45 @@ RSpec.describe ::SolrDocument, type: :model do
       end
     end
   end
+
+  describe '#visibility' do
+    subject(:solr_doc) { described_class.new(etd.to_solr) }
+    let(:etd)          { FactoryBot.build(:etd) }
+
+    it 'is public' do
+      expect(solr_doc.visibility)
+        .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    context 'when private' do
+      let(:etd)     { FactoryBot.build(:etd, visibility: private) }
+      let(:private) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+
+      it 'is private' do
+        expect(solr_doc.visibility).to eq private
+      end
+    end
+
+    context 'when under embargo' do
+      subject(:etd) do
+        FactoryBot.create(:tomorrow_expiration,
+                          files_embargoed: false,
+                          toc_embargoed:   false)
+      end
+
+      it 'is restricted to all' do
+        expect(solr_doc.visibility).to eq VisibilityTranslator::ALL_EMBARGOED
+      end
+
+      it 'reflects file level embargo' do
+        etd.visibility = VisibilityTranslator::FILES_EMBARGOED
+        expect(solr_doc.visibility).to eq VisibilityTranslator::FILES_EMBARGOED
+      end
+
+      it 'reflects toc level embargo' do
+        etd.visibility = VisibilityTranslator::TOC_EMBARGOED
+        expect(solr_doc.visibility).to eq VisibilityTranslator::TOC_EMBARGOED
+      end
+    end
+  end
 end

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -253,5 +253,33 @@ describe EtdPresenter do
     it { is_expected.to delegate_method(:requires_permissions).to(:solr_document) }
     it { is_expected.to delegate_method(:other_copyrights).to(:solr_document) }
     it { is_expected.to delegate_method(:patents).to(:solr_document) }
+
+    describe '#permission_badge' do
+      it 'shows Open Access' do
+        expect(presenter.permission_badge).to include 'Open Access'
+      end
+
+      context 'when under embargo' do
+        subject(:etd) do
+          FactoryBot.create(:tomorrow_expiration,
+                            files_embargoed: false,
+                            toc_embargoed:   false)
+        end
+
+        it 'is under embargo' do
+          expect(presenter.permission_badge).to include 'All Restricted'
+        end
+
+        it 'reflects file level embargo' do
+          etd.visibility = VisibilityTranslator::FILES_EMBARGOED
+          expect(presenter.permission_badge).to include 'Files'
+        end
+
+        it 'reflects toc level embargo' do
+          etd.visibility = VisibilityTranslator::TOC_EMBARGOED
+          expect(presenter.permission_badge).to include 'ToC'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We have extended `Etd#visibility` to support various embargo levels as distinct
visibilities. By default, Hyrax treats all items under embargo as needing an
`Embargo` permission badge, whatever the actual visibility under embargo is.
The object's `SolrDocument#visibility` reflects this visibility transformation.

To support display of badges for custom embargo level visibilities, we update
`SolrDocument` to derive its visibility from `VisibilityTranslator`, we then use
the `EtdPermissionBadge` class to generate badges in the `EtdPresenter`.

Connected to #1208.