### PR TITLE
Fix for copyright questions

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -206,6 +206,9 @@ export default {
     // this executes only the first time the page is loaded (before adding it to the dom), so we need the freshest saved data we have, and we use it to set the state of the tabs.
     this.sharedState.loadSavedData()
     this.sharedState.loadTabs()
+    this.sharedState.copyrights = Number(this.sharedState.savedData.additional_copyrights) || this.sharedState.copyrights
+    this.sharedState.permissions = Number(this.sharedState.savedData.requires_permissions) || this.sharedState.permissions
+    this.sharedState.patents = Number(this.sharedState.savedData.patents) || this.sharedState.patents
   },
   beforeMount () {
     // this is loaded every time the form changes (whenever the component changes and before the native DOM is updated)

--- a/app/javascript/CopyrightQuestions.vue
+++ b/app/javascript/CopyrightQuestions.vue
@@ -5,15 +5,15 @@
         <div class="well" v-for="question in sharedState.copyrightQuestions" v-bind:key="question.name">
             <label :for="question.name">{{ question.label }}</label>
             <p>{{ question.text }}</p>
-            <select v-if="question.name == 'etd[additional_copyrights]'" @change="sharedState.setCopyrights()" class="form-control" v-model="copyrights" :id="question.name" :name="question.name">
+            <select v-if="question.name == 'etd[additional_copyrights]'" class="form-control" v-model="sharedState.copyrights" :id="question.name" :name="question.name">
                 <option value="0">No, my thesis or dissertation does not contain copyrighted material.</option>
                 <option value="1">Yes, my thesis or dissertation contains copyrighted material.</option>
             </select>
-            <select v-if="question.name == 'etd[requires_permissions]'" @change="sharedState.setPermissions()" class="form-control" v-model="permissions" :id="question.name" :name="question.name">
+            <select v-if="question.name == 'etd[requires_permissions]'" class="form-control" v-model="sharedState.permissions" :id="question.name" :name="question.name">
                 <option value="0">No, my thesis or dissertation does not require additional permissions.</option>
                 <option value="1">Yes, my thesis or dissertation requires additional permissions.</option>
             </select>
-            <select v-if="question.name == 'etd[patents]'" class="form-control" @change="sharedState.setPatents()" v-model="patents" :id="question.name" :name="question.name">
+            <select v-if="question.name == 'etd[patents]'" class="form-control" v-model="sharedState.patents" :id="question.name" :name="question.name">
                 <option value="0">No, my thesis or dissertation does not contain patentable material.</option>
                 <option value="1">Yes, my thesis or dissertation contains patentable material.</option>
             </select>
@@ -27,11 +27,8 @@ import Vue from "vue"
 import App from "./App"
 import { formStore } from './formStore'
 export default {
- data() {
+ data () {
      return {
-         permissions: formStore.getPermissions() || formStore.savedData.requires_permissions,
-         copyrights: formStore.getCopyrights() || formStore.savedData.additional_copyrights,
-         patents: formStore.getPatents() ||formStore.savedData.patents,
          sharedState: formStore
      }
  }

--- a/app/javascript/config/copyrightQuestions.json
+++ b/app/javascript/config/copyrightQuestions.json
@@ -1,17 +1,20 @@
-[{
-  "label": "Fair Use",
-  "text": "Does your thesis or dissertation contain any third-party text, audiovisual content or other material which is beyond a fair use and would require permission?",
-  "choice": "no",
-  "name": "etd[requires_permissions]"
-}, {
-  "label": "Copyright",
-  "text": "Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have questions about your use of copyrighted material, contact the Scholarly Communications Office at scholcom@listserv.cc.emory.edu",
-  "choice": "no",
-  "name": "etd[additional_copyrights]"
-},
-{
-  "label": "Patents",
-  "text": "Does your thesis or dissertation disclose or described any inventions or discoveries that could potentially have commercial application and therefore may be patented? If so please contact the Office of Technology Transfer (OTT) at (404) 727-2211.",
-  "choice": "no",
-  "name": "etd[patents]"
-}]
+[
+  {
+    "label": "Copyright",
+    "text": "Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have questions about your use of copyrighted material, contact the Scholarly Communications Office at scholcom@listserv.cc.emory.edu",
+    "choice": 0,
+    "name": "etd[additional_copyrights]"
+  },
+  {
+    "label": "Fair Use",
+    "text": "Does your thesis or dissertation contain any third-party text, audiovisual content or other material which is beyond a fair use and would require permission?",
+    "choice": 0,
+    "name": "etd[requires_permissions]"
+  },
+  {
+    "label": "Patents",
+    "text": "Does your thesis or dissertation disclose or described any inventions or discoveries that could potentially have commercial application and therefore may be patented? If so please contact the Office of Technology Transfer (OTT) at (404) 727-2211.",
+    "choice": 0,
+    "name": "etd[patents]"
+  }
+]

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -419,24 +419,6 @@ export var formStore = {
     if (this.supplementalFiles === undefined || this.supplementalFiles.length === 0) return
     return JSON.stringify(this.supplementalFiles)
   },
-  setCopyrights () {
-    this.copyrights = Number(!this.copyrights)
-  },
-  setPermissions () {
-    this.permissions = Number(!this.permissions)
-  },
-  setPatents () {
-    this.patents = Number(!this.patents)
-  },
-  getCopyrights () {
-    return `${this.copyrights}`
-  },
-  getPermissions () {
-    return `${this.permissions}`
-  },
-  getPatents () {
-    return `${this.patents}`
-  },
   getGraduationDate () {
     return this.savedData['graduation_date']
   },

--- a/app/javascript/test/CopyrightQuestions.spec.js
+++ b/app/javascript/test/CopyrightQuestions.spec.js
@@ -5,16 +5,17 @@ import { shallowMount } from '@vue/test-utils'
 import CopyrightQuestions from 'CopyrightQuestions'
 import { formStore } from '../formStore'
 
-formStore.savedData.additional_copyrights = '1'
-formStore.savedData.getPermissions = jest.fn(() => { return 0 })
-formStore.savedData.patents = '1'
+formStore.savedData.additional_copyrights = 1
+formStore.savedData.requires_permissions = 0
+formStore.savedData.patents = 1
 
 describe('CopyrightQuestions.vue', () => {
   it('has the correct html', () => {
     const wrapper = shallowMount(CopyrightQuestions, {
     })
-    expect(wrapper.html()).toContain(`etd[requires_permissions]`)
+
     expect(wrapper.html()).toContain(`etd[additional_copyrights]`)
+    expect(wrapper.html()).toContain(`etd[requires_permissions]`)
     expect(wrapper.html()).toContain(`etd[patents]`)
   })
 


### PR DESCRIPTION
These will now reload properly
when you refresh the page (based on the savedData) and when you click around the tabs
(based on the values in the formStore).

The questions are displayed
in the order on the Keyword and submission tabs.

For #1583, #1569