### PR TITLE
Set the submitted to true when clicking Submit

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -488,6 +488,7 @@ export var formStore = {
       formData: this.formData
     })
     if (this.allowTabSave()) {
+      this.submitted = true
       saveAndSubmit.submitEtd()
     } else {
       this.submitted = true


### PR DESCRIPTION
There was a case added for the update, which does set
the submitted state to true, but not for the initial
submit.

This sets the sumbmitted state to true, which causes the
spinner to show up and the submit button to hide.

Closes #1497