### PR TITLE
display legacy language when editing legacy etd

### DIFF
--- a/app/javascript/Language.vue
+++ b/app/javascript/Language.vue
@@ -33,6 +33,9 @@ export default {
     getSelected(data){
       var selected = this.sharedState.getSavedLanguage()
       if (selected !== undefined) {
+        if (this.sharedState.allowTabSave() === false){
+          data.unshift({ "value": selected, "active": true, "label": selected, "selected": "selected"})
+        }
         this.selected = selected
       } else {
         data.unshift({ "value": "", "active": true, "label": "Select a Language", "disabled":"disabled" ,"selected": "selected"})

--- a/app/javascript/test/LegacyLanguage.spec.js
+++ b/app/javascript/test/LegacyLanguage.spec.js
@@ -1,0 +1,30 @@
+/* global describe */
+/* global it */
+/* global expect */
+/* global jest */
+
+import { shallowMount } from '@vue/test-utils'
+import Language from 'Language'
+import axios from 'axios'
+
+jest.mock('axios')
+
+describe('Language.vue Display Legacy Language', () => {
+  const resp = {data: [{'id': 'French', 'label': 'French', 'active': true}]}
+  axios.get.mockResolvedValue(resp)
+  beforeEach(() => {
+    const wrapper = shallowMount(Language, {
+    })
+    wrapper.vm.$data.sharedState.allowTabSave = jest.fn((value) => { return false } )
+    wrapper.vm.$data.sharedState.getSavedLanguage = jest.fn((value) => { return 'Greek' } )
+    wrapper.vm.$data.languages = resp.data
+
+  })
+
+  it('renders a select element', () => {
+    const wrapper = shallowMount(Language, {
+    })
+    wrapper.vm.getSelected(resp.data)
+    expect(resp.data).toContainEqual({"active": true, "label": "Greek", "selected": "selected", "value": "Greek"})
+  })
+})


### PR DESCRIPTION
This commit ensures legacy Language items will be displayed as the selected item when editing a legacy Etd.