### PR TITLE
Display the supplemental files on the ETD edit form.  Part of story #1445.

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -56,9 +56,10 @@
     <div v-if="isUploadedFile(getPrimaryFile())">
       <input type="hidden" name="uploaded_files[]" :value="sharedState.files[0][0].id" />
     </div>
-    <!-- TODO: the final param to hyrax needs to be uploaded_files but this name should probly be supp_files-->
-    <div v-if="sharedState.supplementalFiles[0]">
-      <input type="hidden" name="uploaded_files[]" :value="sharedState.supplementalFiles[0].id" />
+    <div v-for="(suppFiles, key) in sharedState.supplementalFiles">
+      <div v-if="isUploadedFile(sharedState.supplementalFiles[key])">
+        <input type="hidden" name="uploaded_files[]" :value="sharedState.supplementalFiles[key].id" />
+      </div>
     </div>
     <section class='errorMessage' v-if="sharedState.hasError('files')">
         <p>{{ sharedState.getErrorMessage('files').files[0] }}</p>
@@ -89,10 +90,10 @@
           <tr v-for="(files, key) in sharedState.supplementalFiles" v-bind:key="key">
             <td><input type="text" :value="files.name" class="form-control" disabled />
             <input type='hidden' :value="files.name" :name="supplementalFileName(key)"></td>
-            <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)"/></td>
-            <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" /></td>
+            <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])"/></td>
+            <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])" /></td>
             <td>
-              <select :name="supplementalFileTypeName(key)" class="form-control file-type" v-on:change="sharedState.setValid('My Files', false)">
+              <select :name="supplementalFileTypeName(key)" class="form-control file-type" v-on:change="sharedState.setValid('My Files', false)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])">
                 <option v-if="getSavedFileType(key)" selected="selected" :value="getSavedFileType(key)">{{getSavedFileType(key)}}</option>
                 <option v-else selected="selected" disabled="disabled">Please select a file type</option>
                 <option>Text</option>

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -68,6 +68,7 @@ export default class SaveAndSubmit {
       axios.post('/concern/etds', savedDataToSubmit)
         .then(response => {
           localStorage.removeItem('school')
+          localStorage.removeItem('files')
           window.location = response.request.responseURL
         })
         .catch(e => {

--- a/app/javascript/SupplementalFileDelete.js
+++ b/app/javascript/SupplementalFileDelete.js
@@ -5,6 +5,7 @@ export default class SupplementalFileDelete extends FileDelete {
     var xhr = new XMLHttpRequest()
     xhr.open('DELETE', this.deleteUrl, true)
     xhr.setRequestHeader('X-CSRF-Token', this.token)
+    xhr.setRequestHeader('Accept', 'application/json')
     xhr.send(null)
 
     const filteredFiles = this.formStore.supplementalFiles.filter(

--- a/app/javascript/test/Files.spec.js
+++ b/app/javascript/test/Files.spec.js
@@ -76,8 +76,7 @@ describe('Files.vue', () => {
     const wrapper = mount(Files, { })
     const fakeFileData = { deleteUrl: '/uploads/123', id: '123_my_super_unique_id' }
     formStore.files = [[fakeFileData]]
-
-    expect(wrapper.html()).toContain('123_my_super_unique_id')
+    expect(wrapper.find('input[name=uploaded_files\\[\\]]').attributes().value).toBe('123_my_super_unique_id')
   })
 
   it('when the file is a ::FileSet, the uploaded_files doesn\'t contain the record ID', () => {
@@ -87,4 +86,25 @@ describe('Files.vue', () => {
 
     expect(wrapper.html()).not.toContain('123_my_super_unique_id')
   })
+
+  it('student can edit metadata fields for newly uploaded files', () => {
+    const wrapper = mount(Files, { })
+    const fakeFileData = { deleteUrl: '/uploads/123', id: '123_my_super_unique_id' }
+    formStore.supplementalFiles = [fakeFileData]
+
+    expect(wrapper.find('input[name=etd\\[supplemental_file_metadata\\]\\[0\\]title]').attributes().disabled).toBe(undefined)
+    expect(wrapper.find('input[name=etd\\[supplemental_file_metadata\\]\\[0\\]description]').attributes().disabled).toBe(undefined)
+    expect(wrapper.find('select[name=etd\\[supplemental_file_metadata\\]\\[0\\]file_type]').attributes().disabled).toBe(undefined)
+  })
+
+  it('student cannot edit metadata fields for previously uploaded files', () => {
+    const wrapper = mount(Files, { })
+    const fakeFileData = { deleteUrl: '/concern/file_sets/123', id: '123_my_super_unique_id' }
+    formStore.supplementalFiles = [fakeFileData]
+
+    expect(wrapper.find('input[name=etd\\[supplemental_file_metadata\\]\\[0\\]title]').attributes().disabled).toBe('disabled')
+    expect(wrapper.find('input[name=etd\\[supplemental_file_metadata\\]\\[0\\]description]').attributes().disabled).toBe('disabled')
+    expect(wrapper.find('select[name=etd\\[supplemental_file_metadata\\]\\[0\\]file_type]').attributes().disabled).toBe('disabled')
+  })
+
 })


### PR DESCRIPTION
When editing an ETD that I have previously submitted, the supplemental
files that I previously attached to my ETD will be displayed on the edit
form, along with the button to add more supplemental files.

There is a 'Remove' button next to each supplemental file in the list,
so I can delete any of the supplemental files.

For supplemental files that were already attached to the ETD, I won't be
able to edit the metadata fields (inputs will be disabled).  But if I
upload a new supplemental file, I can enter metadata for that new file.
(Note: Currently that new metadata won't be persisted when you hit the
submit button.  This is a known problem.  I will follow up later with a
separate PR for that problem.)

Connected to #1445 