### PR TITLE
Don't allow changes to school after selected

### DIFF
--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
     <label for="school">School</label>
-    <select id="school" class="form-control" v-model="selected" aria-required="true" v-on:change="clearDepartmentAndSubfields(), sharedState.setValid('About Me', false, ['My Program', 'Embargo'])">
+    <select v-if="!this.sharedState.getSavedOrSelectedSchool()" id="school" class="form-control" v-model="selected" aria-required="true" v-on:change="clearDepartmentAndSubfields(), sharedState.setValid('About Me', false, ['My Program', 'Embargo'])">
       <option v-for="school in this.sharedState.schools.options" v-bind:value="school.value" v-bind:key='school.value' :selected='school.selected' :disabled='school.disabled'>
         {{ school.text }}
       </option>
     </select>
+    <div v-if="this.sharedState.getSavedOrSelectedSchool()">
+      <b>{{ this.sharedState.getSchoolText(this.sharedState.getSavedOrSelectedSchool()) }}</b>
+    </div>
   </div>
 </template>
 
 <script>
-import Vue from "vue"
-import axios from "axios"
-import VueAxios from "vue-axios"
-import App from "./App"
+import _ from 'lodash'
 import { formStore } from './formStore'
 
 export default {

--- a/app/javascript/test/School.spec.js
+++ b/app/javascript/test/School.spec.js
@@ -2,18 +2,30 @@
 /* global it */
 /* global expect */
 /* global jest */
-import { shallowMount } from '@vue/test-utils'
-import Language from 'School'
+import { mount } from '@vue/test-utils'
+import School from 'School'
 import axios from 'axios'
+import { formStore } from 'formStore'
+
 jest.mock('axios')
 
 describe('School.vue', () => {
   const resp = {data: [{'id': 'Candler School of Theology'}]}
   axios.get.mockResolvedValue(resp)
 
-  it('has the correct html', () => {
-    const wrapper = shallowMount(Language, {
+  it('is a a select box before saving', () => {
+    const wrapper = mount(School, {
     })
+    wrapper.vm.$data.sharedState.schools.options = [{"text":"Select a School","value":"","disabled":"disabled","selected":"selected"},{"text":"Candler School of Theology","value":"candler"},{"text":"Emory College","value":"emory"},{"text":"Laney Graduate School","value":"laney"},{"text":"Rollins School of Public Health","value":"rollins"}]
     expect(wrapper.html()).toContain(`<div><label for="school">School</label> <select id="school" aria-required="true" class="form-control"><option disabled="disabled" value="">`)
+  })
+
+  it('is non-editable text after saving', () => {
+    formStore.savedData.school = 'candler'
+
+    const wrapper = mount(School, {
+    })
+    wrapper.vm.$data.sharedState.schools.options = [{"text":"Select a School","value":"","disabled":"disabled","selected":"selected"},{"text":"Candler School of Theology","value":"candler"},{"text":"Emory College","value":"emory"},{"text":"Laney Graduate School","value":"laney"},{"text":"Rollins School of Public Health","value":"rollins"}]
+    expect(wrapper.html()).toContain(`<div><label for=\"school\">School</label> <!----> <div><b>Candler School of Theology</b></div></div>`)
   })
 })


### PR DESCRIPTION
This commit changes the select
dropdown for school so that a user
can't change it after they have
initially selected it.

Connected to #1562