### PR TITLE
Fixes for embargos

### DIFF
--- a/app/javascript/Embargo.vue
+++ b/app/javascript/Embargo.vue
@@ -1,21 +1,20 @@
 <template>
 <div>
   <label for="embargo-length">Requested Embargo Length</label>
-  <select v-model="selectedEmbargo" name="etd[embargo_length]" aria-required="true" class="form-control" id="embargo-length" v-on:change="sharedState.setValid('Embargo', false)">
-    <option v-for="length in lengths" :value="length.value" :selected="length.selected" :disabled="length.disabled">
+  <select v-model="selectedEmbargo" name="etd[embargo_length]" aria-required="true" class="form-control" id="embargo-length" v-on:change="sharedState.setSelectedEmbargo(selectedEmbargo), sharedState.setValid('Embargo', false)">
+    <option v-for="length in embargoLengths" :value="length.value" :selected="length.selected" :disabled="length.disabled">
         {{ length.value }}
       </option>
-    </select>
+  </select>
   <div v-if="selectedEmbargo != 'None - open access immediately'">
     <label for="content-to-embargo">Content to Embargo</label>
-    <select name="etd[embargo_type]" v-model="selectedContent" class="form-control" id="content-to-embargo" v-on:change="sharedState.setValid('Embargo', false)">
-      <option v-for="content in contents" :value="content.value" :disabled="content.disabled" :selected="content.selected">
+    <select name="etd[embargo_type]" v-model="selectedContent" class="form-control" id="content-to-embargo" v-on:change="sharedState.setSelectedEmbargoContents(selectedContent), sharedState.setValid('Embargo', false)">
+      <option v-for="content in sharedState.getEmbargoContents()" :value="content.value" :disabled="content.disabled" :selected="content.selected">
         {{ content.text }}
       </option>
     </select>
     </div>
-    </div>
-</div>
+  </div>
 </template>
 
 <script>
@@ -26,48 +25,10 @@ import _ from 'lodash'
 export default {
   data() {
     return {
-      selectedEmbargo: 'None - open access immediately',
-      selectedContent: '',
+      selectedContent: formStore.getSelectedEmbargoContents(),
+      selectedEmbargo: formStore.getSelectedEmbargo(),
+      embargoLengths: formStore.getEmbargoLengths(formStore.getSavedOrSelectedSchool()),
       sharedState: formStore
-    }
-  },
-  methods: {
-    setSelected(collection, selected){
-      var match = false
-      //ensuring we have this item in our current school's lengths and types
-      if (selected !== undefined) {
-        _.forEach(collection, function(item) {
-          if (item.value === selected){
-            match = true
-            item.selected = 'selected'
-          }
-        });
-      }
-      if (match === true) {
-        return selected
-      }
-    }
-  },
-  computed: {
-    lengths () {
-      var lengths = formStore.getEmbargoLengths()
-      var selected = formStore.savedData['embargo_length']
-      var selectedLength = this.setSelected(lengths, selected)
-
-      if (selectedLength  !== undefined){
-        this.selectedEmbargo = selectedLength
-      }
-      return lengths
-    },
-    contents () {
-      var contents = formStore.getEmbargoContents()
-      var selected = formStore.savedData['embargo_type']
-      var selectedContent = this.setSelected(contents, selected)
-
-      if (selectedContent !== undefined){
-        this.selectedContent = selectedContent
-      }
-      return contents
     }
   }
 }

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -18,7 +18,7 @@ export default class SaveAndSubmit {
       return `etd[${ok}]`
     })
     // keys in the form we always want to send to server
