### PR TITLE
Fix for for edit form submission on Safari

### DIFF
--- a/app/javascript/lib/formDataNoBlankFiles.js
+++ b/app/javascript/lib/formDataNoBlankFiles.js
@@ -1,0 +1,19 @@
+/**
+ * Safari 11 has a bug where form submission requests are not made if
+ * there are file elements with no values. This function removes any
+ * blank elements from the FormData.
+ *
+ *  See https://bugs.webkit.org/show_bug.cgi?id=184490
+ */
+export function formDataNoBlankFiles(formElementId) {
+  const formElements = document.getElementById(formElementId)
+  const fd = new FormData()
+  for (let e of formElements.elements) {
+    if (e.name === 'primary_files[]' && e.value === '') {
+    } else if (e.name === 'supplemental_files[]' && e.value === '') {
+    } else {
+      fd.set(e.name, e.value)
+    }
+  }
+  return fd
+}

--- a/app/javascript/packs/root.js
+++ b/app/javascript/packs/root.js
@@ -1,4 +1,5 @@
 import 'babel-polyfill'
+import 'formdata-polyfill'
 import TurbolinksAdapter from 'vue-turbolinks'
 import Vue from 'vue/dist/vue.esm'
 import App from '../App'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "caniuse-lite": "^1.0.30000865",
     "css-loader": "^1.0.0",
     "eslint": "^5.0.1",
+    "formdata-polyfill": "^3.0.11",
     "lodash": "^4.17.10",
     "vue": "^2.5.16",
     "vue-axios": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,6 +2823,10 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
+formdata-polyfill@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-3.0.11.tgz#c82b4b4bea3356c0a6752219e54ce1edb2a7fb5b"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"


### PR DESCRIPTION
Safari has a known bug in version 11 that needs
to be coded around for our form submissions. This
commit adds a function that will remove blank file
form submissions that cause the request to not be made in Safari 11. This will only be run when the user is using Safari 11.

Adds a FormData polyfill for better Safari compatibilty.

Connected to #1674