### PR TITLE
Fix dashboard Add New Work button

### DIFF
--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -1,0 +1,57 @@
+<% provide :page_title, t("hyrax.admin.sidebar.works") %>
+
+<% provide :head do %>
+  <%= rss_feed_link_tag route_set: hyrax %>
+  <%= atom_feed_link_tag route_set: hyrax %>
+<% end %>
+
+<script>
+//<![CDATA[
+
+  <%= render partial: 'scripts', formats: [:js] %>
+
+//]]>
+</script>
+
+<% provide :page_header do %>
+  <h1><span class="fa fa-file"></span> <%= t("hyrax.admin.sidebar.works") %></h1>
+  <% if current_ability.can_create_any_work? %>
+  <!-- We override this view partial to add data-turbolinks="false" here, which
+  is needed to get this button to properly redirect to the Vue form -->
+    <div class="pull-right" data-turbolinks="false">
+      <%= link_to(
+            t(:'helpers.action.work.new'),
+            new_polymorphic_path([main_app, @create_work_presenter.first_model]),
+            class: 'btn btn-primary'
+          ) %>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">
+      <%= render 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>
+      <div class="panel-heading">
+        <% if current_page?(hyrax.my_works_path(locale: nil)) %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_own', total_count: @response.total_count).html_safe %></span>
+        <% elsif current_page?(hyrax.dashboard_works_path(locale: nil)) && !current_ability.admin? %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.you_manage', total_count: @response.total_count).html_safe %></span>
+        <% else %>
+          <span class="count-display"><%= I18n.t('hyrax.my.count.works.in_repo', total_count: @response.total_count).html_safe %></span>
+        <% end %>
+      </div>
+      <div class="panel-body">
+        <%= render 'search_header' %>
+        <h2 class="sr-only">Works listing</h2>
+        <%= render 'document_list' %>
+
+        <%= render 'results_pagination' %>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @create_work_presenter if @create_work_presenter.many? %>


### PR DESCRIPTION
There is an Add New Work button on the user's
My Works dashboard, which previously took the user
to a blank screen. This PR overrides the default
hyrax view partial and ensures the button goes to
the Vue form in the correct way.

Fixes #1592 