### PR TITLE
Part of story #1445 - allow student to replace primary file

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -54,7 +54,7 @@
       <button type="button" class="btn btn-primary" @click="boxOAuth('primary')"><span class="glyphicon glyphicon-plus"></span> Add your thesis or dissertation file from Box</button>
     </div>
 
-    <div v-if="sharedState.files[0]">
+    <div v-if="isUploadedFile(getPrimaryFile())">
       <input type="hidden" name="uploaded_files[]" :value="sharedState.files[0][0].id" />
     </div>
     <!-- TODO: the final param to hyrax needs to be uploaded_files but this name should probly be supp_files-->
@@ -130,6 +130,7 @@ import SupplementalFileDelete from './SupplementalFileDelete'
 import SupplementalFileUploader from './SupplementalFileUploader'
 import axios from 'axios'
 import BoxFileUploader from './lib/BoxFileUploader'
+import _ from 'lodash'
 
 export default {
   data() {
@@ -170,6 +171,21 @@ export default {
     }
   },
   methods: {
+    // Determine if the file is a Hyrax::UploadedFile
+    // or a ::FileSet that has already been saved.
+    // They will have different paths in the deleteURL
+    isUploadedFile(file) {
+      if (file) {
+        return _.includes(file.deleteUrl, 'uploads')
+      } else {
+        return false
+      }
+    },
+    getPrimaryFile() {
+      if (this.sharedState.files[0] && this.sharedState.files[0][0]) {
+        return this.sharedState.files[0][0]
+      }
+    },
     onFileChange(e) {
       var fileUploader = new FileUploader({
         formStore: this.sharedState,

--- a/app/javascript/test/Files.spec.js
+++ b/app/javascript/test/Files.spec.js
@@ -2,7 +2,9 @@
 /* global it */
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import Files from 'Files'
+import { formStore } from 'formStore'
 
 describe('Files.vue', () => {
   global.Box = { FilePicker: function() {}}
@@ -19,4 +21,56 @@ describe('Files.vue', () => {
     
     expect(wrapper.findAll('label')).toHaveLength(2)
   })
+
+  it('when primary file is present, it returns primary file', () => {
+    const wrapper = shallowMount(Files, { })
+    const fakeFileData = { id: 'fake file object' }
+    formStore.files = [[fakeFileData]]
+
+    expect(wrapper.vm.getPrimaryFile()).toEqual(fakeFileData)
+  })
+
+  it('when no primary file exists, it returns undefined', () => {
+    const wrapper = shallowMount(Files, { })
+    formStore.files = []
+
+    expect(wrapper.vm.getPrimaryFile()).toEqual(undefined)
+  })
+
+  it('when the file is a Hyrax::UploadedFile, isUploadedFile() returns true', () => {
+    const wrapper = shallowMount(Files, { })
+    const fakeFileData = { deleteUrl: '/uploads/123' }
+
+    expect(wrapper.vm.isUploadedFile(fakeFileData)).toEqual(true)
+  })
+
+  it('when the file is a ::FileSet, isUploadedFile() returns false', () => {
+    const wrapper = shallowMount(Files, { })
+    const fakeFileData = { deleteUrl: '/concern/file_sets/456' }
+
+    expect(wrapper.vm.isUploadedFile(fakeFileData)).toEqual(false)
+  })
+
+  it('when the file is undefined, isUploadedFile() returns false', () => {
+    const wrapper = shallowMount(Files, { })
+
+    expect(wrapper.vm.isUploadedFile(undefined)).toEqual(false)
+  })
+
+  it('when the file is a Hyrax::UploadedFile, the uploaded_files input contains the record ID', () => {
+    const wrapper = mount(Files, { })
+    const fakeFileData = { deleteUrl: '/uploads/123', id: '123_my_super_unique_id' }
+    formStore.files = [[fakeFileData]]
+
+    expect(wrapper.html()).toContain('123_my_super_unique_id')
+  })
+
+  it('when the file is a ::FileSet, the uploaded_files doesn\'t contain the record ID', () => {
+    const wrapper = mount(Files, { })
+    const fakeFileData = { deleteUrl: '/concern/file_sets/123', id: '123_my_super_unique_id' }
+    formStore.files = [[fakeFileData]]
+
+    expect(wrapper.html()).not.toContain('123_my_super_unique_id')
+  })
 })
+


### PR DESCRIPTION
This code fixes a problem when the student had an existing primary PDF
file, and then tried to add a supplemental file, there would be a 404
error.

The problem was caused by the fact that the 'uploaded_files' input on
the form contained not just the newly-uploaded file record IDs, but also
the ID of the previously saved primary PDF.  So when the controller
received that extra ID, it would look for the corresponding
Hyrax::UploadedFiles record (which doesn't exist).

I added a conditional to the hidden 'uploaded_files' input that prevents
previously-saved files from being added to the array.  Previously-saved
files can be differentiated from newly-uploaded files by the deleteUrl,
which contains the model name.

Connected to #1445 