### PR TITLE
Better management of school, dept, and embargo state

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -35,6 +35,14 @@ class InProgressEtdsController < ApplicationController
     end
   end
 
+  def destroy
+    @in_progress_etd = InProgressEtd.find(params[:id])
+    authorize! :update, @in_progress_etd
+    @in_progress_etd.destroy
+
+    redirect_to root_url
+  end
+
   private
 
     def current_step(data)

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -9,7 +9,7 @@
         </button>
       </li>
     </ul>
-    <form role="form" id="vue_form" :action="sharedState.getUpdateRoute()" method="patch" @submit.prevent="onSubmit">
+    <form role="form" id="vue_form" :action="sharedState.getUpdateRoute()" :method="formMethod" @submit.prevent="onSubmit">
       <div v-for="value in sharedState.tabs" v-bind:key="value.label">
         <div class="tab-content form-group" v-if="(value.currentStep && allowTabSave()) || !allowTabSave()">
           <h2> {{ value.label }} </h2>
@@ -139,6 +139,7 @@
           <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
           <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
+          <button id="delete" data-toggle="tooltip" title="This will delete your progress and return you to the home page. You will need to begin the submission process again if you click here!" type="button" @click="changeFormMethod()" class="btn btn-danger">Start Over</button>
         </div>
       </div>
     </form>
@@ -148,6 +149,7 @@
 
 <script>
 import _ from "lodash"
+import axios from 'axios'
 import { formStore } from "./formStore"
 import School from "./School"
 import Department from './Department'
