### PR TITLE
Remove the start over button

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -137,9 +137,6 @@
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
           <input name="request_from_form" type="hidden" value="true" />
           <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-default" autofocus>Save and Continue</button>
-          <div v-if="allowTabSave()">
-            <button id="delete" data-toggle="tooltip" title="This will delete your progress and return you to the home page. You will need to begin the submission process again if you click here!" type="button" @click="changeFormMethod()" class="btn btn-danger">Start Over</button>
-          </div>
         </div>
       </div>
     </form>


### PR DESCRIPTION
This removes the start over button
from the tabs. This is the first part of
#1630.

Connected to #1630