### PR TITLE
Refactor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ after_success:
   if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
     bundle exec cap prod_upgrade deploy
   fi
-before_script:
-- bundle exec rake db:create
 cache:
   bundler: true
   directories:
@@ -23,13 +21,10 @@ env:
   - COVERALLS_PARALLEL=true
   - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   matrix:
-  - TEST_SUITE=style
   - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=unit
   - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=integration
-  - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=js
   - NEW_UI_ENABLED=true NO_COVERAGE=true TEST_SUITE=unit
   - NEW_UI_ENABLED=true NO_COVERAGE=true TEST_SUITE=integration
-  - NEW_UI_ENABLED=true NO_COVERAGE=true TEST_SUITE=js
 install:
 - nvm install node
 - node -v
@@ -48,8 +43,6 @@ notifications:
 rvm:
 - 2.4.2
 script:
-- RAILS_ENV=test ./bin/rails db:migrate
-- RAILS_ENV=test ./bin/rails webpacker:compile
 - xvfb-run -a bundle exec rake ci[$TEST_SUITE]
 services:
 - redis-server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -711,7 +711,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    retriable (3.1.1)
+    retriable (3.1.2)
     rsolr (1.1.2)
       builder (>= 2.1.2)
     rspec (3.7.0)
@@ -756,7 +756,7 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
     samvera-nesting_indexer (2.0.0)
@@ -807,7 +807,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (4.6.1)
-    solr_wrapper (1.2.0)
+    solr_wrapper (2.0.0)
       faraday
       retriable
       ruby-progressbar

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -2,6 +2,7 @@
 version: 6.6.2
 download_dir: /var/tmp
 port: 8985
+verbose: true
 instance_dir: tmp/solr-test
 collection:
     persist: false

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,44 +1,44 @@
 # frozen_string_literal: true
-
 unless Rails.env.production?
-  APP_ROOT = File.dirname(__FILE__)
-  require "solr_wrapper"
-  require "fcrepo_wrapper"
   require 'solr_wrapper/rake_task'
 
+  # Split the test suite into two parts: unit tests and integration tests
+  # Integration tests take longer to run individually, but there are fewer
+  # of them so the suite as a whole takes less time than unit tests.
+  # Bundle integration with style checking and javascript tests (both relatively
+  # quick) to create a balanced job.
   desc "Run Continuous Integration"
   task :ci, [:test_suite] do |task, args|
-    test_suite = args[:test_suite] || "spec"
-    check_style if test_suite == "style"
-    ci_with_infrastructure(test_suite) unless test_suite == "style"
+    test_suite = args[:test_suite] || "integration"
+    Rake::Task['unit_ci'].invoke if test_suite == "unit"
+    Rake::Task['integration_ci'].invoke if test_suite == "integration"
   end
 
-  def ci_with_infrastructure(test_suite)
-    ENV["environment"] = "test"
-    solr_params = {
-      port: 8985,
-      verbose: true,
-      managed: true
-    }
-    fcrepo_params = {
-      port: 8986,
-      verbose: true,
-      managed: true,
-      enable_jms: false,
-      fcrepo_home_dir: 'tmp/fcrepo4-test-data'
-    }
-    SolrWrapper.wrap(solr_params) do |solr|
-      solr.with_collection(
-        name: "hydra-test",
-        persist: false,
-        dir: Rails.root.join("solr", "config")
-      ) do
-        FcrepoWrapper.wrap(fcrepo_params) do
-          Rake::Task[test_suite].invoke
-        end
-      end
+  desc "Run integration CI"
+  task :integration_ci do
+    with_server 'test' do
+      Rake::Task['db:create'].invoke
+      Rake::Task['db:migrate'].invoke
+      Rake::Task['webpacker:compile'].invoke
+      Rake::Task['rubocop'].invoke
+      Rake::Task['integration'].invoke
+      Rake::Task['js_ci'].invoke
     end
-    # Rake::Task["doc"].invoke
+  end
+
+  desc "Run unit CI"
+  task :unit_ci do
+    with_server 'test' do
+      Rake::Task['db:create'].invoke
+      Rake::Task['db:migrate'].invoke
+      Rake::Task['webpacker:compile'].invoke
+      Rake::Task['unit'].invoke
+    end
+  end
+
+  desc "Run javascript CI"
+  task :js_ci do
+    sh "yarn test"
   end
 
   RSpec::Core::RakeTask.new(:integration) do |t|
@@ -47,14 +47,5 @@ unless Rails.env.production?
 
   RSpec::Core::RakeTask.new(:unit) do |t|
     t.rspec_opts = "--tag ~integration --profile"
-  end
-
-  desc "Run js tests"
-  task :js do
-    sh "yarn test"
-  end
-
-  def check_style
-    sh "bundle exec rubocop"
   end
 end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,11 @@
+
+# frozen_string_literal: true
+unless Rails.env.production?
+  require 'rubocop/rake_task'
+
+  desc 'Run style checker'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.requires << 'rubocop-rspec'
+    task.fail_on_error = true
+  end
+end


### PR DESCRIPTION
* Make CI rake task easier to read and understand
* Only run database setup for tasks where it's necessary
* Continue to split the build into chunks, but combine `js` and `integration` so we reduce the number of concurrent jobs required by a single PR.
* Add verbose flag to solr_wrapper so we can diagnose why it keeps failing in travis.

Connected to #1615 