### PR TITLE
Fix supplemental file type options

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -95,6 +95,8 @@
                 <option v-if="getSavedFileType(key)" selected="selected" :value="getSavedFileType(key)">{{getSavedFileType(key)}}</option>
                 <option v-else selected="selected" disabled="disabled">Please select a file type</option>
                 <option>Text</option>
+                <option>Dataset</option>
+                <option>Image</option>
                 <option>Sound</option>
                 <option>Video</option>
                 <option>Software</option>


### PR DESCRIPTION
We missed some of these. This adds them to the
list.

Closes #1534