### PR TITLE
Handle `InProgressEtd::NO_EMBARGO` values in the actor stack

### DIFF
--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -19,6 +19,8 @@
 # the data on the `Etd` record that it represents.
 
 class InProgressEtd < ApplicationRecord
+  NO_EMBARGO = 'None - open access immediately'
+
   after_create :add_id_to_data_store
 
   # custom validators check for presence of tab-determined set of fields based on presence of tab-identifying data
@@ -54,17 +56,17 @@ class InProgressEtd < ApplicationRecord
   # currently the EtdForm uses the boolean param "no_embargoes", so we need to send or remove it (seems a good candidate for refactoring in EtdForm)
 
   def add_no_embargoes(new_data)
-    resulting_data = new_data[:embargo_length] == 'None - open access immediately' ? new_data.merge("no_embargoes" => "1") : nil
+    resulting_data = new_data[:embargo_length] == NO_EMBARGO ? new_data.merge("no_embargoes" => "1") : nil
 
     resulting_data.nil? ? new_data : resulting_data
   end
 
-  # Remove embargo_type, if new_data[:embargo_length] == 'None - open access immediately'
-  # Remove no_embargoes if new_data[:embargo_length] != 'None - open access immediately'
+  # Remove embargo_type, if new_data[:embargo_length] == NO_EMBARGO
+  # Remove no_embargoes if new_data[:embargo_length] != NO_EMBARGO
 
   def remove_stale_embargo_data(existing_data, new_data)
-    existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:embargo_length] != 'None - open access immediately'
-    existing_data.delete('embargo_type') if new_data[:embargo_length] == 'None - open access immediately' && existing_data.keys.include?('embargo_type')
+    existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:embargo_length] != NO_EMBARGO
+    existing_data.delete('embargo_type') if new_data[:embargo_length] == NO_EMBARGO && existing_data.keys.include?('embargo_type')
     existing_data
   end
 

--- a/spec/actors/hyrax/actors/pregrad_embargo_spec.rb
+++ b/spec/actors/hyrax/actors/pregrad_embargo_spec.rb
@@ -19,6 +19,21 @@ describe Hyrax::Actors::PregradEmbargo do
       expect { middleware.create(env) }.not_to change { env.attributes }
     end
 
+    context 'with a specific string passed from InProgressEtd' do
+      let(:attributes) do
+        { 'title' => ['good fun'],
+          'creator' => ['Sneddon, River'],
+          'school' => ['Emory College'],
+          'embargo_length' => InProgressEtd::NO_EMBARGO }
+      end
+
+      it 'does not apply an embargo' do
+        expect { middleware.create(env) }
+          .to change { env.attributes }
+          .to attributes.except('embargo_length')
+      end
+    end
+
     context 'with a requested embargo' do
       let(:six_years_from_today) { Time.zone.today + 6.years }
 

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -299,11 +299,11 @@ describe InProgressEtd do
 
       context 'with existing no_embargoes and new no_embargoes' do
         let(:old_data) { { no_embargoes: '1' } }
-        let(:new_data) { { 'embargo_length': 'None - open access immediately' } }
+        let(:new_data) { { 'embargo_length': described_class::NO_EMBARGO } }
 
         it "preserves the no_embargoes and adds the new embargo_length data" do
           expect(resulting_data).to eq({
-            'embargo_length' => 'None - open access immediately',
+            'embargo_length' => described_class::NO_EMBARGO,
             'no_embargoes' => '1',
             "schoolHasChanged" => false
           })
@@ -326,11 +326,11 @@ describe InProgressEtd do
       context 'with existing embargoes and new no embargo data' do
         let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
 
-        let(:new_data) { { 'embargo_length': 'None - open access immediately' } }
+        let(:new_data) { { 'embargo_length': described_class::NO_EMBARGO } }
 
         it 'removes old embargo lengths and types and sets no_embargoes' do
           expect(resulting_data).to eq({
-            'embargo_length' => 'None - open access immediately',
+            'embargo_length' => described_class::NO_EMBARGO,
             'no_embargoes' => '1',
             "schoolHasChanged" => false
           })


### PR DESCRIPTION
The `PregradEmbargo` actor is responsible for setting up attributes for a
six-year pregraduation embargo when an `embargo_length` is passed during `Etd`
creation. This works more or less the same as its predecessor, but relies more
on base Hyrax behavior. The values passed here are eventually interpreted at
graduation time to determine the post-grad embargo release date.

However, the `InProgressEtd` data stores a specific string indicating that no
embargo is requested and passes that value to the stack. This is always
interpreted as a request for a pregrad embargo.

Ideally, we would handle this at the edge of `InProgressEtd` so other parts of
the application don't need to be aware of this blessed string. It's likely that
`InProgressEtd` needs this to be round-tripabble, and the handling for
transformation of this data lives across various methods. Rather than attempt an
immediate refactor, we fix the bug by handling the special data in the actor
stack. We raise a warning so the larger fix won't get ignored.

Fixes #1485.