### PR TITLE
persist supplemental files metadata

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -88,11 +88,11 @@
 
             <td><input type="text" :value="sharedState.supplementalFiles[key].filename" class="form-control" disabled />
             <input type='hidden' :value="files.name" :name="supplementalFileName(key)"></td>
-            <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="sharedState.supplementalFiles[key].title" v-on:change="sharedState.setValid('My Files', false)"/></td>
-            <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="sharedState.supplementalFiles[key].description" v-on:change="sharedState.setValid('My Files', false)"/></td>
+            <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)" v-on:change="sharedState.setValid('My Files', false)"/></td>
+            <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" v-on:change="sharedState.setValid('My Files', false)"/></td>
             <td>
               <select :name="supplementalFileTypeName(key)" class="form-control file-type" v-on:change="sharedState.setValid('My Files', false)">
-                <option v-if="sharedState.supplementalFiles[key].file_type" selected="selected" :value="sharedState.supplementalFiles[key].file_type">{{sharedState.supplementalFiles[key].file_type}}</option>
+                <option v-if="sharedState.supplementalFiles[key].file_type" selected="selected" :value="getSavedFileType(key)">{{getSavedFileType(key)}}</option>
                 <option v-else selected="selected" disabled="disabled">Please select a file type</option>
                 <option>Text</option>
                 <option>Sound</option>
@@ -204,7 +204,6 @@ export default {
       this.sharedState.setValid('My Files', false)
     },
     deleteSupplementalFile(deleteUrl) {
-      console.log(deleteUrl)
      var supplementalFileDelete = new SupplementalFileDelete({
         deleteUrl: deleteUrl,
         token: this.sharedState.token,
@@ -227,6 +226,21 @@ export default {
   },
   supplementalFileName (key) {
     return `etd[supplemental_file_metadata][${key}]filename`
+  },
+  getSavedTitle(key){
+    if (this.sharedState.supplementalFilesMetadata[key] !== undefined) {
+      return this.sharedState.supplementalFilesMetadata[key].title
+    }
+  },
+  getSavedDescription(key){
+    if (this.sharedState.supplementalFilesMetadata[key] !== undefined) {
+      return this.sharedState.supplementalFilesMetadata[key].description
+    }
+  },
+  getSavedFileType(key){
+    if (this.sharedState.supplementalFilesMetadata[key] !== undefined) {
+      return this.sharedState.supplementalFilesMetadata[key].file_type
+    }
   }
   }
 }

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -162,6 +162,7 @@ export var formStore = {
   submitted: false,
   files: [],
   supplementalFiles: [],
+  supplementalFilesMetadata: [],
   departments: [],
   selectedDepartment: '',
   selectedSubfield: '',
@@ -417,7 +418,18 @@ export var formStore = {
       })
     }
   },
-
+  addSupplementalFileMetadata () {
+    if (this.savedData['supplemental_file_metadata']) {
+      // check for duplicates
+      _.forEach(this.savedData['supplemental_file_metadata'], (sfm) => {
+        var file = _.find(this.supplementalFilesMetadata, function(o) { return o.filename === sfm.filename })
+        // add only if it isn't there
+        if ( !(_.isObject(file)) ) {
+          this.supplementalFilesMetadata.push({ filename: sfm.filename, title: sfm.title, description: sfm.description, file_type: sfm.file_type })
+        }
+      })
+    }
+  },
   addFileData () {
     if (this.savedData['files']) {
       var parsedFiles = this.tryParseJSON(this.savedData['files'])


### PR DESCRIPTION
This commit makes sure we persist and display saved supplemental file metadata, following the same duplicate-prevention strategy we use with primary and supplemental files. It depends on the having the same object keys as the supplemental files array.