### PR TITLE
Load committee info from savedData

### DIFF
--- a/app/javascript/CommitteeMember.vue
+++ b/app/javascript/CommitteeMember.vue
@@ -75,11 +75,13 @@ export default {
     };
   },
   mounted() {
-    this.$nextTick(() => {
+      this.sharedState.committeeChairs.load(
+        this.sharedState.savedData["committee_chair_attributes"]
+      )
+
       this.sharedState.committeeMembers.load(
         this.sharedState.savedData["committee_members_attributes"]
-      );
-    });
+      )
   },
   methods: {
     chairNameAttr(chair) {

--- a/app/javascript/test/CommitteeMember.spec.js
+++ b/app/javascript/test/CommitteeMember.spec.js
@@ -2,13 +2,26 @@
 /* global it */
 /* global expect */
 
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import CommitteeMember from 'CommitteeMember'
+import { formStore } from 'formStore'
+
+formStore.savedData['committee_chair_attributes'] = {"0":{"affiliation_type":"Emory University","name":["Person"]},"1":{"affiliation_type":"Emory University","name":["Someone"]}}
+formStore.savedData['committee_member_attributes'] = {"0":{"affiliation_type":"Non-Emory University","name":["Member"]},"1":{"affiliation_type":"Emory University","name":["Someone"]}}
 
 describe('CommitteeMember.vue', () => {
   it('renders two links to start with', () => {
     const wrapper = shallowMount(CommitteeMember, {
     })
     expect(wrapper.findAll('button')).toHaveLength(2)
+  })
+
+  it('loads the data from savedData on mount', () => {
+    const wrapper = mount(CommitteeMember, {
+    })
+    expect(wrapper.html()).toContain('Person')
+    expect(wrapper.html()).toContain('Someone')
+    expect(wrapper.html()).toContain('Member')
+    expect(wrapper.html()).toContain('Non-Emory')
   })
 })


### PR DESCRIPTION
This loads the stored commitee
data, so that when you save
and come back it's still present
in the form.

For #1568