### PR TITLE
Update the embargo_release_date of file sets

### DIFF
--- a/spec/jobs/graduation_job_spec.rb
+++ b/spec/jobs/graduation_job_spec.rb
@@ -1,6 +1,26 @@
 require 'rails_helper'
-describe GraduationJob, :clean do
-  context "calculating embargo_release_date", :clean do
+describe GraduationJob, integration: true do
+  before(:context) do
+    DatabaseCleaner.clean
+    ActiveFedora::Cleaner.clean!
+
+    workflow_settings = { superusers_config: "#{fixture_path}/config/emory/superusers.yml",
+                          admin_sets_config: "#{fixture_path}/config/emory/candler_admin_sets.yml",
+                          log_location:      "/dev/null" }
+
+    setup_args = [workflow_settings[:superusers_config],
+                  workflow_settings[:admin_sets_config],
+                  workflow_settings[:log_location]]
+
+    WorkflowSetup.new(*setup_args).setup
+  end
+
+  after(:context) do
+    DatabaseCleaner.clean
+    ActiveFedora::Cleaner.clean!
+  end
+
+  context "calculating embargo_release_date" do
     it "can interpret a length of '6 months'" do
       e = described_class.embargo_length_to_embargo_release_date(Time.zone.today, "6 months")
       expect(e).to eq Time.zone.today + 6.months
@@ -10,27 +30,45 @@ describe GraduationJob, :clean do
       expect(e).to eq Time.zone.today + 3.years
     end
   end
-  context "when a student graduates" do
-    let(:etd) { FactoryBot.create(:sample_data, school: ["Candler School of Theology"]) }
-    let(:depositing_user) { User.where(ppid: etd.depositor).first }
+
+  context "when a student graduates", :perform_jobs do
+    let(:attributes) do
+      { 'title' => ['The Adventures of Cottontail Rabbit'],
+        'post_graduation_email' => ['me@after.graduation.com'],
+        'creator' => ['Sneddon, River'],
+        'school' => ["Candler School of Theology"],
+        'department' => ["Divinity"],
+        'embargo_length' => '6 months',
+        'files_embargoed' => true,
+        'uploaded_files' => [uploaded_file.id] }
+    end
+    let(:actor)      { Hyrax::CurationConcern.actor }
+    let(:ability)    { ::Ability.new(user) }
+    let(:etd)        { FactoryBot.build(:etd) }
+    let(:terminator) { Hyrax::Actors::Terminator.new }
+    let(:user)       { FactoryBot.create(:user) }
+    let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
+    let(:open)       { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    let(:restricted) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    let(:uploaded_file) do
+      FactoryBot.create :primary_uploaded_file, user_id: user.id
+    end
     let(:six_years_from_today) { Time.zone.today + 6.years }
     before do
       allow(Hyrax::Workflow::DegreeAwardedNotification).to receive(:send_notification)
-      # This replicates what InterpretVisibilityActor does
-      etd.embargo_length = "6 months"
-      etd.apply_embargo(
-        six_years_from_today,
-        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
-        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
-      )
-      etd.embargo.save
-      etd.save
+      ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob]
+      actor.create(env)
+      etd.reload
       expect(etd.degree_awarded).to eq nil
       expect(etd.embargo.embargo_release_date).to eq six_years_from_today
       expect(etd.embargo_length).to eq "6 months"
+      expect(etd.reload.file_sets.first.embargo)
+        .to have_attributes embargo_release_date: six_years_from_today,
+                            visibility_during_embargo: restricted,
+                            visibility_after_embargo: open
+      expect(etd.file_sets.first)
+        .to have_attributes visibility: restricted
       graduation_job = described_class.new
-      # Don't try to publish the object in this context, we haven't set up workflow here.
-      allow(graduation_job).to receive(:publish_object)
       graduation_job.perform(etd.id, Time.zone.tomorrow)
       etd.reload
     end
@@ -38,10 +76,14 @@ describe GraduationJob, :clean do
       expect(etd.degree_awarded).to eq Time.zone.tomorrow
     end
     it "updates the depositor's email address" do
-      expect(depositing_user.email).to eq(etd.post_graduation_email.first)
+      expect(user.reload.email).to eq(etd.post_graduation_email.first)
     end
-    it "resets the embargo_release_date" do
+    it "resets the embargo_release_date for the ETD and any attached files" do
       expect(etd.embargo.embargo_release_date).to eq Time.zone.tomorrow + 6.months
+      expect(etd.file_sets.first.embargo.embargo_release_date).to eq Time.zone.tomorrow + 6.months
+    end
+    it "leaves the visibility of the file sets restricted" do
+      expect(etd.file_sets.first).to have_attributes visibility: restricted
     end
     it "leaves embargo_length intact" do
       expect(etd.embargo_length).to eq "6 months"


### PR DESCRIPTION
Upon graduation, update the embargo_release_date
of all filesets attached to a work, in addition
to updating the embargo_release_date of the work
itself.

Fixes #1210 