### PR TITLE
displaying legacy submitting types in edit

### DIFF
--- a/app/javascript/SubmittingType.vue
+++ b/app/javascript/SubmittingType.vue
@@ -34,6 +34,9 @@ export default {
     getSelected(data){
       var selected = this.sharedState.getSubmittingType()
       if (selected !== undefined) {
+        if (this.sharedState.allowTabSave() === false){
+          data.unshift({ "value": selected, "active": true, "label": selected, "selected": "selected"})
+        }
         _.forEach(data, function(o){
           if (o.id == selected){
             o.selected = 'selected'

--- a/app/javascript/test/LegacySubmittingType.spec.js
+++ b/app/javascript/test/LegacySubmittingType.spec.js
@@ -1,0 +1,31 @@
+/* global describe */
+/* global it */
+/* global expect */
+/* global jest */
+
+import { shallowMount } from '@vue/test-utils'
+import SubmittingType from 'SubmittingType'
+import axios from 'axios'
+
+jest.mock('axios')
+
+describe('SubmittingType.vue Display Legacy SubmittingType', () => {
+  const resp = {data: [{'id': 'Honors Thesis', 'label': 'Honors Thesis', 'active': true}]}
+  axios.get.mockResolvedValue(resp)
+
+  beforeEach(() => {
+    const wrapper = shallowMount(SubmittingType, {
+    })
+    wrapper.vm.$data.sharedState.allowTabSave = jest.fn((value) => { return false } )
+    wrapper.vm.$data.sharedState.getSubmittingType = jest.fn((value) => { return 'Major Paper' } )
+    wrapper.vm.$data.submittingTypes = resp.data
+
+  })
+
+  it('renders a select element', () => {
+    const wrapper = shallowMount(SubmittingType, {
+    })
+    wrapper.vm.getSelected(resp.data)
+    expect(resp.data).toContainEqual({"active": true, "label": "Major Paper", "selected": "selected", "value": "Major Paper"})
+  })
+})


### PR DESCRIPTION
This commit will display a legacy submitting type when editing an Etd, if one exists.

Connected to #1094 