### PR TITLE
remove the metadata as well the file

### DIFF
--- a/app/javascript/SupplementalFileDelete.js
+++ b/app/javascript/SupplementalFileDelete.js
@@ -10,8 +10,12 @@ export default class SupplementalFileDelete extends FileDelete {
     const filteredFiles = this.formStore.supplementalFiles.filter(
       file => file.deleteUrl !== this.deleteUrl
     )
+    const filteredMetadata = this.formStore.supplementalFilesMetadata.filter(
+      file => file.id !== this.id
+    )
     console.log(filteredFiles)
     this.formStore.supplementalFiles = filteredFiles
+    this.formStore.supplementalFilesMetadata = filteredMetadata
     this.formStore.removeSavedSupplementalFile(this.deleteUrl)
     this.formStore.removeSavedSupplementalFileMetadata(this.id)
   }


### PR DESCRIPTION
This commit fixes a bug caused by removing metadata from savedData but not the formStore array.