### PR TITLE
Don't return prematurely in `after_update_response` hook

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -42,7 +42,7 @@ module Hyrax
     # Overriding this method avoids redirects to confirmation pages when
     # updating the visibility and permissions of a work.
     def after_update_response
-      return enforce_file_visibility(curation_concern) if
+      enforce_file_visibility(curation_concern) if
         curation_concern.file_sets.present? &&
         (permissions_changed? || curation_concern.visibility_changed?)
 


### PR DESCRIPTION
The errant `return` forced an undesired JSON redirect response.

Fixes #1489.