### PR TITLE
Fix for subfields not displaying

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -352,7 +352,7 @@ export var formStore = {
   },
   getSubfields () {
     if (this.subfieldEndpoints[this.selectedDepartment]) {
-      axios.get().then((response) => {
+      axios.get(this.subfieldEndpoints[this.selectedDepartment]).then((response) => {
         this.subfields = response.data
       })
     }


### PR DESCRIPTION
This fixes a bug with subfields not displaying.

The URL was missing from the request. I added some
checking to make sure we had the url, but forgot to
add the URL to the request.

Closes #1496