### PR TITLE
in edit of an etd, legacy graduation date options are set to selected

### DIFF
--- a/app/javascript/GraduationDate.vue
+++ b/app/javascript/GraduationDate.vue
@@ -2,8 +2,8 @@
     <div>
         <label for="graduation-date">Graduation Date</label>
         <select id="graduation-date" name="etd[graduation_date]" class="form-control" aria-required="true">
-            <option v-for="graduationDate in graduationDates" v-bind:value="graduationDate.id" 
-            v-bind:key='graduationDate.id' v-if="graduationDate.active" :disabled="graduationDate.disabled"  
+            <option v-for="graduationDate in graduationDates" v-bind:value="graduationDate.id"
+            v-bind:key='graduationDate.id' v-if="graduationDate.active" :disabled="graduationDate.disabled"
             :selected="graduationDate.selected">
                 {{ graduationDate.label }}
             </option>
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import Axios from "axios"
+import axios from "axios"
 import { formStore } from './formStore'
 import _ from 'lodash'
 export default {
@@ -26,9 +26,11 @@ export default {
   },
   methods: {
     fetchData() {
-      Axios.get(this.graduationDatesEndpoint).then(response => {
+      axios.get(this.graduationDatesEndpoint).then(response => {
         this.graduationDates = this.getSelected(response.data)
-      });
+      }).catch(e => {
+        console.log(e)
+      })
     },
     getSelected(data){
       var selected = this.sharedState.getGraduationDate()
@@ -36,6 +38,7 @@ export default {
         _.forEach(data, function(o){
           if (o.id == selected){
             o.selected = 'selected'
+            o.active = true
           }
         })
       } else {

--- a/app/javascript/test/GraduationDate.spec.js
+++ b/app/javascript/test/GraduationDate.spec.js
@@ -6,10 +6,13 @@
 import { shallowMount } from '@vue/test-utils'
 import GraduationDate from 'GraduationDate'
 import axios from 'axios'
+
 jest.mock('axios')
 
 describe('GraduationDate.vue', () => {
-  const resp = {data: [{'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}]}
+
+  const resp = {data: [{'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}, {'id': '2013', 'label': '2013', 'active': true}]}
+
   axios.get.mockResolvedValue(resp)
 
   it('renders a select element', () => {
@@ -27,6 +30,7 @@ describe('GraduationDate.vue', () => {
   it('has the correct html', () => {
     const wrapper = shallowMount(GraduationDate, {
     })
+
     expect(wrapper.html()).toEqual(`<div><label for="graduation-date">Graduation Date</label> <select id="graduation-date" name="etd[graduation_date]" aria-required="true" class="form-control"></select></div>`)
   })
 })

--- a/app/javascript/test/LegacyGraduation.spec.js
+++ b/app/javascript/test/LegacyGraduation.spec.js
@@ -1,0 +1,35 @@
+/* global describe */
+/* global it */
+/* global expect */
+/* global jest */
+
+import { shallowMount } from '@vue/test-utils'
+import GraduationDate from 'GraduationDate'
+import axios from 'axios'
+
+jest.mock('axios')
+describe('GraduationDate.vue with an inactive legacy term', () => {
+  const respData = {data: [
+        {'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}, {'id': '2013', 'label': '2013', 'active': true}]}
+
+  axios.get.mockResolvedValue(respData)
+
+  beforeEach(() => {
+    const wrapper = shallowMount(GraduationDate, {
+    })
+    wrapper.vm.$data.graduationDates = respData
+    wrapper.vm.$data.sharedState.getGraduationDate = jest.fn(() => {
+      return '2013'
+    })
+  })
+
+  it('will set the legacy option properties active = true and selected = selected', () => {
+    const wrapper = shallowMount(GraduationDate, {
+    })
+    wrapper.vm.$data.graduationDates = respData
+
+    const expected_option_data = {data: [{'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}, {'id': '2013', 'label': '2013', 'active': true, 'selected': 'selected'}]}
+
+    expect(wrapper.vm.getSelected(respData)).toEqual(expected_option_data)
+  })
+})


### PR DESCRIPTION
This commit makes the graduation date component respond to a savedData graduation date by setting its active property to true, which ensures it will not be skipped by the template guard clause skipping inactive options. Only in legacy cases will there be a savedData graduation_date that might be inactive. Since that property is never sent to the server in form submissions, it should be a benign change that provides the user the ability to see and change their legacy graduation data.

Connected to #1094 