### PR TITLE
Only display embargoed Etds when indexing embargoes

### DIFF
--- a/app/search_builders/etd_embargo_search_builder.rb
+++ b/app/search_builders/etd_embargo_search_builder.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
+##
+# A custom search builder limiting Embargo search to embargoes on `Etd` objects.
+#
+# @see Blacklight::SearchBuilder
 class EtdEmbargoSearchBuilder < Hyrax::EmbargoSearchBuilder
   self.default_processor_chain =
-    [:with_pagination, :with_sorting, :only_active_embargoes,
-     :only_etd_embargoes]
+    [:with_pagination, :with_sorting, :only_etd_embargoes]
 
   def only_etd_embargoes(params)
-    params[:fq] += ' has_model_ssim:Etd'
+    params[:fq] = '+embargo_release_date_dtsi:* +has_model_ssim:Etd'
   end
 end

--- a/app/services/etd_embargo_service.rb
+++ b/app/services/etd_embargo_service.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 class EtdEmbargoService < Hyrax::EmbargoService
   class << self
-      def assets_under_embargo
-        presenters(EtdEmbargoSearchBuilder.new(self))
-      end
+    def assets_under_embargo
+      presenters(EtdEmbargoSearchBuilder.new(self))
+    end
   end
 end

--- a/spec/services/etd_embargo_service_spec.rb
+++ b/spec/services/etd_embargo_service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe EtdEmbargoService do
+  describe '.assets_under_embargo' do
+    before { FactoryBot.create(:etd) }
+
+    context 'when no works are under embargo' do
+      it 'is empty' do
+        expect(described_class.assets_under_embargo).to be_empty
+      end
+    end
+
+    context 'when there are embargoed etds', :clean do
+      let(:embargoed_etd) do
+        FactoryBot.create(:sample_data_with_everything_embargoed)
+      end
+
+      before { embargoed_etd } # create the etd with embargo
+
+      it 'has only the emborgoed etds' do
+        expect(described_class.assets_under_embargo.map(&:id))
+          .to contain_exactly embargoed_etd.id
+      end
+
+      context 'and embargoed FileSets' do
+        before do
+          primary_pdf_file = "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"
+          etd_factory      = EtdFactory.new
+          etd_factory.etd  = embargoed_etd
+
+          etd_factory.primary_pdf_file = primary_pdf_file
+          etd_factory.attach_primary_pdf_file
+
+          embargoed_etd.save
+
+          # fail in setup if the embargo didn't apply; if there's no FileSet
+          # embargo, the tests in this context are not useful.
+          expect(embargoed_etd.representative.embargo).to be_present
+        end
+
+        it 'has only the emborgoed etds (not the FileSets)' do
+          expect(described_class.assets_under_embargo.map(&:id))
+            .to contain_exactly embargoed_etd.id
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The embargo filter in #1478 failed to correctly specify an `fq=` for Solr. We
fix this in an updated `EtdEmbargoSearchBuilder`, and add unit tests at the
`EtdEmbargoService` level to ensure that the filter is working correctly.

Fixes #1548.