### PR TITLE
enabling display of language in edit of etd

### DIFF
--- a/app/javascript/Language.vue
+++ b/app/javascript/Language.vue
@@ -33,6 +33,10 @@ export default {
     getSelected(data){
       var selected = this.sharedState.getSavedLanguage()
       if (selected !== undefined) {
+        //TODO: the model should return strings not arrays 
+        if(_.has(this.sharedState.savedData, 'etd_id')){
+          selected = selected[0]
+        }
         this.selected = selected
       } else {
         data.unshift({ "value": "", "active": true, "label": "Select a Language", "disabled":"disabled" ,"selected": "selected"})


### PR DESCRIPTION
This commit makes sure the front end handle the data for language from an etd record, and contains a todo noting that we should do this in the model. 