### PR TITLE
Ensure that babel-polyfill is loaded

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,23 +1,38 @@
 {
-  "presets": ["es2015",
-    ["env", {
-      "modules": false,
-      "targets": {
-        "browsers": "> 1%",
-        "uglify": true
-      },
-      "useBuiltIns": true
-    }]
+  "presets": [
+    [
+      "env",
+      {
+        "modules": false,
+        "targets": {
+          "browsers": "> 1%",
+          "uglify": true
+        },
+        "useBuiltIns": true
+      }
+    ]
   ],
   "plugins": [
     "syntax-dynamic-import",
     "transform-object-rest-spread",
-    ["transform-class-properties", { "spec": true }],
+    [
+      "transform-class-properties",
+      {
+        "spec": true
+      }
+    ]
   ],
   "env": {
     "test": {
       "presets": [
-        ["env", { "targets": { "node": "current" }}]
+        [
+          "env",
+          {
+            "targets": {
+              "browsers": ["cover 99.5% in US"]
+            }
+          }
+        ]
       ]
     }
   }

--- a/app/javascript/packs/root.js
+++ b/app/javascript/packs/root.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import TurbolinksAdapter from 'vue-turbolinks'
 import Vue from 'vue/dist/vue.esm'
 import App from '../App'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@rails/webpacker": "3.5",
     "axios": "^0.18.0",
     "babel-core": "^6.26.3",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "caniuse-lite": "^1.0.30000865",
     "css-loader": "^1.0.0",


### PR DESCRIPTION
We needed to import this as the first script
in the root.js file so that babel will be
able to polyfill.

Tangentially related to #1513