### PR TITLE
Persist primary file across page refresh

### DIFF
--- a/app/javascript/FileDelete.js
+++ b/app/javascript/FileDelete.js
@@ -16,5 +16,6 @@ export default class FileDelete {
     )
     this.formStore.files = filteredFiles
     this.formStore.removeSavedFile(this.deleteUrl)
+    localStorage.removeItem('files')
   }
 }

--- a/app/javascript/FileUploader.js
+++ b/app/javascript/FileUploader.js
@@ -21,6 +21,7 @@ export default class FileUploader {
         this.formStore.files.push(
           JSON.parse(xhr.responseText).files
         )
+       localStorage.setItem('files', xhr.responseText)
       }
     }
     xhr.send(this.formData)

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="files">
+  <div>
     <section class="thesis-file">
     <h2>Add Your Thesis or Dissertation File</h2>
     <div v-if="accessToken">
@@ -140,6 +140,11 @@ export default {
       accessToken: window.location.search.split('&access_token=')[1]
     }
   },
+  created() {
+    if (localStorage.getItem('files')) {
+      this.sharedState.files = [[JSON.parse(localStorage.getItem('files')).files[0]]]
+    }
+  },
   mounted () {
     var folderId = '0'
     var accessToken = window.location.search.split('&access_token=')[1]
@@ -164,7 +169,6 @@ export default {
       })
 
       boxFileUploader.getUrlFromBox()
-      filePicker.hide()
       })
     }
   },
@@ -193,7 +197,6 @@ export default {
       })
       fileUploader.uploadFile()
       formStore.setValid('My Files', false)
-      
     },
     onSupplementalFileChange(e) {
         var supplementalFileUploader = new SupplementalFileUploader({
@@ -204,9 +207,6 @@ export default {
       })
       supplementalFileUploader.uploadFile()
       formStore.setValid('My Files', false)
-
-      localStorage.setItem('suppFiles', this.supplementalFiles)
-      localStorage.setItem('suppFilesMetadata', this.supplementalFilesMetadata)
     },
     getFormData() {
       var form = document.getElementById('vue_form')

--- a/app/javascript/test/FileDelete.spec.js
+++ b/app/javascript/test/FileDelete.spec.js
@@ -12,7 +12,8 @@ const mockXHR = {
 }
 
 window.XMLHttpRequest = jest.fn(() => mockXHR)
-
+window.localStorage = jest.fn()
+window.localStorage.removeItem = jest.fn((value) => { return value})
 describe('FileDelete', () => {
 
   it('makes an HTTP requst and remove the file from the state', () => {
@@ -22,6 +23,7 @@ describe('FileDelete', () => {
       formStore: formStore
     })
     fileDelete.deleteFile()
+    expect(window.localStorage.removeItem).toBeCalledWith('files')
     expect(mockXHR.open).toBeCalledWith('DELETE', 'http://example.com/delete', true)
   })
 })

--- a/app/javascript/test/Files.spec.js
+++ b/app/javascript/test/Files.spec.js
@@ -6,6 +6,9 @@ import { mount } from '@vue/test-utils'
 import Files from 'Files'
 import { formStore } from 'formStore'
 
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn((value) => { return undefined })
+
 describe('Files.vue', () => {
   global.Box = { FilePicker: function() {}}
   global.boxClientId = function() {}
@@ -22,6 +25,10 @@ describe('Files.vue', () => {
     expect(wrapper.findAll('label')).toHaveLength(2)
   })
 
+  it('checks for some JSON in localStorage files', () => {
+    expect(window.localStorage.getItem).toBeCalledWith('files')
+  })
+  
   it('when primary file is present, it returns primary file', () => {
     const wrapper = shallowMount(Files, { })
     const fakeFileData = { id: 'fake file object' }


### PR DESCRIPTION
The primary files is special case because
it needs to be persisted even if a user
navigates to Box even if they have not
saved the tab.

Box files pesist when tabbing around, but not if you navigate away from
the page without saving. That is how
all of the other tabs function! Primary
files are special case.

This persists the primary file JSON in localStorage so that if
the user moves to Box or to
another tab, the primary file remains.

This also keeps the Box UI present
after a file has been picked so that
multiple files can be added.

Connected to #1627
Connected to #1618
Contented to #1617