### PR TITLE
Merge UI update behavior with embargo updates

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -68,23 +68,12 @@ module Hyrax
       sanitize_input(params)
       merge_selected_files_hashes(params) if params["selected_files"]
 
-      if Rails.application.config_for(:new_ui).fetch('enabled', false)
-        new_ui_update_behavior
-      else # old UI behavior
+      # If the new ui is not enabled, keep these legacy behaviors
+      unless Rails.application.config_for(:new_ui).fetch('enabled', false)
         update_supplemental_files
         update_committee_members
-        super
       end
-    end
-
-    def new_ui_update_behavior
-      if actor.update(actor_environment)
-        path = main_app.hyrax_etd_path(curation_concern)
-        render json: { redirectPath: path }, status: :ok
-      else
-        raise "TODO: Error path is not implemented yet"
-        # render json: { errors: curation_concern.errors.messages }, status: 422
-      end
+      super
     end
 
     # Override from Hyrax:app/controllers/concerns/hyrax/curation_concern_controller.rb
@@ -103,8 +92,8 @@ module Hyrax
     # Any fields coming in through tinymce are likely to be full of ms word
     # type markup that we don't want. Sanitize it.
     def sanitize_input(params)
-      params["etd"]["abstract"] = ::InputSanitizer.sanitize(params["etd"]["abstract"])
-      params["etd"]["table_of_contents"] = ::InputSanitizer.sanitize(params["etd"]["table_of_contents"])
+      params["etd"]["abstract"] = ::InputSanitizer.sanitize(params["etd"]["abstract"]) if params["etd"]["abstract"]
+      params["etd"]["table_of_contents"] = ::InputSanitizer.sanitize(params["etd"]["table_of_contents"]) if params["etd"]["table_of_contents"]
     end
 
     def update_committee_members

--- a/spec/features/embargo_edit_spec.rb
+++ b/spec/features/embargo_edit_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+require 'workflow_setup'
+include Warden::Test::Helpers
+
+RSpec.feature 'edit an embargo', :perform_jobs, :js, :new_ui, integration: true do
+  before(:all) do
+    DatabaseCleaner.clean
+    ActiveFedora::Cleaner.clean!
+
+    workflow_settings = { superusers_config: "#{fixture_path}/config/emory/superusers.yml",
+                          admin_sets_config: "#{fixture_path}/config/emory/candler_admin_sets.yml",
+                          log_location:      "/dev/null" }
+
+    setup_args = [workflow_settings[:superusers_config],
+                  workflow_settings[:admin_sets_config],
+                  workflow_settings[:log_location]]
+
+    WorkflowSetup.new(*setup_args).setup
+  end
+
+  after(:all) do
+    DatabaseCleaner.clean
+    ActiveFedora::Cleaner.clean!
+  end
+
+  let(:attributes) do
+    { 'title' => ['The Adventures of Cottontail Rabbit'],
+      'post_graduation_email' => ['me@after.graduation.com'],
+      'creator' => ['Sneddon, River'],
+      'abstract' => ["This is an abstract"],
+      'table_of_contents' => ['My table of contents'],
+      'school' => ["Candler School of Theology"],
+      'department' => ["Divinity"],
+      'embargo_length' => '6 months',
+      'embargo_type' =>  "files_embargoed, toc_embargoed, abstract_embargoed",
+      'uploaded_files' => [uploaded_file.id] }
+  end
+  let(:actor)      { Hyrax::CurationConcern.actor }
+  let(:ability)    { ::Ability.new(user) }
+  let(:etd)        { FactoryBot.build(:etd) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user)       { FactoryBot.create(:user) }
+  let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
+  let(:open)       { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  let(:restricted) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+  let(:uploaded_file) do
+    FactoryBot.create :primary_uploaded_file, user_id: user.id
+  end
+  let(:six_years_from_today) { Time.zone.today + 6.years }
+  let(:approving_user) { User.find_by(uid: "candleradmin") }
+
+  before do
+    allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
+    allow(Hyrax::Workflow::DegreeAwardedNotification).to receive(:send_notification)
+    actor.create(env)
+    etd.reload
+    expect(etd.degree_awarded).to eq nil
+    expect(etd.embargo.embargo_release_date).to eq six_years_from_today
+    expect(etd.embargo_length).to eq "6 months"
+    expect(etd.reload.file_sets.first.embargo)
+      .to have_attributes embargo_release_date: six_years_from_today,
+                          visibility_during_embargo: restricted,
+                          visibility_after_embargo: open
+    expect(etd.file_sets.first)
+      .to have_attributes visibility: restricted
+  end
+
+  scenario "Approver can change the embargo settings" do
+    login_as approving_user
+    visit("/embargoes/#{etd.id}/edit")
+    expect(find('#etd_visibility_during_embargo').find(:xpath, 'option[1]').text).to eq 'All Restricted'
+    find('#etd_embargo_release_date')
+    fill_in 'etd_embargo_release_date', with: (Time.zone.today + 8.years).to_s
+    execute_script('$("form").submit()')
+    expect(page).to have_current_path("/concern/etds/#{etd.id}?locale=en")
+    expect(page).to have_content etd.title.first
+    expect(page).to have_content "successfully updated"
+    expect(page).to have_content etd.abstract.first
+    expect(page).to have_content etd.table_of_contents.first
+    expect(etd.reload.file_sets.first.embargo.embargo_release_date).to eq etd.reload.embargo_release_date
+  end
+end


### PR DESCRIPTION
Do not re-set abstract and table_of_contents
params unless they exist and need to be sanitized.
Do not short-circut after_update_response by
sending the response prematurely.
Redirect the user to the object show page after
an update, regardless of whether they have updated
via the UI form or the embargo edit form.
Feature test for editing embargoes.

Connected to #1489 
Connected to #1586 