### PR TITLE
Set visibility on import

### DIFF
--- a/app/lib/importer/migration_mapper.rb
+++ b/app/lib/importer/migration_mapper.rb
@@ -43,7 +43,7 @@ module Importer
        :graduation_year, :keyword, :partnering_agency, :post_graduation_email,
        :research_field, :research_field_id, :school, :subfield,
        :submitting_type, :table_of_contents, :abstract_embargoed,
-       :files_embargoed, :toc_embargoed]
+       :files_embargoed, :toc_embargoed, :visibility]
     end
 
     def supplementary_files
@@ -261,6 +261,10 @@ module Importer
                    .children.to_s
 
       Array.wrap(HtmlSanitizer.sanitize(contents))
+    end
+
+    def visibility
+      Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     class RepositoryObject

--- a/spec/importer/asynchronous_record_importer_spec.rb
+++ b/spec/importer/asynchronous_record_importer_spec.rb
@@ -77,6 +77,13 @@ RSpec.describe Importer::AsynchronousRecordImporter, :clean do
                               'Sectors across Lebanon and Jordan'
       end
 
+      it 'has open visibility' do
+        importer.import(record: record)
+
+        expect(Etd.last.visibility)
+          .to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+
       it 'has a primary file' do
         importer.import(record: record)
 

--- a/spec/importer/migration_mapper_spec.rb
+++ b/spec/importer/migration_mapper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Importer::MigrationMapper do
        :graduation_year, :keyword, :partnering_agency, :post_graduation_email,
        :research_field, :research_field_id, :school, :subfield,
        :submitting_type, :table_of_contents, :abstract_embargoed,
-       :files_embargoed, :toc_embargoed]
+       :files_embargoed, :toc_embargoed, :visibility]
     end
   end
 


### PR DESCRIPTION
We want items to default to "open"/PUBLIC visibility when being
imported. Setting this via the mapper ensures the attributes are present and set
in the importer's custom actor stack.