### PR TITLE
Translate file visibility for embargoed works in importer

### DIFF
--- a/app/lib/importer/migration_import_job.rb
+++ b/app/lib/importer/migration_import_job.rb
@@ -86,6 +86,7 @@ module Importer
 
     def stack_actors
       [Hyrax::Actors::CreateWithFilesActor,
+       Hyrax::Actors::FileVisibilityAttributesActor,
        Hyrax::Actors::CollectionsMembershipActor,
        Hyrax::Actors::AddToWorkActor,
        Hyrax::Actors::AttachMembersActor,


### PR DESCRIPTION
`MigrationImportJob` uses a special, pared down actor stack. Since we are adding `Hyrax::Actors::FileVisibilityAttributesActor` to our local stack to handle embargo behavior for `FileSet` visibility, we need to include this in the stack to handle files on import.

Fixes #1629.