@@ -179,7 +181,8 @@ export default {
       tabInputs: [],
       files: [],
       deleteableFiles: [],
-      lastCompletedStep: 0
+      lastCompletedStep: 0,
+      formMethod: 'patch'
     }
   },
   components: {
@@ -219,6 +222,17 @@ export default {
   // If student is editing an ETD that has already been persisted to fedora,
   // don't allow student to save record on individual tabs.  This is because
   // we want to save to the Etd, not the InProgressEtd.
+  changeFormMethod() {
+    axios.delete(this.sharedState.getUpdateRoute())
+         .then((response) => { 
+                localStorage.removeItem('school')
+                window.location = '/'
+          })
+        .catch(() => {
+                localStorage.removeItem('school')
+                window.location = '/'
+          })
+  },
   allowTabSave () {
     if (this.sharedState.etdId) {
       return false
@@ -279,10 +293,10 @@ export default {
     onSubmit (event) {
       this.sharedState.setFormData(event.target)
       if (this.readyForReview()){
-        console.log('ready for review')
+        
         this.reviewTabs()
       } else if (this.readyForSubmission()){
-        console.log('ready for submission')
+        
         this.submitForPublication()
       } else {
         this.saveTab()
@@ -357,5 +371,9 @@ input {
 
 .errorMessage {
   color: red;
+}
+
+#delete {
+  float: right;
 }
 </style>

--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <label for="department">Department</label>
-    <select class="form-control" id="department" v-model="selected" aria-required="true" v-on:change="sharedState.setValid('My Program', false)">
+    <select name="etd[department]" class="form-control" id="department" v-model="selected" aria-required="true" v-on:change="sharedState.setValid('My Program', false)">
       <option v-for="department in sharedState.departments" v-bind:value="department.label" v-bind:key="department.label">
         {{ department.label }}
       </option>
@@ -23,22 +23,13 @@ export default {
 
   watch: {
     selected () {
-      this.sharedState.clearDepartment()
-      this.sharedState.clearSubfields()
-      this.sharedState.setSelectedDepartment(this.selected)
+      this.sharedState.getSavedOrSelectedDepartment()
       this.sharedState.getSubfields()
     }
   },
-  // this keeps track of whether the user has a saved school, and can use it to load departments, or whether the user has a mismatch between a newly selected school and a saved one, in which case the user is told of the problem.
   beforeMount: function(){
-    if (this.sharedState.messySchoolState()){
-      this.sharedState.clearDepartment()
-      this.sharedState.clearSubfields()
-    } else if (this.sharedState.getSavedSchool()) {
       this.sharedState.loadDepartments()
-    } else {
       this.selected = this.sharedState.getSavedOrSelectedSchool()
-    }
   },
   mounted: function (){
     this.$nextTick(function () {

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div id="files">
     <section class="thesis-file">
     <h2>Add Your Thesis or Dissertation File</h2>
     <div v-if="accessToken">
@@ -193,6 +193,7 @@ export default {
       })
       fileUploader.uploadFile()
       formStore.setValid('My Files', false)
+      
     },
     onSupplementalFileChange(e) {
         var supplementalFileUploader = new SupplementalFileUploader({
@@ -203,6 +204,9 @@ export default {
       })
       supplementalFileUploader.uploadFile()
       formStore.setValid('My Files', false)
+
+      localStorage.setItem('suppFiles', this.supplementalFiles)
+      localStorage.setItem('suppFilesMetadata', this.supplementalFilesMetadata)
     },
     getFormData() {
       var form = document.getElementById('vue_form')
@@ -229,7 +233,7 @@ export default {
   },
   boxOAuth(mode) {
     this.sharedState.boxFilePickerMode.setMode(mode)
-    console.log('setting mode')
+    
     window.location = this.boxOAuthUrl()
   },
   boxOAuthUrl () {

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -13,8 +13,6 @@ export default class SaveAndSubmit {
     this.formData.append("etd[files]", this.formStore.getPrimaryFile())
     this.formData.append("etd[supplemental_files]", this.formStore.getSupplementalFiles())
 
-    // the client sends a param the server uses to track whether an old school matches a new school
-    this.formData.append('etd[schoolHasChanged]', this.formStore.savedData['schoolHasChanged'])
     axios
       .patch(this.formStore.getUpdateRoute(), this.formData, {
         config: { headers: { 'Content-Type': 'multipart/form-data' } }
@@ -50,14 +48,13 @@ export default class SaveAndSubmit {
         this.formStore.loadTabs()
       })
       .catch(error => {
-        console.log('an error', error)
+        
       })
   }
   submitEtd () {
     // we want the latest data from the server loaded into the form only when ready to submit for publication
     this.formStore.loadSavedData()
     // submit as form data
-    this.formStore.savedData['school'] = this.formStore.getSchoolText(this.formStore.savedData['school'])
 
     var uploadedFilesIds = []
     uploadedFilesIds.push(`${this.formStore.files[0][0].id}`)
@@ -68,11 +65,12 @@ export default class SaveAndSubmit {
     var savedDataToSubmit = { 'etd': this.formStore.savedData, 'uploaded_files': uploadedFilesIds }
     axios.post('/concern/etds', savedDataToSubmit)
       .then(response => {
+        localStorage.removeItem('school')
         window.location = response.request.responseURL
       })
       .catch(e => {
         this.errors.push(e)
-        console.log('an error', e)
+        
       })
   }
   updateEtd () {
@@ -86,7 +84,7 @@ export default class SaveAndSubmit {
       })
       .catch(e => {
         // this.errors.push(e)
-        console.log('an error', e)
+        
       })
   }
 }

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -1,12 +1,13 @@
 <template>
   <div>
     <label for="school">School</label>
-    <select v-if="!this.sharedState.getSavedOrSelectedSchool()" id="school" class="form-control" v-model="selected" aria-required="true" v-on:change="clearDepartmentAndSubfields(), sharedState.setValid('About Me', false, ['My Program', 'Embargo'])">
+    <select v-if="!this.sharedState.getSavedOrSelectedSchool()" id="school" class="form-control" v-model="selected" aria-required="true" v-on:change="sharedState.setValid('About Me', false, ['My Program', 'Embargo'])">
       <option v-for="school in this.sharedState.schools.options" v-bind:value="school.value" v-bind:key='school.value' :selected='school.selected' :disabled='school.disabled'>
         {{ school.text }}
       </option>
     </select>
     <div v-if="this.sharedState.getSavedOrSelectedSchool()">
+      <input type="hidden" name="etd[school]" :value="this.sharedState.getSchoolText(this.sharedState.getSavedOrSelectedSchool())" />
       <b>{{ this.sharedState.getSchoolText(this.sharedState.getSavedOrSelectedSchool()) }}</b>
     </div>
   </div>
@@ -39,9 +40,7 @@ export default {
     this.$nextTick(function () {
       //this needs to be saved or selected
       var selected = this.sharedState.getSavedOrSelectedSchool()
-      if(selected === undefined){
-        selected = ''
-      }
+
       // TODO: fix model to return string not array
       if (_.has(this.sharedState.savedData, 'etd_id')){
         var schoolValue = this.sharedState.getSchoolValue(selected[0])
@@ -53,10 +52,7 @@ export default {
   watch: {
     selected() {
       //this executes when the component is rendered the first time and when the change event fires (user selects something)
-      this.fetchData();
-      if (this.sharedState.messySchoolState()){
-        this.sharedState.errors.push({"schoolDeptMismatch": ''})
-      }
+      this.fetchData()
     }
   }
 };

--- a/app/javascript/SupplementalFileDelete.js
+++ b/app/javascript/SupplementalFileDelete.js
@@ -1,19 +1,19 @@
 import FileDelete from './FileDelete'
 export default class SupplementalFileDelete extends FileDelete {
   deleteFile (key) {
-    console.log(this.deleteUrl)
+    
     var xhr = new XMLHttpRequest()
     xhr.open('DELETE', this.deleteUrl, true)
     xhr.setRequestHeader('X-CSRF-Token', this.token)
     xhr.send(null)
-    console.log(this.deleteUrl)
+    
     const filteredFiles = this.formStore.supplementalFiles.filter(
       file => file.deleteUrl !== this.deleteUrl
     )
     const filteredMetadata = this.formStore.supplementalFilesMetadata.filter(
       file => file.id !== this.id
     )
-    console.log(filteredFiles)
+    
     this.formStore.supplementalFiles = filteredFiles
     this.formStore.supplementalFilesMetadata = filteredMetadata
     this.formStore.removeSavedSupplementalFile(this.deleteUrl)

--- a/app/javascript/SupplementalFileUploader.js
+++ b/app/javascript/SupplementalFileUploader.js
@@ -5,6 +5,11 @@ export default class SupplementalFileUploader extends FileUploader {
     if (isSafari11()) {
       this.formData.delete('primary_files[]')
     }
+    // this should not submit a school 
+    try {
+      this.formData.delete('etd[school]')
+    } catch (error) {}
+
     var files = this.event.target.files || this.event.dataTransfer.files
     if (!files.length) return
     var xhr = new XMLHttpRequest()
@@ -12,7 +17,6 @@ export default class SupplementalFileUploader extends FileUploader {
     xhr.setRequestHeader('X-CSRF-Token', this.token)
     xhr.onreadystatechange = () => {
       if (xhr.readyState === XMLHttpRequest.DONE) {
-        console.log(xhr.responseText)
         this.formStore.supplementalFiles.push(
           JSON.parse(xhr.responseText).files[0]
         )

--- a/app/javascript/components/submit/Embargo.vue
+++ b/app/javascript/components/submit/Embargo.vue
@@ -23,7 +23,7 @@ export default {
       try {
       var readableType = this.sharedState.embargoContents.filter((embargo) => { return embargo.value === type })[0].text
       } catch(error) {
-        console.log(error)
+        
       }
       if (readableType)
       return readableType

--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -2,7 +2,7 @@
   <section>   
     <h4>My Program</h4>
     <h5>Department</h5>
-    <div> {{ sharedState.getSelectedDepartment() }} </div>
+    <div> {{ sharedState.getSavedOrSelectedDepartment() }} </div>
     <div v-if="sharedState.getSubfields()">
           <h5>Subfield</h5>
       <div> {{ sharedState.getSubfields() }} </div>

--- a/app/javascript/test/Department.spec.js
+++ b/app/javascript/test/Department.spec.js
@@ -6,8 +6,12 @@ import { mount } from '@vue/test-utils'
 import Department from 'Department'
 import axios from 'axios'
 import { formStore } from 'formStore'
-
 jest.mock('axios')
+
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn()
+window.localStorage.setItem = jest.fn()
+
 formStore.departments = [{"id":"Divinity","label":"Divinity","active":true},{"id":"Ministry","label":"Ministry","active":true},{"id":"Pastoral Counseling","label":"Pastoral Counseling","active":true},{"id":"Theological Studies","label":"Theological Studies","active":true}]
 formStore.getSavedOrSelectedDepartment = () => { return 'Divinity' }
 describe('Department.vue', () => {
@@ -15,7 +19,7 @@ describe('Department.vue', () => {
     const wrapper = mount(Department, {
     })
     wrapper.vm.$data.selected = formStore.getSavedOrSelectedDepartment()
-    console.log(wrapper.html())
+    
     expect(wrapper.html()).toContain('Divinity')
   })
 })

--- a/app/javascript/test/Embargo.spec.js
+++ b/app/javascript/test/Embargo.spec.js
@@ -5,6 +5,9 @@ import { shallowMount } from '@vue/test-utils'
 import Embargo from 'Embargo'
 import { formStore } from '../formStore'
 
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn((value) => { return 'laney' } )
+
 describe('Embargo.vue', () => {
   it('has the correct html', () => {
     const wrapper = shallowMount(Embargo, {
@@ -16,6 +19,7 @@ describe('Embargo.vue', () => {
       const wrapper = shallowMount(Embargo, {
       })
       formStore.schools.selected = 'laney'
+      formStore.savedData.schools = 'laney'
       formStore.savedData['embargo_length'] = '6 Years'
     })
 

--- a/app/javascript/test/School.spec.js
+++ b/app/javascript/test/School.spec.js
@@ -8,6 +8,9 @@ import axios from 'axios'
 import { formStore } from 'formStore'
 
 jest.mock('axios')
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn()
+window.localStorage.setItem = jest.fn()
 
 describe('School.vue', () => {
   const resp = {data: [{'id': 'Candler School of Theology'}]}
@@ -25,7 +28,8 @@ describe('School.vue', () => {
 
     const wrapper = mount(School, {
     })
+  
     wrapper.vm.$data.sharedState.schools.options = [{"text":"Select a School","value":"","disabled":"disabled","selected":"selected"},{"text":"Candler School of Theology","value":"candler"},{"text":"Emory College","value":"emory"},{"text":"Laney Graduate School","value":"laney"},{"text":"Rollins School of Public Health","value":"rollins"}]
-    expect(wrapper.html()).toContain(`<div><label for=\"school\">School</label> <!----> <div><b>Candler School of Theology</b></div></div>`)
+    expect(wrapper.html()).toContain(`<div><label for=\"school\">School</label> <!----> <div><input type=\"hidden\" name=\"etd[school]\" value=\"Candler School of Theology\"> <b>Candler School of Theology</b></div></div>`)
   })
 })

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -4,6 +4,10 @@
 
 import { formStore } from '../formStore'
 
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn()
+window.localStorage.setItem = jest.fn()
+
 formStore.getSavedOrSelectedSchool = jest.fn(() => {return 'Emory College'})
 describe('formStore', () => {
   it('returns the correct embargo length based on the selected school', () => {

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -124,6 +124,8 @@ class InProgressEtd < ApplicationRecord
     em_type = EmbargoTypeFromAttributes.new(etd.files_embargoed, etd.toc_embargoed, etd.abstract_embargoed)
     new_data['embargo_type'] = em_type.s
 
+    # This code allows you to display and add chairs and members on the
+    # edit form, but not remove them.
     etd_members = etd.members.map { |chair| JSON.parse(chair.to_json) }.map { |values| { name: values["name"], affiliation: values["affiliation"] } }.uniq
 
     members = []

--- a/spec/controllers/in_progress_etds_controller_spec.rb
+++ b/spec/controllers/in_progress_etds_controller_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe InProgressEtdsController, type: :controller do
       end
     end
 
+    describe 'DELETE DESTROY' do
+      before { ipe }
+      it 'redirects to login' do
+        delete :destroy, params: { id: ipe.id }
+        expect(InProgressEtd.all.size).to eq(0)
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
     describe 'PATCH UPDATE' do
       let(:new_title) { ['New Title from Update'] }
 
@@ -123,6 +132,13 @@ RSpec.describe InProgressEtdsController, type: :controller do
     describe 'PATCH UPDATE' do
       it 'redirects to login' do
         patch :update, params: { id: ipe.id, in_progress_etd: { title: ['New Title from Update'] } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    describe 'DELETE DESTROY' do
+      it 'redirects to login' do
+        delete :destroy, params: { id: ipe.id }
         expect(response).to redirect_to(new_user_session_path)
       end
     end


### PR DESCRIPTION
This commit fixes some bugs in the management of the
state of the properties that are based on the school.

The state is based on the saved school primarily now.

A copy of the school is also saved in the browser's
`localStorage` as a precaution.

This commit also adds a  destroy action to to the
InProgressEtd controller, this allows for a Start
Over button to be in the form that can be used
by a user to delete their InProgressEtd and start
over from scratch in case something goes wrong or
they enter the wrong school.

Connected to #1623 
Connected to #1622 
Connected to #1603 
Connected to #1617 