### PR TITLE
displaying legacy degree in editing

### DIFF
--- a/app/javascript/Degree.vue
+++ b/app/javascript/Degree.vue
@@ -31,6 +31,10 @@ export default {
     getSelected(data){
       var selected = this.sharedState.getSavedDegree()
       if (selected !== undefined) {
+        //if we are editing etds, we might have a legacy term that is not in our list. Add it to the top and make it selected if so.
+        if (this.sharedState.allowTabSave() === false){
+          data.unshift({ "value": selected, "active": true, "label": selected, "selected": "selected"})
+        }
         _.forEach(data, function(o){
           if (o.id == selected){
             o.selected = 'selected'

--- a/app/javascript/test/LegacyDegree.spec.js
+++ b/app/javascript/test/LegacyDegree.spec.js
@@ -1,0 +1,30 @@
+/* global describe */
+/* global it */
+/* global expect */
+/* global jest */
+
+import { shallowMount } from '@vue/test-utils'
+import Degree from 'Degree'
+import axios from 'axios'
+
+jest.mock('axios')
+
+describe('Degree.vue Display Legacy Degree', () => {
+  const resp = {data: [{'id': 'Th.D.', 'label': 'Th.D.', 'active': true}]}
+  axios.get.mockResolvedValue(resp)
+  beforeEach(() => {
+    const wrapper = shallowMount(Degree, {
+    })
+    wrapper.vm.$data.sharedState.allowTabSave = jest.fn((value) => { return false } )
+    wrapper.vm.$data.sharedState.getSavedDegree = jest.fn((value) => { return 'phd' } )
+    wrapper.vm.$data.degrees = resp.data
+
+  })
+
+  it('renders a select element', () => {
+    const wrapper = shallowMount(Degree, {
+    })
+    wrapper.vm.getSelected(resp.data)
+    expect(resp.data).toContainEqual({"active": true, "label": "phd", "selected": "selected", "value": "phd"})
+  })
+})


### PR DESCRIPTION
This commit ensures a legacy degree is displayed as the selected item when editing a legacy Etd.

Connected to #1094 