### PR TITLE
Fixed a problem where submitting the form for a previously-submitted Etd record would result in an infinite loop

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -74,7 +74,22 @@ module Hyrax
         update_supplemental_files
         update_committee_members
       end
-      super
+
+      if params['request_from_form'] == 'true'
+        update_with_response_for_form
+      else
+        super
+      end
+    end
+
+    def update_with_response_for_form
+      if actor.update(actor_environment)
+        path = main_app.hyrax_etd_path(curation_concern)
+        render json: { redirectPath: path }, status: :ok
+      else
+        render json: { errors: 'ERROR: Unable to save the ETD' }, status: 422
+        # TODO: render json: { errors: curation_concern.errors.messages }, status: 422
+      end
     end
 
     # Override from Hyrax:app/controllers/concerns/hyrax/curation_concern_controller.rb

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -135,6 +135,7 @@
 
           <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
+          <input name="request_from_form" type="hidden" value="true" />
           <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
           <div v-if="allowTabSave()">
             <button id="delete" data-toggle="tooltip" title="This will delete your progress and return you to the home page. You will need to begin the submission process again if you click here!" type="button" @click="changeFormMethod()" class="btn btn-danger">Start Over</button>

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -93,7 +93,7 @@ export default class SaveAndSubmit {
     xhr.onreadystatechange = () => {
       if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status === 200) {
-        window.location = xhr.getResponseHeader('Location')
+          window.location = JSON.parse(xhr.response).redirectPath
         } else {
          formStore.failedSubmission = true
         }

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -124,6 +124,11 @@ describe('App.vue', () => {
   })
 
   describe('Edit form:', () => {
+    it('contains hidden flag needed on back end', () => {
+      const wrapper = shallowMount(App, { })
+      expect(wrapper.contains('input[name=request_from_form][value=true]')).toBe(true)
+    })
+
     it('with an associated ETD record, renders the form without tabs', () => {
       const wrapper = shallowMount(App, { })
       wrapper.vm.$data.sharedState.setEtdId('123')


### PR DESCRIPTION
Fixed a problem where submitting the form for a previously-submitted Etd record would result in an infinite loop of patch updates to the EtdsController.

Because there are several forms in the UI that will hit
EtdsController#update, we need to differentiate between requests that
come from the edit form for the ETD and some other form (such as embargo
edit form).  I added a hidden field 'request_from_form' to make it
possible to clearly distinguish which form sent the request.

If the request came from the ETD edit form, then return a json response
that tells the form to redirect to the show page for the Etd record
after a successful update.