### PR TITLE
Display embargo type in edit screen

### DIFF
--- a/app/lib/embargo_type_from_attributes.rb
+++ b/app/lib/embargo_type_from_attributes.rb
@@ -1,0 +1,19 @@
+class EmbargoTypeFromAttributes
+  def initialize(files, toc, abstract)
+    @files = files
+    @toc = toc
+    @abstract = abstract
+  end
+
+  def s
+    embargo_type = [@files, @toc, @abstract]
+    case embargo_type
+    when ['true', 'false', 'false']
+      return 'files_embargoed'
+    when ['true', 'true', 'false']
+      return 'files_embargoed, toc_embargoed'
+    when ['true', 'true', 'true']
+      return 'files_embargoed, toc_embargoed, abstract_embargoed'
+    end
+  end
+end

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -117,7 +117,8 @@ class InProgressEtd < ApplicationRecord
     new_data['keyword'] = etd.keyword
     new_data['department'] = etd.department
     new_data['research_field'] = etd.research_field
-
+    em_type = EmbargoTypeFromAttributes.new(etd.files_embargoed, etd.toc_embargoed, etd.abstract_embargoed)
+    new_data['embargo_type'] = em_type.s
     members = etd.committee_members.inject([]) do |member_list, person|
       member_list << { name: person.name, affiliation_type: person.affiliation[0] }
     end

--- a/spec/lib/embargo_type_from_attributes_spec.rb
+++ b/spec/lib/embargo_type_from_attributes_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+RSpec.describe EmbargoTypeFromAttributes do
+  let(:embargo_type) { described_class }
+
+  it 'returns the correct response for files' do
+    type = embargo_type.new('true', 'false', 'false')
+    expect(type.s).to eq('files_embargoed')
+  end
+
+  it 'returns the correct resposne for files and toc' do
+    type = embargo_type.new('true', 'true', 'false')
+    expect(type.s).to eq('files_embargoed, toc_embargoed')
+  end
+
+  it 'returns the correct response for files, toc, and abstract' do
+    type = embargo_type.new('true', 'true', 'true')
+    expect(type.s).to eq('files_embargoed, toc_embargoed, abstract_embargoed')
+  end
+end


### PR DESCRIPTION
This introduces a class that translates the embargo
attributes back into a string that be editied on the form.

When you save from an edit, I would assume that the
embargo code in the Etd actor would translate the
string back into the attributes, but this isn't happening.

Connected to #1595