### PR TITLE
supplemental data display bug fixes

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -90,10 +90,13 @@
           <tr v-for="(files, key) in sharedState.supplementalFiles" v-bind:key="key">
             <td><input type="text" :value="files.name" class="form-control" disabled />
             <input type='hidden' :value="files.name" :name="supplementalFileName(key)"></td>
-            <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])"/></td>
-            <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])" /></td>
+
+            <td><input :name="supplementalFileTitleName(key)" type="text" class="form-control" :value="getSavedTitle(key)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])" @change="onMetadataChange(key, $event)" /></td>
+
+            <td><input :name="supplementalFileDescriptionName(key)" type="text" class="form-control" :value="getSavedDescription(key)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])" @change="onMetadataChange(key, $event)" /></td>
+
             <td>
-              <select :name="supplementalFileTypeName(key)" class="form-control file-type" v-on:change="sharedState.setValid('My Files', false)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])">
+              <select :name="supplementalFileTypeName(key)" class="form-control file-type" @change="onMetadataChange(key, $event)" :disabled="!isUploadedFile(sharedState.supplementalFiles[key])">
                 <option v-if="getSavedFileType(key)" selected="selected" :value="getSavedFileType(key)">{{getSavedFileType(key)}}</option>
                 <option v-else selected="selected" disabled="disabled">Please select a file type</option>
                 <option>Text</option>
@@ -210,6 +213,10 @@ export default {
       })
       supplementalFileUploader.uploadFile()
     },
+    onMetadataChange(key, e) {
+      var fieldName = e.target.name.replace(`etd[supplemental_file_metadata][${key}]`, '')
+      this.sharedState.setSupplementalFileMetadata(key, fieldName, e.target.value)
+    },
     getFormData() {
       var form = document.getElementById('vue_form')
       var formData = new FormData(form)
@@ -235,7 +242,7 @@ export default {
   },
   boxOAuth(mode) {
     this.sharedState.boxFilePickerMode.setMode(mode)
-    
+
     window.location = this.boxOAuthUrl()
   },
   boxOAuthUrl () {

--- a/app/javascript/SupplementalFileDelete.js
+++ b/app/javascript/SupplementalFileDelete.js
@@ -11,12 +11,9 @@ export default class SupplementalFileDelete extends FileDelete {
     const filteredFiles = this.formStore.supplementalFiles.filter(
       file => file.deleteUrl !== this.deleteUrl
     )
-    const filteredMetadata = this.formStore.supplementalFilesMetadata.filter(
-      file => file.id !== this.id
-    )
 
     this.formStore.supplementalFiles = filteredFiles
-    this.formStore.supplementalFilesMetadata = filteredMetadata
+    this.formStore.supplementalFilesMetadata.splice(key, 1);
     this.formStore.removeSavedSupplementalFile(this.deleteUrl)
     this.formStore.removeSavedSupplementalFileMetadata(key)
   }

--- a/app/javascript/SupplementalFileUploader.js
+++ b/app/javascript/SupplementalFileUploader.js
@@ -20,6 +20,13 @@ export default class SupplementalFileUploader extends FileUploader {
         this.formStore.supplementalFiles.push(
           JSON.parse(xhr.responseText).files[0]
         )
+        this.formStore.supplementalFilesMetadata.push(
+          { filename: JSON.parse(xhr.responseText).files[0]['name'],
+            title: '',
+            description: '',
+            file_type: ''
+          }
+        )
       }
     }
     xhr.send(this.formData)

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -317,7 +317,7 @@ export const formStore = {
   getSavedOrSelectedSchool () {
     if (localStorage.getItem('school')) {
       return localStorage.getItem('school')
-    } 
+    }
     if (this.savedData['school']) {
       return  this.savedData['school']
     } else {
@@ -357,8 +357,6 @@ export const formStore = {
   },
 
   getSavedOrSelectedDepartment () {
-    console.log(this.selectedDepartment)
-    console.log(this.savedData['department'])
     return this.selectedDepartment.length === 0 ? this.savedData['department'] : this.selectedDepartment
   },
 
@@ -388,6 +386,7 @@ export const formStore = {
   loadDepartments () {
     if (this.savedData['department'] !== undefined) {
       var schoolEndpoint = this.schools[this.savedData['school']]
+
       this.getDepartments(schoolEndpoint)
     }
   },
@@ -470,6 +469,11 @@ export const formStore = {
         this.partneringAgencyChoices = response.data
       })
   },
+
+  setSupplementalFileMetadata (key, field, newValue) {
+    this.supplementalFilesMetadata[key][field] = newValue
+  },
+
   addSupplementalFileMetadata () {
     if (this.savedData['supplemental_file_metadata']) {
       // check for duplicates

--- a/app/javascript/test/Files.spec.js
+++ b/app/javascript/test/Files.spec.js
@@ -28,7 +28,7 @@ describe('Files.vue', () => {
   it('checks for some JSON in localStorage files', () => {
     expect(window.localStorage.getItem).toBeCalledWith('files')
   })
-  
+
   it('when primary file is present, it returns primary file', () => {
     const wrapper = shallowMount(Files, { })
     const fakeFileData = { id: 'fake file object' }
@@ -107,4 +107,46 @@ describe('Files.vue', () => {
     expect(wrapper.find('select[name=etd\\[supplemental_file_metadata\\]\\[0\\]file_type]').attributes().disabled).toBe('disabled')
   })
 
+  it('stores supplemental metadata for each file', () => {
+    const wrapper = mount(Files, { })
+    const fakeFileData = { deleteUrl: '/concern/file_sets/abc', id: 'abc_my_super_unique_id' }
+    const moreFakeFileData = { deleteUrl: '/concern/file_sets/def', id: 'def_my_super_unique_id' }
+    formStore.supplementalFiles = [fakeFileData, moreFakeFileData]
+
+    const title = wrapper.find('input[name=etd\\[supplemental_file_metadata\\]\\[0\\]title]')
+
+    title.value = "Great Title"
+    title.trigger('input')
+    title.trigger('keyup.enter')
+
+    wrapper.find('#add-supplemental-file').trigger('click')
+
+    expect(title.value).toBe("Great Title")
+  })
+
+  it('removes supplemental metadata when student removes supplemental file', () => {
+    const mockXHR = {
+      open: jest.fn(),
+      send: jest.fn(),
+      setRequestHeader: jest.fn()
+    }
+    window.XMLHttpRequest = jest.fn(() => mockXHR)
+
+    const wrapper = mount(Files, { })
+    const fakeFileData = { deleteUrl: '/concern/file_sets/abc', id: 'abc_my_super_unique_id' }
+    const moreFakeFileData = { deleteUrl: '/concern/file_sets/def', id: 'def_my_super_unique_id' }
+
+    const supplementalData = {'title': 'One'}
+    const moreSupplementalData = {'title': 'Two'}
+
+    formStore.supplementalFiles = [fakeFileData, moreFakeFileData]
+    formStore.supplementalFilesMetadata = [supplementalData, moreSupplementalData]
+
+    wrapper.vm.deleteSupplementalFile(fakeFileData.deleteUrl, 0)
+    
+    const remainingFiles = formStore.supplementalFiles.length
+    const remainingMetadata = formStore.supplementalFilesMetadata.length
+    expect(remainingFiles).toEqual(1)
+    expect(remainingMetadata).toEqual(1)
+  })
 })


### PR DESCRIPTION
This commit ensures the supplemental files metadata is preserved and displayed when students add and remove files.

Connected to #1634 