### PR TITLE
remove saved supplemental file metadata

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -86,13 +86,13 @@
         <tbody>
           <tr v-for="(files, key) in sharedState.supplementalFiles" v-bind:key="key">
 
-            <td><input type="text" :value="sharedState.supplementalFiles[key].filename" class="form-control" disabled />
+            <td><input type="text" :value="sharedState.supplementalFilesMetadata[key].filename" class="form-control" disabled />
             <input type='hidden' :value="files.name" :name="supplementalFileName(key)"></td>
             <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)" v-on:change="sharedState.setValid('My Files', false)"/></td>
             <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" v-on:change="sharedState.setValid('My Files', false)"/></td>
             <td>
               <select :name="supplementalFileTypeName(key)" class="form-control file-type" v-on:change="sharedState.setValid('My Files', false)">
-                <option v-if="sharedState.supplementalFiles[key].file_type" selected="selected" :value="getSavedFileType(key)">{{getSavedFileType(key)}}</option>
+                <option v-if="sharedState.supplementalFilesMetadata[key].file_type" selected="selected" :value="getSavedFileType(key)">{{getSavedFileType(key)}}</option>
                 <option v-else selected="selected" disabled="disabled">Please select a file type</option>
                 <option>Text</option>
                 <option>Sound</option>

--- a/app/javascript/SupplementalFileDelete.js
+++ b/app/javascript/SupplementalFileDelete.js
@@ -12,5 +12,7 @@ export default class SupplementalFileDelete extends FileDelete {
     )
     console.log(filteredFiles)
     this.formStore.supplementalFiles = filteredFiles
+    this.formStore.removeSavedSupplementalFile(this.deleteUrl)
+    this.formStore.removeSavedSupplementalFileMetadata(this.id)
   }
 }

--- a/app/javascript/test/SupplementalFileDelete.spec.js
+++ b/app/javascript/test/SupplementalFileDelete.spec.js
@@ -5,7 +5,7 @@
 /* gloabl createXHRmock */
 
 import SupplementalFileDelete from '../SupplementalFileDelete'
-
+import { formStore } from '../formStore'
 const mockXHR = {
   open: jest.fn(),
   send: jest.fn(),
@@ -19,7 +19,7 @@ describe('SupplementalFileDelete', () => {
     var fileDelete = new SupplementalFileDelete({
       deleteUrl: 'http://example.com/delete',
       token: 'token',
-      formStore: { supplementalFiles: [] }
+      formStore: formStore
     })
     fileDelete.deleteFile()
     expect(mockXHR.open).toBeCalledWith('DELETE', 'http://example.com/delete', true)


### PR DESCRIPTION
This commit ensures that saved supplemental file metadata is removed as well as saved supplemental files, following established patterns for finding and filtering and preventing duplicate entries as the other add/remove files functions. It relies on the supplementalFiles and supplementalFIlesMetadata arrays in the formStore, expects them to contain the same items in the same order.