### PR TITLE
persist supplemental files

### DIFF
--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -21,9 +21,12 @@ export default class SaveAndSubmit {
     var ignoreSet = ['etd[currentTab]', 'etd[currentStep]','etd[schoolHasChanged]']
 
     for (var key of this.formData.keys()) {
-      // add supplementalFilesMetadata to ignore set
+      // add supplementalFiles and supplementalFilesMetadata to ignore set
       if (ourTab === "My Files") {
         if (_.includes(key, 'etd[supplemental_file_metadata]')){
+          ignoreSet.push(key)
+        }
+        if (_.includes(key, 'etd[supplemental_files]')){
           ignoreSet.push(key)
         }
       }
@@ -40,8 +43,10 @@ export default class SaveAndSubmit {
     }
   }
   saveTab () {
+    // files are special
     this.formData.append("etd[files]", this.formStore.getPrimaryFile())
-    //this.formData.append("etd[supplemental_files_metadata]",  this.formStore.getSupplementalFilesMetadata())
+    this.formData.append("etd[supplemental_files]", this.formStore.getSupplementalFiles())
+
     // the client sends a param the server uses to track whether an old school matches a new school
     this.formData.append('etd[schoolHasChanged]', this.formStore.savedData['schoolHasChanged'])
     this.rejectOtherTabKeys()

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -368,6 +368,11 @@ export var formStore = {
     return JSON.stringify(this.files[0][0])
   },
 
+  getSupplementalFiles(){
+    if (this.supplementalFiles === undefined || this.supplementalFiles.length === 0) return
+    return JSON.stringify(this.supplementalFiles)
+  },
+
   getGraduationDate () {
     return this.savedData['graduation_date']
   },
@@ -442,6 +447,24 @@ export var formStore = {
       }
     }
   },
+  addSupplementalFiles () {
+    if (this.savedData['supplemental_files']){
+      var parsedFiles = this.tryParseJSON(this.savedData['supplemental_files'])
+      // we have a legit parsed file array of objects
+      if (!(_.isError(parsedFiles))){
+        // check for duplicates
+        _.forEach(parsedFiles, (psf) => {
+          var file = _.find(this.supplementalFiles, function(sf) {
+            return sf.deleteUrl === psf.deleteUrl
+          })
+          // add only if it isn't there
+          if ( !(_.isObject(file)) ) {
+            this.supplementalFiles.push(psf)
+          }
+        })
+      }
+    }
+  },
   tryParseJSON(str){
     return _.attempt(JSON.parse.bind(null, str));
   },
@@ -476,7 +499,7 @@ export var formStore = {
       this.savedData = JSON.parse(el.dataset.inProgressEtd)
     }
     this.addFileData()
-    this.addSupplementalFileMetadata()
+    this.addSupplementalFiles()
     if (Object.keys(this.savedData).length > 0) {
       this.setIpeId(this.savedData['ipe_id'])
       this.setEtdId(this.savedData['etd_id'])


### PR DESCRIPTION
This commit persists the supplemental file data exactly like the primary file data: encoding it with json, appending it to the form, and retrieving it from savedData back into the form elements for display.