### PR TITLE
prevent duplicates in supplementalFiles in formstore

### DIFF
--- a/app/javascript/FileDelete.js
+++ b/app/javascript/FileDelete.js
@@ -13,8 +13,8 @@ export default class FileDelete {
     const filteredFiles = this.formStore.files.filter(
       file => file[0].deleteUrl !== this.deleteUrl
     )
+    console.log('filtered files: ', filteredFiles)
     this.formStore.files = filteredFiles
-    //TODO: we need a remove from savedFiles function
-    //this.formStore.removeSavedFile(this.deleteUrl)
+    this.formStore.removeSavedFile(this.deleteUrl)
   }
 }

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -204,7 +204,6 @@ export default {
       this.sharedState.setValid('My Files', false)
     },
     deleteSupplementalFile(deleteUrl) {
-      console.log(deleteUrl)
      var supplementalFileDelete = new SupplementalFileDelete({
         deleteUrl: deleteUrl,
         token: this.sharedState.token,

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -41,11 +41,9 @@ export default class SaveAndSubmit {
   }
   saveTab () {
     this.formData.append("etd[files]", this.formStore.getPrimaryFile())
-    //this.formData.append("etd[supplemental_files_metadata]",  this.formStore.getSupplementalFilesMetadata())
     // the client sends a param the server uses to track whether an old school matches a new school
     this.formData.append('etd[schoolHasChanged]', this.formStore.savedData['schoolHasChanged'])
     this.rejectOtherTabKeys()
-
     axios
       .patch(this.formStore.getUpdateRoute(), this.formData, {
         config: { headers: { 'Content-Type': 'multipart/form-data' } }


### PR DESCRIPTION
This commit prevents the creation of duplicates in the the formStore's supplementalFiles array, that was caused during the adding of supplemental file metadata to the savedData object used for persisting information. 