### PR TITLE
Initial work on members/chairs for editing

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -77,6 +77,8 @@ module Hyrax
       end
 
       if params['request_from_form'] == 'true'
+        reset_committee_chairs
+        reset_committee_members
         update_with_response_for_form
       else
         super
@@ -260,6 +262,26 @@ module Hyrax
     end
 
     private
+
+        def reset_committee_chairs
+          return unless params['request_from_form']
+          etd = Etd.find(params['id'])
+          etd.committee_chair = []
+          etd.committee_chair_attributes = []
+          etd.committee_chair_name = []
+          etd.save!
+          etd.reload
+        end
+
+        def reset_committee_members
+          return unless params['request_from_form']
+          etd = Etd.find(params['id'])
+          etd.committee_members = []
+          etd.committee_members_attributes = []
+          etd.committee_members_names= []
+          etd.save!
+          etd.reload
+      end
 
       def translate_embargo_string(params)
         return unless params['etd']['embargo_type']

--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -263,24 +263,24 @@ module Hyrax
 
     private
 
-        def reset_committee_chairs
-          return unless params['request_from_form']
-          etd = Etd.find(params['id'])
-          etd.committee_chair = []
-          etd.committee_chair_attributes = []
-          etd.committee_chair_name = []
-          etd.save!
-          etd.reload
-        end
+      def reset_committee_chairs
+        return unless params['request_from_form']
+        etd = Etd.find(params['id'])
+        etd.committee_chair = []
+        etd.committee_chair_attributes = []
+        etd.committee_chair_name = []
+        etd.save!
+        etd.reload
+      end
 
-        def reset_committee_members
-          return unless params['request_from_form']
-          etd = Etd.find(params['id'])
-          etd.committee_members = []
-          etd.committee_members_attributes = []
-          etd.committee_members_names= []
-          etd.save!
-          etd.reload
+      def reset_committee_members
+        return unless params['request_from_form']
+        etd = Etd.find(params['id'])
+        etd.committee_members = []
+        etd.committee_members_attributes = []
+        etd.committee_members_names = []
+        etd.save!
+        etd.reload
       end
 
       def translate_embargo_string(params)

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -132,10 +132,10 @@ class InProgressEtd < ApplicationRecord
 
     members = []
     etd_members.each do |member|
-      if member[:affiliation] != 'Emory University'
+      if member[:affiliation] != ['Emory University']
         members.push(name: member[:name], affiliation: member[:affiliation], affiliation_type: 'Non-Emory')
       end
-      if member[:affiliation] == 'Emory University'
+      if member[:affiliation] == ['Emory University']
         members.push(name: member[:name], affiliation: member[:affiliation], affiliation_type: 'Emory University')
       end
     end


### PR DESCRIPTION
The committee chairs/members aren't updating
correctly. When updating an Etd this commit
should remove any existing members/chairs
and replace them with whatever is in your update
submission.

Before members/chairs where never being deleted
but appended to on each update so you would have
many duplicates. Whenever I run this code it seems
like sometimes the update hasn't been indexed
correctly because the members don't show up on
show page, but are present on the `Etd` object.

Connected to #1675
Connected to #1616