### PR TITLE
Fix for Safari 11 file upload

### DIFF
--- a/app/javascript/FileUploader.js
+++ b/app/javascript/FileUploader.js
@@ -1,3 +1,4 @@
+import { isSafari11 } from './lib/isSafari11'
 export default class FileUploader {
   constructor (options) {
     this.formStore = options.formStore
@@ -7,6 +8,9 @@ export default class FileUploader {
   }
 
   uploadFile () {
+    if (isSafari11()) {
+      this.formData.delete('supplemental_files[]')
+    }
     var files = this.event.target.files || this.event.dataTransfer.files
     if (!files.length) return
     var xhr = new XMLHttpRequest()

--- a/app/javascript/SupplementalFileUploader.js
+++ b/app/javascript/SupplementalFileUploader.js
@@ -1,6 +1,10 @@
 import FileUploader from './FileUploader'
+import { isSafari11 } from './lib/isSafari11'
 export default class SupplementalFileUploader extends FileUploader {
   uploadFile () {
+    if (isSafari11()) {
+      this.formData.delete('primary_files[]')
+    }
     var files = this.event.target.files || this.event.dataTransfer.files
     if (!files.length) return
     var xhr = new XMLHttpRequest()

--- a/app/javascript/lib/isSafari11.js
+++ b/app/javascript/lib/isSafari11.js
@@ -1,0 +1,3 @@
+export function isSafari11 () {
+  return navigator.userAgent.indexOf('Safari') > 0 && navigator.userAgent.indexOf('Version/11') > 0
+}


### PR DESCRIPTION
This fixes an issue effecting Safari 11. There is
a bug in Safari 11 that stops POST requests that
have an empty file in the form.

https://bugs.webkit.org/show_bug.cgi?id=184490

This checks if you are using Safari 11 and deletes the
form data that would be empty when you are uploading
a file.

Fixes #1513