### PR TITLE
Fix supplemental file metadata when uploading from Box

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -2,7 +2,6 @@
   <div>
     <section class="thesis-file">
     <h2>Add Your Thesis or Dissertation File</h2>
-    <div id="box-picker"></div>
     <div v-if="accessToken">
       <link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/elements/4.4.0/en-US/picker.css" />
     </div>
@@ -72,6 +71,7 @@
       You may upload as many supplemental files as you like. No single file should exceed 2.5 GB.
       If you have a file larger than 2.5 GB, contact the ETD team at <a href="mailto:etd-help@LISTSERV.CC.EMORY.EDU">etd-help@LISTSERV.CC.EMORY.EDU</a> for help.
     </div>
+    <div id="box-picker"></div>
     <div v-if="sharedState.supplementalFiles.length > 0" class="file-row form-inline">
       <table class="table table-striped metadata">
         <thead>
@@ -85,8 +85,7 @@
         </thead>
         <tbody>
           <tr v-for="(files, key) in sharedState.supplementalFiles" v-bind:key="key">
-
-            <td><input type="text" :value="getSavedFileName(key)" class="form-control" disabled />
+            <td><input type="text" :value="files.name" class="form-control" disabled />
             <input type='hidden' :value="files.name" :name="supplementalFileName(key)"></td>
             <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)" v-on:change="sharedState.setValid('My Files', false)"/></td>
             <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" v-on:change="sharedState.setValid('My Files', false)"/></td>
@@ -103,8 +102,7 @@
               </select>
             </td>
             <td>
-              {{ files.deleteUrl }}
-              <button type="button" class="btn btn-danger remove-btn" @click="deleteSupplementalFile(files.deleteUrl)">
+              <button type="button" class="btn btn-danger remove-btn" @click="deleteSupplementalFile(files.deleteUrl, key)">
               <span class="glyphicon glyphicon-trash"></span> Remove this file</button>
             </td>
           </tr>
@@ -220,13 +218,13 @@ export default {
       fileDelete.deleteFile()
       this.sharedState.setValid('My Files', false)
     },
-    deleteSupplementalFile(deleteUrl) {
+    deleteSupplementalFile(deleteUrl, key) {
      var supplementalFileDelete = new SupplementalFileDelete({
         deleteUrl: deleteUrl,
         token: this.sharedState.token,
         formStore: this.sharedState
       })
-      supplementalFileDelete.deleteFile()
+      supplementalFileDelete.deleteFile(key)
       this.sharedState.setValid('My Files', false)
   },
   boxOAuth(mode) {

--- a/app/javascript/SupplementalFileDelete.js
+++ b/app/javascript/SupplementalFileDelete.js
@@ -1,6 +1,6 @@
 import FileDelete from './FileDelete'
 export default class SupplementalFileDelete extends FileDelete {
-  deleteFile () {
+  deleteFile (key) {
     console.log(this.deleteUrl)
     var xhr = new XMLHttpRequest()
     xhr.open('DELETE', this.deleteUrl, true)
@@ -17,6 +17,6 @@ export default class SupplementalFileDelete extends FileDelete {
     this.formStore.supplementalFiles = filteredFiles
     this.formStore.supplementalFilesMetadata = filteredMetadata
     this.formStore.removeSavedSupplementalFile(this.deleteUrl)
-    this.formStore.removeSavedSupplementalFileMetadata(this.id)
+    this.formStore.removeSavedSupplementalFileMetadata(key)
   }
 }

--- a/app/javascript/components/submit/MyFiles.vue
+++ b/app/javascript/components/submit/MyFiles.vue
@@ -15,6 +15,7 @@
         </tr>
       </tbody>
     </table>
+  <div v-if="Object.keys(supplementalFiles).length > 0">
     <h5>Supplemental Files</h5>
     <table class="table table-striped metadata">
       <thead>
@@ -42,6 +43,7 @@
         </tr>
       </tbody>
     </table>
+  </div>
   </section>
 </template>
 

--- a/app/javascript/lib/BoxFileUploader.js
+++ b/app/javascript/lib/BoxFileUploader.js
@@ -22,9 +22,10 @@ export default class BoxFileUploader {
 
   postToUploads (boxResponse) {
     const formData = new FormData()
-    formData.set('primary_files', [this.event[0].name])
-    formData.set('filename', [this.event[0].name])
-    formData.set('remote_url', boxResponse.location)
+    formData.append('primary_files', [this.event[0].name])
+    formData.append('filename', [this.event[0].name])
+    formData.append('remote_url', boxResponse.location)
+
     var xhr = new XMLHttpRequest()
     xhr.open('POST', '/uploads')
     xhr.setRequestHeader('X-CSRF-Token', this.csrfToken)
@@ -39,7 +40,7 @@ export default class BoxFileUploader {
 
         if (formStore.boxFilePickerMode.mode === 'supplemental') {
           this.sharedState.supplementalFiles.push(
-            JSON.parse(xhr.responseText).files
+            JSON.parse(xhr.responseText).files[0]
           )
         }
       }


### PR DESCRIPTION
This commit fixes the supplemental file upload
from box not having the name in the display.

It also changes some instances
where we were using `FormData.set` to `FormData.append`.

FormData.set is not available on Safari and IE, but `.append` is.

Related to #1572