### PR TITLE
Don't show cached file name on edit screen

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -147,9 +147,11 @@ export default {
     }
   },
   created() {
-    if (localStorage.getItem('files')) {
-      this.sharedState.files = [[JSON.parse(localStorage.getItem('files')).files[0]]]
-    }
+     if (formStore.allowTabSave()) {
+     if (localStorage.getItem('files')) {
+        this.sharedState.files = [[JSON.parse(localStorage.getItem('files')).files[0]]]
+      }
+     }
   },
   mounted () {
     var folderId = '0'

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -67,8 +67,7 @@ export default class SaveAndSubmit {
 
       axios.post('/concern/etds', savedDataToSubmit)
         .then(response => {
-          localStorage.removeItem('school')
-          localStorage.removeItem('files')
+          localStorage.clear()
           window.location = response.request.responseURL
         })
         .catch(e => {
@@ -94,6 +93,7 @@ export default class SaveAndSubmit {
     xhr.onreadystatechange = () => {
       if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status === 200) {
+          localStorage.clear()  
           window.location = JSON.parse(xhr.response).redirectPath
         } else {
          formStore.failedSubmission = true

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -13,7 +13,9 @@
         <div class="no-edit-school-name well">
           <b>{{ this.sharedState.getSchoolText(this.sharedState.getSavedOrSelectedSchool()) }}</b>
         </div>
-        <button type="button" class="start-over-button btn btn-danger btn-xs" @click="sharedState.showStartOver = true">Start Over With a New School</button>
+        <div v-if="this.sharedState.allowTabSave()">
+          <button type="button" class="start-over-button btn btn-danger btn-xs" @click="sharedState.showStartOver = true">Start Over With a New School</button>
+        </div>
       </div>
     </div>
     <start-over-modal></start-over-modal>

--- a/app/javascript/components/StartOverModal.vue
+++ b/app/javascript/components/StartOverModal.vue
@@ -43,12 +43,11 @@ export default {
       axios
         .delete(this.sharedState.getUpdateRoute())
         .then(response => {
-          console.log(this.sharedState.getUpdateRoute())
-          localStorage.removeItem("school")
+          localStorage.clear()
           window.location = "/"
         })
         .catch(() => {
-          localStorage.removeItem("school")
+          localStorage.clear()
           window.location = "/"
         })
     }

--- a/app/javascript/test/FileDelete.spec.js
+++ b/app/javascript/test/FileDelete.spec.js
@@ -13,7 +13,8 @@ const mockXHR = {
 
 window.XMLHttpRequest = jest.fn(() => mockXHR)
 window.localStorage = jest.fn()
-window.localStorage.removeItem = jest.fn((value) => { return value})
+window.localStorage.clear = jest.fn(() => { return ''})
+window.localStorage.removeItem = jest.fn((value) => { return '' })
 describe('FileDelete', () => {
 
   it('makes an HTTP requst and remove the file from the state', () => {

--- a/app/javascript/test/School.spec.js
+++ b/app/javascript/test/School.spec.js
@@ -33,4 +33,16 @@ describe('School.vue', () => {
     expect(wrapper.html()).not.toContain('<select')
     expect(wrapper.html()).toContain(`Candler School of Theology`)
   })
+
+  it('does not let you change in the edit screen', () => {
+    formStore.savedData.school = 'candler'
+
+    const wrapper = mount(School, {
+    })
+  
+    formStore.allowTabSave = jest.fn(() => {return false})
+    wrapper.vm.$data.sharedState.schools.options = [{"text":"Select a School","value":"","disabled":"disabled","selected":"selected"},{"text":"Candler School of Theology","value":"candler"},{"text":"Emory College","value":"emory"},{"text":"Laney Graduate School","value":"laney"},{"text":"Rollins School of Public Health","value":"rollins"}]
+    expect(wrapper.html()).not.toContain('<button')
+    expect(wrapper.html()).toContain(`Candler School of Theology`)
+  })
 })


### PR DESCRIPTION
This does additional clear when saving works so that
cached file information is not persisted when it shouldn't be.

This also includes a fix for the start over button showing up the
edit screen.

Connected to #1642
Connected to #1667
Connected to #1631