### PR TITLE
Ensure that type is displayed

### DIFF
--- a/app/javascript/components/submit/MyFiles.vue
+++ b/app/javascript/components/submit/MyFiles.vue
@@ -38,7 +38,7 @@
           <td>{{ supplementalFile.filename }}</td>
           <td>{{ supplementalFile.title }}</td>
           <td>{{ supplementalFile.description }}</td>
-          <td>{{ supplementalFile.type }}</td>
+          <td>{{ supplementalFile.file_type }}</td>
         </tr>
       </tbody>
     </table>

--- a/app/javascript/test/components/submit/MyFiles.spec.js
+++ b/app/javascript/test/components/submit/MyFiles.spec.js
@@ -1,15 +1,26 @@
 /* global describe */
 /* global it */
 /* global expect */
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import MyFiles from '../../../components/submit/MyFiles'
 import { formStore } from '../../../formStore'
 
-formStore.savedData.files = '{"id":85,"name":"c4611_sample_explain.pdf","size":88226,"deleteUrl":"/uploads/85?locale=en","deleteType":"DELETE"}'
+formStore.savedData.supplemental_file_metadata = {"0":{"filename":"File Name","title":"Title","description":"Description","file_type":"Text"}}
+formStore.savedData['files'] = '{"id":104,"name":"2016FEB10.pdf","size":1944456,"deleteUrl":"/uploads/104?locale=en","deleteType":"DELETE"}'
 describe('MyFiles.vue', () => {
   it('has the correct label', () => {
     const wrapper = shallowMount(MyFiles, {
     })
     expect(wrapper.html()).toContain('My Files')
+  })
+
+  it('displays the correct metadata', () => {
+    const wrapper = mount(MyFiles, {
+    })
+
+    expect(wrapper.html()).toContain('File Name')
+    expect(wrapper.html()).toContain('Title')
+    expect(wrapper.html()).toContain('Description')
+    expect(wrapper.html()).toContain('Text')
   })
 })


### PR DESCRIPTION
This changes the type display to use
the correct accessor. To display
the type you need to access `file_type` not `type`.

This adds a spec to check that the
correct values are displayed.

Connected to #1539