### PR TITLE
Display files on final submission tab

### DIFF
--- a/app/javascript/components/submit/MyFiles.vue
+++ b/app/javascript/components/submit/MyFiles.vue
@@ -1,7 +1,47 @@
 <template>
   <section>   
     <h4>My Files</h4>
-    <!-- TODO: We need some kind of info about the files in sharedState.savedData -->
+    <table class="table table-striped metadata">
+      <thead>
+        <tr>
+          <th>
+           Your Thesis or Dissertation
+          </th>
+          </tr>
+      </thead>
+      <tbody>
+        <tr>
+        <td>{{ primaryFile.name }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <h5>Supplemental Files</h5>
+    <table class="table table-striped metadata">
+      <thead>
+        <tr>
+          <th>
+            Filename
+          </th>
+          <th>
+            Title
+          </th>
+          <th>
+            Description
+          </th>
+          <th>
+            Type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="supplementalFile in supplementalFiles">
+          <td>{{ supplementalFile.filename }}</td>
+          <td>{{ supplementalFile.title }}</td>
+          <td>{{ supplementalFile.description }}</td>
+          <td>{{ supplementalFile.type }}</td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </template>
 
@@ -12,7 +52,8 @@ import { formStore } from '../../formStore'
 export default {
   data() {
     return {
-      sharedState: formStore
+      supplementalFiles: formStore.savedData.supplemental_file_metadata,
+      primaryFile: JSON.parse(formStore.savedData.files)
     }
   }
 }

--- a/app/javascript/test/components/submit/MyFiles.spec.js
+++ b/app/javascript/test/components/submit/MyFiles.spec.js
@@ -3,7 +3,9 @@
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
 import MyFiles from '../../../components/submit/MyFiles'
+import { formStore } from '../../../formStore'
 
+formStore.savedData.files = '{"id":85,"name":"c4611_sample_explain.pdf","size":88226,"deleteUrl":"/uploads/85?locale=en","deleteType":"DELETE"}'
 describe('MyFiles.vue', () => {
   it('has the correct label', () => {
     const wrapper = shallowMount(MyFiles, {


### PR DESCRIPTION
This commit displays the primary and supplemental
files that a user has uploaded on the final submission tab.

Related to #1190