### PR TITLE
displaying legacy research fields

### DIFF
--- a/app/javascript/ResearchField.vue
+++ b/app/javascript/ResearchField.vue
@@ -47,13 +47,20 @@ export default {
     },
     fetchData() {
       axios.get(this.researchFieldsEndpoint).then(response => {
-        this.researchFields = response.data
+        var data = response.data
+        if(this.sharedState.allowTabSave() === false){
+          //TODO: confirm this value is ok for label in the absence of a real one
+          _.forEach(this.sharedState.getSavedResearchFields(), (srf) => {
+            data.unshift({'id': srf, 'active': true, 'label': srf})
+          } )
+        }
+        this.researchFields = data
       })
     },
   },
   created() {
     this.fetchData()
-    this.sharedState.getSavedResearchFields()  
+    this.sharedState.getSavedResearchFields()
   }
 }
 </script>

--- a/app/javascript/test/LegacyResearchField.spec.js
+++ b/app/javascript/test/LegacyResearchField.spec.js
@@ -1,0 +1,34 @@
+/* global describe */
+/* global it */
+/* global expect */
+/* global jest */
+
+import Vue from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import ResearchField from 'ResearchField'
+import axios from 'axios'
+
+jest.mock('axios')
+
+describe('ResearchField.vue Display Legacy ResearchField', () => {
+  const resp = {data: [{'id': 'Horticulture', 'active': true, 'label': '0237'}]}
+  axios.get.mockResolvedValue(resp)
+
+  let Constructor;
+  let vm;
+
+  beforeEach(() => {
+    Constructor = Vue.extend(ResearchField);
+    vm = new Constructor().$mount();
+    vm.$data.sharedState.savedData['research_field'] = ['Anthropology']
+    vm.$data.sharedState.allowTabSave = jest.fn((value) => { return false } )
+  })
+
+  afterEach(() => {
+    vm.$destroy()
+  })
+
+  it('renders a select element', () => {
+    expect(vm.$data.researchFields).toContainEqual({"active": true, "id": "Anthropology", "label": "Anthropology"}, {"active": true, "id": "Horticulture", "label": "0237"})
+  })
+})


### PR DESCRIPTION
This commit will display legacy research fields when editing an etd. Since we don't know the label of legacy research data items, we have commented where we supply the item's value for its term.

Connected to #1094 