### PR TITLE
Push saved department to top of list in edit screen

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -368,9 +368,20 @@ export const formStore = {
   },
 
   getDepartments (selectedSchool) {
-    axios.get(selectedSchool).then(response => {
-      this.departments = response.data
-    })
+    if (!this.allowTabSave()) {
+      var savedValue = { "value": this.getSavedDepartment()[0], "active": true, "label": this.getSavedDepartment()[0], "selected": "selected" }
+      axios.get(selectedSchool).then(response => {
+        this.departments = response.data
+        if (!this.allowTabSave()) {
+          this.departments.unshift(savedValue)
+        }
+      })
+      return savedValue
+    } else {
+      axios.get(selectedSchool).then(response => {
+        this.departments = response.data
+      })
+    }
   },
   loadDepartments () {
     if (this.savedData['department'] !== undefined) {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -10,6 +10,15 @@ window.localStorage.setItem = jest.fn()
 
 formStore.getSavedOrSelectedSchool = jest.fn(() => {return 'Emory College'})
 describe('formStore', () => {
+
+  it('loads the saved department as the first choice', () => {
+
+    formStore.allowTabSave = jest.fn(() => { return false })
+    formStore.getSavedDepartment = jest.fn(() => { return ['African Studies'] })
+    formStore.getDepartments()
+    expect(formStore.getDepartments()).toEqual({'active': true, 'label': 'African Studies', 'selected': 'selected', 'value': 'African Studies'})
+  })
+
   it('returns the correct embargo length based on the selected school', () => {
     formStore.setSelectedSchool('Emory College')
     expect(formStore.getEmbargoLengths()).toEqual([{ value: 'None - open access immediately', selected: 'selected' },


### PR DESCRIPTION
This will restore any saved department to the top
of the select box in the edit screen. This will allow
users to see/edit legacy departments.

Connected to #1094