### PR TITLE
Part of story #1445 - allow student to replace their primary PDF.

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -1,0 +1,25 @@
+require File.join(Hyrax::Engine.root, 'app', 'controllers', 'hyrax', 'file_sets_controller.rb')
+
+module Hyrax
+  class FileSetsController < ApplicationController
+    # Override this method from Hyrax, so that we can
+    # return a JSON response (instead of redirect) if
+    # the user is deleting the FileSet by using the
+    # 'Remove' button on the form for editing the ETD.
+    def destroy
+      parent = curation_concern.parent
+      actor.destroy
+
+      respond_to do |format|
+        format.html do
+          redirect_to [main_app, parent], notice: 'The file has been deleted.'
+        end
+
+        # TODO: If 'actor.destroy' is false, return an error message.
+        format.json do
+          render json: { status: '200' }
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/FileDelete.js
+++ b/app/javascript/FileDelete.js
@@ -9,6 +9,7 @@ export default class FileDelete {
     var xhr = new XMLHttpRequest()
     xhr.open('DELETE', this.deleteUrl, true)
     xhr.setRequestHeader('X-CSRF-Token', this.token)
+    xhr.setRequestHeader('Accept', 'application/json')
     xhr.send(null)
     const filteredFiles = this.formStore.files.filter(
       file => file[0].deleteUrl !== this.deleteUrl

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -176,7 +176,6 @@ export default {
         formData: this.getFormData()
       })
       fileUploader.uploadFile()
-      // 999
       formStore.setValid('My Files', false)
     },
     onSupplementalFileChange(e) {

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -121,8 +121,23 @@ class InProgressEtd < ApplicationRecord
     end
     new_data['committee_chair_attributes'] = chairs unless chairs.blank?
 
+    primary_file = file_for_refresh(etd.primary_file_fs.first)
+    new_data['files'] = primary_file unless primary_file.blank?
+
     self.data = new_data.to_json
     save!
+  end
+
+  # Information about the file that the JavaScript needs for display and to render the 'Remove' button.
+  def file_for_refresh(file_set)
+    return if file_set.blank?
+    {
+      'id' => file_set.id,
+      'name' => file_set.label,
+      'size' => file_set.file_size.first,
+      'deleteUrl' => Rails.application.class.routes.url_helpers.hyrax_file_set_path(file_set),
+      'deleteType' => 'DELETE'
+    }.to_json
   end
 
   # All the fields that this model needs to know,


### PR DESCRIPTION
This code handles the case where the student has already submitted an
ETD, and they use the 'Remove' button to delete their primary PDF file.

I added code to the refresh_from_etd method to include the data that the
JavaScript needs to display the PDF file on the form along with the
'Remove' button to delete that file.

Note that since the student has already submitted their ETD, an 'Etd'
record with attached 'FileSet' record(s) has already been created, so
when the student hits the 'Remove' button, the delete action will go to
the FileSetsController instead of the UploadsController (which is where
it would go if the FileSet(s) hadn't been created yet).