### PR TITLE
Translate embargo_type into expected params

### DIFF
--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -7,8 +7,8 @@ module Hyrax
       private
 
         def apply_save_data_to_curation_concern(env)
+          translate_embargo_types(env)
           super
-
           # ActiveFedora fails to propgate changes to nested attributes to
           # `#resource` when indexed nested attributes are used. We force the
           # issue here to work around for form edits.
@@ -16,6 +16,17 @@ module Hyrax
             attribute = attribute_key.to_s.gsub('_attributes', '').to_sym
             env.curation_concern.send(attribute).each { |member| member.try(:persist!) }
           end
+        end
+
+        # We must translate a value like env.attributes[:embargo_type] = "files_embargoed, toc_embargoed, abstract_embargoed"
+        # into the ETD's expected etd.files_embargoed = 'true', etd.toc_embargoed = 'true',
+        # etd.abstract_embargoed = 'true'
+        def translate_embargo_types(env)
+          return unless env.attributes[:embargo_type]
+          embargo_type = env.attributes.delete(:embargo_type)
+          env.attributes[:files_embargoed] = 'true' if embargo_type =~ /files_embargoed/
+          env.attributes[:toc_embargoed] = 'true' if embargo_type =~ /toc_embargoed/
+          env.attributes[:abstract_embargoed] = 'true' if embargo_type =~ /abstract_embargoed/
         end
     end
   end

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -32,6 +32,7 @@ module Hyrax
     # my embargo terms
     self.terms += [:embargo_length]
     self.terms += [:embargo_release_date]
+    self.terms += [:embargo_type]
     self.terms += [:files_embargoed]
     self.terms += [:abstract_embargoed]
     self.terms += [:toc_embargoed]

--- a/spec/actors/stack_spec.rb
+++ b/spec/actors/stack_spec.rb
@@ -95,14 +95,14 @@ describe Hyrax::CurationConcern do
           expect(etd.file_sets.first).to have_attributes visibility: open
         end
 
-        context 'and files_embargoed is true' do
+        context 'and embargo_type contains files_embargoed' do
           let(:attributes) do
             { 'title' => ['good fun'],
               'creator' => ['Sneddon, River'],
               'school' => ['Emory College'],
               'embargo_length' => '6 months',
               'uploaded_files' => [uploaded_file.id],
-              'files_embargoed' => true }
+              'embargo_type' =>  "files_embargoed, toc_embargoed, abstract_embargoed" }
           end
 
           it 'sets the file embargo' do


### PR DESCRIPTION
We have a mis-match between what the new UI
form is sending for embargo_type and what
the object is expecting to receive. This
translates between the two.

Fixes #1512 