### PR TITLE
Expire embargoes on attached file sets

### DIFF
--- a/app/services/embargo_expiration_service.rb
+++ b/app/services/embargo_expiration_service.rb
@@ -94,6 +94,11 @@ class EmbargoExpirationService
       expiration.deactivate_embargo!
       expiration.embargo.save
       expiration.save
+      expiration.file_sets.each do |fs|
+        fs.visibility = expiration.visibility
+        fs.deactivate_embargo!
+        fs.save
+      end
     end
   end
 


### PR DESCRIPTION
When the embargo expiration service runs it
should also remove embargoes and re-set
visibility on attached file sets.

Fixes #1511 