### PR TITLE
Don't allow primary files from Box

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -51,7 +51,7 @@
       <label class="btn btn-primary" for="add-file"><span class='glyphicon glyphicon-plus'></span>
       Add your thesis or dissertation file from your computer
       </label>
-      <button type="button" class="btn btn-primary" @click="boxOAuth('primary')"><span class="glyphicon glyphicon-plus"></span> Add your thesis or dissertation file from Box</button>
+      <button v-if="sharedState.allowPrimaryBoxUpload" type="button" class="btn btn-primary" @click="boxOAuth('primary')"><span class="glyphicon glyphicon-plus"></span> Add your thesis or dissertation file from Box</button>
     </div>
 
     <div v-if="isUploadedFile(getPrimaryFile())">

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -157,7 +157,7 @@ export var formStore = {
       return `/in_progress_etds/${this.ipeId}`
     }
   },
-  copyrights: 0,
+  allowPrimaryBoxUpload: false,
   permissions: 0,
   patents: 0,
   copyrightQuestions: copyrightQuestions,

--- a/app/javascript/test/Files.spec.js
+++ b/app/javascript/test/Files.spec.js
@@ -12,7 +12,7 @@ describe('Files.vue', () => {
   it('has 2 buttons when rendered', () => {
     const wrapper = shallowMount(Files, {
     })
-    expect(wrapper.findAll('button')).toHaveLength(2)
+    expect(wrapper.findAll('button')).toHaveLength(1)
   })
 
   it('has two labels ', () => {


### PR DESCRIPTION
This disables primary file uploads
from Box. If needed in the future
it can be re-enabled.

Connected to #1572