### PR TITLE
Display legacy vocab terms for partnering agency and subfields

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -221,7 +221,7 @@ export default {
   // we want to save to the Etd, not the InProgressEtd.
   changeFormMethod() {
     axios.delete(this.sharedState.getUpdateRoute())
-         .then((response) => { 
+         .then((response) => {
                 localStorage.removeItem('school')
                 window.location = '/'
           })
@@ -290,10 +290,10 @@ export default {
     onSubmit (event) {
       this.sharedState.setFormData(event.target)
       if (this.readyForReview()){
-        
+
         this.reviewTabs()
       } else if (this.readyForSubmission()){
-        
+
         this.submitForPublication()
       } else {
         this.saveTab()

--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <label for="department">Department</label>
-    <select name="etd[department]" class="form-control" id="department" v-model="selected" aria-required="true" v-on:change="sharedState.setValid('My Program', false)">
+    <select name="etd[department]" class="form-control" id="department" v-model="selected" aria-required="true" v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
       <option v-for="department in sharedState.departments" v-bind:value="department.label" v-bind:key="department.label">
         {{ department.label }}
       </option>

--- a/app/javascript/PartneringAgency.vue
+++ b/app/javascript/PartneringAgency.vue
@@ -1,19 +1,22 @@
 <template>
 <div>
-  <div v-if="sharedState.getSelectedSchool() === 'rollins'">
+  <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
     <label>Partnering Agency
-    <div v-for="parnterningAgency in sharedState.partneringAgencies.partneringAgencies()">
-    <select name="etd[partnering_agency][]" class="form-control" v-model="parnterningAgency.value">
+    <div v-for="partneringAgency in sharedState.partneringAgencies.partneringAgencies()">
+    <select name="etd[partnering_agency][]" class="form-control" v-model="partneringAgency.value">
+      <option>{{ partneringAgency.value }}</option>
       <option v-for="agency in sharedState.partneringAgencyChoices">
         {{ agency.id }}
       </option>
     </select>
-    <button type="button" class="btn btn-default" @click="sharedState.partneringAgencies.remove(parnterningAgency)">
+    <button type="button" class="btn btn-danger remove-partner" @click="sharedState.partneringAgencies.remove(partneringAgency)">
       <span class="glyphicon glyphicon-trash"></span> Remove This Partnering Agency</button>
     </div>
     </label>
-    <button type="button" class="btn btn-default" @click="sharedState.partneringAgencies.addEmpty()">
+    <div>
+      <button type="button" class="btn btn-default add-partner" @click="sharedState.partneringAgencies.addEmpty()">
       <span class="glyphicon glyphicon-plus"></span> Add Another Partnering Agency</button>
+    </div>
   </div>
   <div v-else>
     <input name="etd[partnering_agency][]" type="hidden" value="No partnering agency." />
@@ -44,6 +47,12 @@ export default {
 </script>
 
 <style>
+.add-partner {
+  margin-top: 1em;
+}
+.remove-partner {
+  margin-bottom: 1em;
+}
 select {
   margin-bottom: 1em;
 }

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -14,6 +14,7 @@ import embargoContents from './config/embargoContents.json'
 import embargoLengths from './config/embargoLengths.json'
 import schools from './config/schools.json'
 import helpText from './config/helpText.json'
+import PartneringAgency from './lib/PartneringAgency';
 
 export const formStore = {
   tabs: {
@@ -386,7 +387,6 @@ export const formStore = {
   loadDepartments () {
     if (this.savedData['department'] !== undefined) {
       var schoolEndpoint = this.schools[this.savedData['school']]
-      
       this.getDepartments(schoolEndpoint)
     }
   },
@@ -400,10 +400,23 @@ export const formStore = {
     this.selectedSubfield = subfield
   },
   getSubfields () {
-    if (this.subfieldEndpoints[this.selectedDepartment]) {
-      axios.get(this.subfieldEndpoints[this.selectedDepartment]).then((response) => {
-        this.subfields = response.data
-      })
+    const dept = this.getSavedOrSelectedDepartment()
+    const endpoints = this.subfieldEndpoints
+    const endpoint = endpoints[dept]
+    if (endpoints[dept] || formStore.subfieldsEdit) {
+      if (!this.allowTabSave()) {
+        axios.get(endpoint).then((response) => {
+          this.clearSubfields()
+          this.subfields = response.data
+          this.subfields.unshift({ 'id': this.savedData['subfield'], 'active': true, 'label': this.savedData['subfield'], 'selected': 'selected' })
+        })
+        return true
+      } else {
+        axios.get(endpoint).then((response) => {
+          this.clearSubfields()
+          this.subfields = response.data
+        })
+      }
     }
   },
   clearSubfields () {

--- a/app/javascript/test/PartneringAgency.spec.js
+++ b/app/javascript/test/PartneringAgency.spec.js
@@ -6,11 +6,14 @@
 import { shallowMount } from '@vue/test-utils'
 import PartneringAgency from 'PartneringAgency'
 
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn((value) =>{ return 'Rollins School of Public Health' })
+
 describe('PartneringAgency.vue', () => {
   const wrapper = shallowMount(PartneringAgency, {
   })
 
   it('has the correct html', () => {
-    expect(wrapper.html()).toContain('<div><div><input name="etd[partnering_agency][]" type="hidden" value="No partnering agency."></div></div>')
+    expect(wrapper.html()).toContain('Add Another Partnering Agency')
   })
 })

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -43,4 +43,10 @@ describe('formStore', () => {
     }
     ])
   })
+
+ it('returns a previously saved subfield the list', () => {
+   formStore.subfieldsEdit = true
+   formStore.allowTabSave = jest.fn(() => { return false })
+   expect(formStore.getSubfields()).toEqual(true)
+ })
 })

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -121,6 +121,7 @@ class InProgressEtd < ApplicationRecord
     new_data['other_copyrights'] = etd.other_copyrights
     new_data['patents'] = etd.patents
     new_data['requires_permissions'] = etd.requires_permissions
+    new_data['partnering_agency'] = etd.partnering_agency
 
     em_type = EmbargoTypeFromAttributes.new(etd.files_embargoed, etd.toc_embargoed, etd.abstract_embargoed)
     new_data['embargo_type'] = em_type.s

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -474,7 +474,9 @@ describe InProgressEtd do
       let(:ipe) { described_class.new(etd_id: etd.id, data: stale_data.to_json) }
 
       it 'replaces the stale data with updated data' do
-        expect(refreshed_data.except('committee_chair_attributes', 'ipe_id', 'etd_id', 'title', 'embargo_type')).to eq new_data.except('committee_chair_attributes', 'title', 'embargo_type')
+        expect(
+          refreshed_data.except('committee_chair_attributes', 'ipe_id', 'etd_id', 'title', 'embargo_type', 'partnering_agency')
+          ).to eq new_data.except('committee_chair_attributes', 'title', 'embargo_type', 'partnering_agency')
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Another University/)
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Merlin/)
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Emory University/)


### PR DESCRIPTION
This commit adds the ability to view legacy terms for
partnering agency and subfields. This follows the same
basic patterns used in the other commits.

This also includes a fix for the InProgressEtd model
which was turning the agency arrays into strings.

Connected to #1094