-    var ignoreSet = ['etd[currentTab]', 'etd[currentStep]','etd[schoolHasChanged]']
+    var ignoreSet = ['etd[currentTab]', 'etd[currentStep]','etd[schoolHasChanged]', 'etd[embargo_length]', 'etd[embargo_type]']
 
     for (var key of this.formData.keys()) {
       // add supplementalFiles and supplementalFilesMetadata to ignore set

--- a/app/javascript/components/submit/Embargo.vue
+++ b/app/javascript/components/submit/Embargo.vue
@@ -3,6 +3,8 @@
     <h4>Embargoes</h4>
     <h5>Embargo Length</h5>
     <div>{{ sharedState.savedData.embargo_length }}</div>
+    <h5>Embargo Type</h5>
+    <div>{{ humanReadableEmbargoContents(sharedState.savedData.embargo_type) }}</div>
   </section>
 </template>
 
@@ -14,6 +16,17 @@ export default {
   data() {
     return {
       sharedState: formStore
+    }
+  },
+  methods: {
+    humanReadableEmbargoContents(type) {
+      try {
+      var readableType = this.sharedState.embargoContents.filter((embargo) => { return embargo.value === type })[0].text
+      } catch(error) {
+        console.log(error)
+      }
+      if (readableType)
+      return readableType
     }
   }
 }

--- a/app/javascript/config/embargoLengths.json
+++ b/app/javascript/config/embargoLengths.json
@@ -1,10 +1,10 @@
 {
   "emory": [{"value": "None - open access immediately", "selected": "selected"},
-    {"value": "6 Months"}, {"value": "1 Year"}, {"value": "2 Years"}],
+    {"value": "6 months"}, {"value": "1 year"}, {"value": "2 years"}],
   "candler": [{"value": "None - open access immediately", "selected": "selected"},
-    {"value": "6 Months"}, {"value": "1 Year"}, {"value": "2 Years"}],
-  "laney": [{"value": "None - open access immediately", "selected": "selected"}, {"value": "6 Months"},
-    {"value": "1 Year"}, {"value": "2 Years"}, {"value": "6 Years"}],
+    {"value": "6 months"}, {"value": "1 year"}, {"value": "2 years"}],
+  "laney": [{"value": "None - open access immediately", "selected": "selected"}, {"value": "6 months"},
+    {"value": "1 year"}, {"value": "2 years"}, {"value": "6 years"}],
   "rollins": [{"value": "None - open access immediately", "selected": "selected"},
-    {"value": "6 Months"}, {"value": "1 Year"}, {"value": "2 Years"}]
+    {"value": "6 months"}, {"value": "1 year"}, {"value": "2 years"}]
 }

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -163,6 +163,8 @@ export var formStore = {
   boxFilePickerMode: new BoxFilePickerMode(),
   agreement: false,
   submitted: false,
+  selectedEmbargo: 'None - open access immediately',
+  selectedEmbargoContents: '',
   files: [],
   supplementalFiles: [],
   supplementalFilesMetadata: [],
@@ -303,13 +305,33 @@ export var formStore = {
   getSelectedSchool () {
     return this.schools.selected
   },
-
   getSavedOrSelectedSchool () {
     if (this.selectedSchool === undefined) {
       this.selectedSchool = ''
     }
     return this.selectedSchool.length === 0
       ? this.savedData['school'] : this.schools.selected
+  },
+  setSelectedEmbargo (embargo) {
+    this.selectedEmbargo = embargo
+  },
+  setSelectedEmbargoContents (contents) {
+    this.selectedEmbargoContents = contents
+  },
+  getSelectedEmbargo () {
+    if (this.savedData['embargo_length']) {
+      return this.savedData['embargo_length']
+    } else {
+      return this.selectedEmbargo
+    }
+  },
+  getSelectedEmbargoContents () {
+    if (this.selectedEmbargoContents) {
+      return this.selectedEmbargoContents
+    }
+    if (this.savedData['embargo_type']) {
+      return this.savedData['embargo_type']
+    }
   },
   getSavedSchool () {
     return this.savedData['school']
@@ -400,7 +422,7 @@ export var formStore = {
     }
   },
   getEmbargoLengths () {
-    return this.embargoLengths[this.schools.selected]
+    return this.embargoLengths[this.getSavedOrSelectedSchool()]
   },
   getEmbargoContents () {
     return this.embargoContents

--- a/app/javascript/test/components/submit/Embargo.spec.js
+++ b/app/javascript/test/components/submit/Embargo.spec.js
@@ -3,8 +3,10 @@
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
 import Embargo from '../../../components/submit/Embargo'
+import { formStore } from '../../../formStore'
 import axios from 'axios'
-jest.mock('')
+
+formStore.getSavedOrSelectedSchool = jest.fn(() => {return 'emory'})
 
 describe('Embargo.vue', () => {
   it('has the correct label', () => {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -4,11 +4,12 @@
 
 import { formStore } from '../formStore'
 
+formStore.getSavedOrSelectedSchool = jest.fn(() => {return 'emory'})
 describe('formStore', () => {
   it('returns the correct embargo length based on the selected school', () => {
     formStore.setSelectedSchool('emory')
     expect(formStore.getEmbargoLengths()).toEqual([{ value: 'None - open access immediately', selected: 'selected' },
-    { value: '6 Months' }, { value: '1 Year' }, { value: '2 Years' }])
+    { value: '6 months' }, { value: '1 year' }, { value: '2 years' }])
   })
 
   it('returns the correct embargo contents', () => {


### PR DESCRIPTION
This will persist emabargoes in `saved_data` and display them in
the correct way on the submission tab.

Related to #1514, #1494, #1190, #1468