### PR TITLE
Set visibility to open when creating an ETD in the actor stack

### DIFF
--- a/app/actors/hyrax/actors/public_visibility_actor.rb
+++ b/app/actors/hyrax/actors/public_visibility_actor.rb
@@ -1,0 +1,18 @@
+module Hyrax
+  module Actors
+    ##
+    # Sets `env.attributes[:visibility] to
+    # `Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC`
+    # ("open") if a visibility is not already explictly set.
+    #
+    # This actor operates o
+    class PublicVisibilityActor < AbstractActor
+      DEFAULT_VISIBILITY = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+
+      def create(env)
+        (env.attributes[:visibility] ||= DEFAULT_VISIBILITY) &&
+          next_actor.create(env)
+      end
+    end
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -274,4 +274,5 @@ end
 
 Hyrax::CurationConcern.actor_factory.insert_after(Hyrax::Actors::TransactionalRequest, PrimaryFileTitleActor)
 Hyrax::CurationConcern.actor_factory.insert_after(Hyrax::Actors::CreateWithFilesActor, Hyrax::Actors::FileVisibilityAttributesActor)
+Hyrax::CurationConcern.actor_factory.insert_before(Hyrax::Actors::InterpretVisibilityActor, Hyrax::Actors::PublicVisibilityActor)
 Hyrax::CurationConcern.actor_factory.insert_before(Hyrax::Actors::InterpretVisibilityActor, Hyrax::Actors::PregradEmbargo)

--- a/spec/actors/hyrax/actors/public_visibility_actor_spec.rb
+++ b/spec/actors/hyrax/actors/public_visibility_actor_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Hyrax::Actors::PublicVisibilityActor do
+  subject(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+    stack.build(terminator)
+  end
+
+  let(:ability)    { ::Ability.new(FactoryBot.create(:user)) }
+  let(:attributes) { {} }
+  let(:etd)        { FactoryBot.build(:etd, visibility: restricted) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
+
+  let(:open) do
+    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  end
+
+  let(:restricted) do
+    Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+  end
+
+  describe '#create' do
+    it 'sets the work visibility to open' do
+      expect { middleware.create(env) }
+        .to change { env.attributes }
+        .to include visibility: open
+    end
+
+    context 'when the attributes have a visibility' do
+      let(:attributes) { { visibility: restricted } }
+
+      it 'does not change visibility' do
+        expect { middleware.create(env) }
+          .not_to change { env.attributes }
+          .from include visibility: restricted
+      end
+    end
+  end
+end

--- a/spec/actors/stack_spec.rb
+++ b/spec/actors/stack_spec.rb
@@ -26,7 +26,7 @@ describe Hyrax::CurationConcern do
   subject(:actor) { described_class.actor }
 
   let(:ability)    { ::Ability.new(user) }
-  let(:etd)        { FactoryBot.build(:etd) }
+  let(:etd)        { FactoryBot.build(:etd, visibility: 'restricted') }
   let(:terminator) { Hyrax::Actors::Terminator.new }
   let(:user)       { FactoryBot.create(:user) }
   let(:env)        { Hyrax::Actors::Environment.new(etd, ability, attributes) }
@@ -42,6 +42,12 @@ describe Hyrax::CurationConcern do
       expect { actor.create(env) }
         .to change { etd.persisted? }
         .to true
+    end
+
+    it 'sets visibility to open' do
+      expect { actor.create(env) }
+        .to change { etd.visibility }
+        .to Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
     context 'with a requested embargo' do


### PR DESCRIPTION
It looks like this behavior got dropped from our default actor stack when we
moved back to Hyrax's `InterpretVisibilityActor` from our custom one.

This readds the behavior by adding an attribute to the environment if it hasn't
already been passed in. Passing another visibility to the stack avoids setting
to the default.

Connected to #1659 