### PR TITLE
Make "hidden" Etds have "private" visibility

### DIFF
--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -16,7 +16,7 @@ class EtdIndexer < Hyrax::WorkIndexer
 
   class IndexingService < Hyrax::BasicMetadataIndexer
     self.stored_fields +=
-      [:abstract, :email, :post_graduation_email]
+      [:abstract, :email, :post_graduation_email, :hidden?]
 
     self.stored_and_facetable_fields +=
       [:creator, :graduation_year, :table_of_contents, :files_embargoed,

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -24,6 +24,13 @@ class FileSet < ActiveFedora::Base
     parent&.admin_set
   end
 
+  ##
+  # @return [Boolean]
+  def hidden?
+    # rubocop:disable Style/DoubleNegation
+    !!parent&.hidden?
+  end
+
   def original?
     pcdm_use == ORIGINAL
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -92,6 +92,10 @@ class SolrDocument
     self[Solrizer.solr_name('graduation_year')]
   end
 
+  def hidden?
+    self[Solrizer.solr_name('hidden?', type: :boolean)]
+  end
+
   def school
     self[Solrizer.solr_name('school')]
   end

--- a/app/services/visibility_translator.rb
+++ b/app/services/visibility_translator.rb
@@ -33,9 +33,9 @@ class VisibilityTranslator
   end
 
   def visibility
-    return proxy.visibility unless obj.under_embargo?
-    return ALL_EMBARGOED    if     obj.abstract_embargoed
-    return TOC_EMBARGOED    if     obj.toc_embargoed
+    return proxy.visibility if obj.hidden? || !obj.under_embargo?
+    return ALL_EMBARGOED    if obj.abstract_embargoed
+    return TOC_EMBARGOED    if obj.toc_embargoed
 
     FILES_EMBARGOED
   end

--- a/spec/indexers/etd_indexer_spec.rb
+++ b/spec/indexers/etd_indexer_spec.rb
@@ -21,4 +21,10 @@ RSpec.describe EtdIndexer do
     # Index both committee members and chairs for faceting
     expect(solr_doc['committee_names_sim']).to contain_exactly('Jackson, Henrietta', 'Matsumoto, Yukihiro', 'Yurchenko, Alice')
   end
+
+  it 'indexes hidden status' do
+    etd.hidden = true
+
+    expect(solr_doc['hidden?_bsi']).to be true
+  end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -495,6 +495,14 @@ RSpec.describe Etd do
         .to open
     end
 
+    it 'can be private when hidden' do
+      etd.visibility = restricted
+
+      expect { etd.hidden = true }
+        .not_to change { etd.visibility }
+        .from restricted
+    end
+
     context 'with no embargo set' do
       it 'cannot set to file restricted access' do
         expect { etd.visibility = files }.to raise_error ArgumentError
@@ -534,6 +542,13 @@ RSpec.describe Etd do
         expect { etd.visibility = all }
           .to change { etd.visibility }
           .to all
+      end
+
+      it 'uses original implemenation when hidden' do
+        expect { etd.hidden = true }
+          .to change { etd.visibility }
+          .from(all)
+          .to open
       end
     end
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe FileSet do
     end
   end
 
+  describe '#hidden' do
+    it 'is false without a parent' do
+      expect(file_set).not_to be_hidden
+    end
+
+    context 'when it belongs to a work' do
+      let(:etd) { FactoryBot.build(:etd, hidden: true) }
+
+      before do
+        etd.ordered_members << file_set
+        etd.save
+      end
+
+      it 'gives the hidden status for the parent work' do
+        expect(file_set).to be_hidden
+      end
+    end
+  end
+
   context 'with a new FileSet' do
     its(:pcdm_use) { is_expected.to be_nil }
     its(:embargo_length) { is_expected.to be_nil }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe ::SolrDocument, type: :model do
     end
   end
 
+  describe '#hidden?' do
+    subject(:solr_doc) { described_class.new(etd.to_solr) }
+    let(:etd)          { FactoryBot.build(:etd, hidden: true) }
+
+    it 'is hidden' do
+      expect(solr_doc).to be_hidden
+    end
+  end
+
   describe '#visibility' do
     subject(:solr_doc) { described_class.new(etd.to_solr) }
     let(:etd)          { FactoryBot.build(:etd) }

--- a/spec/services/visibility_translator_spec.rb
+++ b/spec/services/visibility_translator_spec.rb
@@ -21,6 +21,14 @@ describe VisibilityTranslator do
       expect(translator.visibility).to eq open
     end
 
+    context 'when the etd is hidden' do
+      before { obj.hidden = true }
+
+      it 'gives the original implementation' do
+        expect(translator.visibility).to eq open
+      end
+    end
+
     context 'when under full embargo' do
       let(:obj) { FactoryBot.create(:sample_data_with_everything_embargoed) }
 
@@ -52,6 +60,14 @@ describe VisibilityTranslator do
 
       it 'is restricted' do
         expect(translator.visibility).to eq restricted
+      end
+    end
+
+    context 'when the etd is hidden' do
+      before { obj.hidden = true }
+
+      it 'gives the original implementation' do
+        expect(translator.visibility).to eq open
       end
     end
   end


### PR DESCRIPTION
When an Etd is marked "hidden", we want its visibility to reflect the original implementation throughout the application. This ensures "private" status is represented even when the object is under embargo.

Fixes #1561.