### PR TITLE
Fix rich text not displaying on the edit form

### DIFF
--- a/app/javascript/components/RichTextEditor.vue
+++ b/app/javascript/components/RichTextEditor.vue
@@ -1,11 +1,11 @@
   <template>
     <div> 
-        <div v-if="typeof parentValue === 'String' || 'string' || 'undefined'">
+        <div v-if="typeof parentValue != 'object'">
           <quill-editor :options="editorOptions" ref="myTextEditor" v-model="inputValue" v-on:change="sharedState.setValid('My Etd', false)">
           </quill-editor>
           <input type="hidden" class="quill-hidden-field" :name="parentName" v-model="inputValue" />
         </div>
-        <div v-else>
+        <div v-if="typeof parentValue === 'object'">
           <quill-editor :options="editorOptions" ref="myTextEditor" v-model="inputValue[0]" v-on:change="sharedState.setValid('My Etd', false)">
           </quill-editor>
         <input type="hidden" class="quill-hidden-field" :name="parentName" v-model="inputValue[0]" />


### PR DESCRIPTION
The type checking wasn't quite right for handling the
edit and creation forms.