### PR TITLE
Persist copyright questions

### DIFF
--- a/app/javascript/CopyrightQuestions.vue
+++ b/app/javascript/CopyrightQuestions.vue
@@ -5,11 +5,18 @@
         <div class="well" v-for="question in sharedState.copyrightQuestions" v-bind:key="question.name">
             <label :for="question.name">{{ question.label }}</label>
             <p>{{ question.text }}</p>
-           <div class="form-inline">
-            <label>Yes <input :id="question.name" class="checkbox copyright-checkbox" :name="question.name" type="checkbox" v-model="question.choice"
-            true-value="yes" false-value="no">
-            </label>
-            </div>
+            <select v-if="question.name == 'etd[additional_copyrights]'" @change="sharedState.setCopyrights()" class="form-control" v-model="copyrights" :id="question.name" :name="question.name">
+                <option value="0">No, my thesis or dissertation does not contain copyrighted material.</option>
+                <option value="1">Yes, my thesis or dissertation contains copyrighted material.</option>
+            </select>
+            <select v-if="question.name == 'etd[requires_permissions]'" @change="sharedState.setPermissions()" class="form-control" v-model="permissions" :id="question.name" :name="question.name">
+                <option value="0">No, my thesis or dissertation does not require additional permissions.</option>
+                <option value="1">Yes, my thesis or dissertation requires additional permissions.</option>
+            </select>
+            <select v-if="question.name == 'etd[patents]'" class="form-control" @change="sharedState.setPatents()" v-model="patents" :id="question.name" :name="question.name">
+                <option value="0">No, my thesis or disseration does not contain patentable material.</option>
+                <option value="1">Yes, my thesis or disseration contains patentable material.</option>
+            </select>
         </div>
       </div>
     </section>
@@ -22,6 +29,9 @@ import { formStore } from './formStore'
 export default {
  data() {
      return {
+         permissions: formStore.getPermissions() || formStore.savedData.requires_permissions || '0',
+         copyrights: formStore.getCopyrights() || formStore.savedData.additional_copyrights || '0',
+         patents: formStore.getPatents() ||formStore.savedData.patents || '0',
          sharedState: formStore
      }
  }
@@ -31,13 +41,5 @@ export default {
 <style scoped>
 .copyright-checkbox {
     margin-left: 1em;
-}
-
-input[type=checkbox]
-{
-  -ms-transform: scale(2); 
-  -moz-transform: scale(2);
-  -webkit-transform: scale(2);
-  -o-transform: scale(2);
 }
 </style>

--- a/app/javascript/components/submit/Keywords.vue
+++ b/app/javascript/components/submit/Keywords.vue
@@ -10,17 +10,32 @@
       <div> {{ keyword }} </div>
     </div>
    <h5>Copyright Questions</h5>
-    <div>
-      <div class="well">
-        Fair Use: <b>{{ onToYes(sharedState.savedData.additional_copyrights) }}</b>
-      </div>
-      <div class="well">
-        Additional Copyrights: <b>{{ onToYes(sharedState.savedData.requires_permissions) }}</b>
-      </div>
-      <div class="well">
-        Patents: <b>{{ onToYes(sharedState.savedData.patents) }}</b>
-      </div>
-    </div>
+    <ul>
+      <li><b>Additional copyrights:</b> 
+        <p v-if="sharedState.savedData.additional_copyrights">
+          Yes, my thesis or dissertation contains copyrighted material.
+        </p>
+        <p v-if="!sharedState.savedData.additional_copyrights">
+          No, my thesis or dissertation does not contain copyrighted material.
+        </p>
+      </li>
+      <li><b>Requires Permission:</b>
+        <p v-if="sharedState.savedData.requires_permissions">
+         Yes, my thesis or dissertation requires additional permissions.
+        </p>
+        <p v-if="!sharedState.savedData.requires_permissions">
+          No, my thesis or dissertation does not require additional permissions.
+        </p>
+      </li>
+      <li><b>Patents:</b> 
+        <p v-if="sharedState.savedData.patents">
+          Yes, my thesis or disseration contains patentable material.
+        </p>
+        <p v-if="!sharedState.savedData.patents">
+          No, my thesis or disseration does not contain patentable material.
+        </p>    
+      </li>
+    </ul>
   </section>
 </template>
 

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -157,6 +157,9 @@ export var formStore = {
       return `/in_progress_etds/${this.ipeId}`
     }
   },
+  copyrights: 0,
+  permissions: 0,
+  patents: 0,
   copyrightQuestions: copyrightQuestions,
   committeeChairs: new ChairList(),
   committeeMembers: new MemberList(),
@@ -416,8 +419,24 @@ export var formStore = {
     if (this.supplementalFiles === undefined || this.supplementalFiles.length === 0) return
     return JSON.stringify(this.supplementalFiles)
   },
-
-
+  setCopyrights () {
+    this.copyrights = Number(!this.copyrights)
+  },
+  setPermissions () {
+    this.permissions = Number(!this.permissions)
+  },
+  setPatents () {
+    this.patents = Number(!this.patents)
+  },
+  getCopyrights () {
+    return `${this.copyrights}`
+  },
+  getPermissions () {
+    return `${this.permissions}`
+  },
+  getPatents () {
+    return `${this.patents}`
+  },
   getGraduationDate () {
     return this.savedData['graduation_date']
   },


### PR DESCRIPTION
This changes the copyright questions
to select boxes, which detail what that
choice means. That change is for #1556. They are select boxes (that
default to no) because we need
to submit the form as form data
and checkboxes are problematic
in that case:

https://api.rubyonrails.org/v5.1.6/classes/ActionView/Helpers/FormHelper.html#method-i-check_box

This commit also address the data
not being persisted on the server by
returning the values that laevigata
expects for each of the options.

Closes #1556
Closes #1557