### PR TITLE
committee_member display in edit bug fix

### DIFF
--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -127,7 +127,7 @@ class InProgressEtd < ApplicationRecord
 
     # This code allows you to display and add chairs and members on the
     # edit form, but not remove them.
-    etd_members = etd.members.map { |chair| JSON.parse(chair.to_json) }.map { |values| { name: values["name"], affiliation: values["affiliation"] } }.uniq
+    etd_members = etd.committee_members.map { |member| JSON.parse(member.to_json) }.map { |values| { name: values["name"], affiliation: values["affiliation"] } }.uniq
 
     members = []
     etd_members.each do |member|


### PR DESCRIPTION
This commit fixes a bug that was preventing the committee member data from being returned to the InProgressEtd edit form.

Connected to #1619 