### PR TITLE
Fix display of copyright questions

### DIFF
--- a/app/javascript/CopyrightQuestions.vue
+++ b/app/javascript/CopyrightQuestions.vue
@@ -2,11 +2,14 @@
     <section aria-labelledby="copyright-questions">
     <h4 id="copyright-questions">Please review the following copyright questions.</h4>
       <div>
-        <div v-for="question in sharedState.copyrightQuestions" v-bind:key="question.name">
+        <div class="well" v-for="question in sharedState.copyrightQuestions" v-bind:key="question.name">
             <label :for="question.name">{{ question.label }}</label>
             <p>{{ question.text }}</p>
-            <input :id="question.name" class="checkbox copyright-checkbox" :name="question.name" type="checkbox" v-model="question.choice"
+           <div class="form-inline">
+            <label>Yes <input :id="question.name" class="checkbox copyright-checkbox" :name="question.name" type="checkbox" v-model="question.choice"
             true-value="yes" false-value="no">
+            </label>
+            </div>
         </div>
       </div>
     </section>
@@ -27,6 +30,14 @@ export default {
 
 <style scoped>
 .copyright-checkbox {
-    margin-bottom: 3em;
+    margin-left: 1em;
+}
+
+input[type=checkbox]
+{
+  -ms-transform: scale(2); 
+  -moz-transform: scale(2);
+  -webkit-transform: scale(2);
+  -o-transform: scale(2);
 }
 </style>

--- a/app/javascript/components/submit/Keywords.vue
+++ b/app/javascript/components/submit/Keywords.vue
@@ -10,11 +10,17 @@
       <div> {{ keyword }} </div>
     </div>
    <h5>Copyright Questions</h5>
-    <ul>
-      <li>Additional copyrights: {{ sharedState.savedData.additional_copyrights }}</li>
-      <li>Requires Permission: {{ sharedState.savedData.requires_permission }} </li>
-      <li>Patents: {{ sharedState.savedData.patents }}</li>
-    </ul>
+    <div>
+      <div class="well">
+        Fair Use: <b>{{ onToYes(sharedState.savedData.additional_copyrights) }}</b>
+      </div>
+      <div class="well">
+        Additional Copyrights: <b>{{ onToYes(sharedState.savedData.requires_permissions) }}</b>
+      </div>
+      <div class="well">
+        Patents: <b>{{ onToYes(sharedState.savedData.patents) }}</b>
+      </div>
+    </div>
   </section>
 </template>
 
@@ -26,6 +32,16 @@ export default {
   data() {
     return {
       sharedState: formStore
+    }
+  },
+  methods: {
+    onToYes(string) {
+      if (string === 'on') {
+        return 'Yes'
+      }
+      if (string === 'off') {
+        return 'No'
+      }
     }
   }
 }


### PR DESCRIPTION
This changes the display of the copyright
questions so they are the same on the Keywords
and the Submit tab.

It also changes the display of "on" in the submit
tab to Yes and "off" to no.

Because of the way that form values are sent to the
InProgressEtd controller, there may need to be additional
processing to ensure we get the off state. Checkboxes in
an html form submit no value if they aren't checked so
we'll need to set them as off by default and change them
to on.

Fixes #1537, #1539