### PR TITLE
 Display current visibility first in embargo edit

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -11,7 +11,7 @@ module HyraxHelper
 
   ##
   # override behavior from `Hyrax::AbilityHelper`
-  def visibility_options(variant)
+  def visibility_options(variant, opts = {})
     options = [
       Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
       VisibilityTranslator::FILES_EMBARGOED,
@@ -22,8 +22,16 @@ module HyraxHelper
 
     case variant
     when :restrict
-      options.delete_at(0)
+      options.delete_at(4) # Private is not a valid embargo option
+      options.delete_at(0) # Public is not a valid embargo option
+      # If there is a current_visibility passed, ensure it is
+      # the first option in the list
+      if opts[:current_visibility]
+        options.delete(opts[:current_visibility])
+        options << opts[:current_visibility]
+      end
       options.reverse!
+
     when :loosen
       options = [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC]
     end

--- a/app/views/hyrax/base/_form_permission_embargo.html.erb
+++ b/app/views/hyrax/base/_form_permission_embargo.html.erb
@@ -1,0 +1,6 @@
+<div class="form-inline">
+  <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+  <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict, current_visibility: @curation_concern.visibility), include_blank: false %>
+  <%= f.input :embargo_release_date, wrapper: :inline, input_html: { value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker' } %>
+  <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+</div>


### PR DESCRIPTION
When editing an embargo, I want to see the work's
current visibility setting first in the drop down menu.

Fixes #1552 