### PR TITLE
Do not allow unauthorized users to load edit form

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -15,10 +15,16 @@ class InProgressEtdsController < ApplicationController
   # Note: There is no 'create' action because the 'new' action does 'find or create'.
 
   def edit
-    @in_progress_etd = InProgressEtd.find(params[:id])
-    authorize! :update, @in_progress_etd
-    @in_progress_etd.refresh_from_etd!
-    @data = @in_progress_etd.data
+    if current_user.nil?
+      redirect_to new_user_session_path
+    else
+      @in_progress_etd = InProgressEtd.find(params[:id])
+      authorize! :update, @in_progress_etd
+      @in_progress_etd.refresh_from_etd!
+      @data = @in_progress_etd.data
+    end
+  rescue ActiveRecord::RecordNotFound
+    redirect_to root_url
   end
 
   # The Vue.js form uses this action to update the record.

--- a/spec/factories/in_progress_etds.rb
+++ b/spec/factories/in_progress_etds.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     email "miranda@graduated.net"
     graduation_date "Summer 2020"
     submission_type "Master's Thesis"
+    user_ppid "0001"
   end
 end

--- a/spec/features/edit_in_progress_etd_spec.rb
+++ b/spec/features/edit_in_progress_etd_spec.rb
@@ -1,0 +1,31 @@
+# Generated via `rails generate hyrax:work Etd`
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+RSpec.feature 'Edit an existing ETD', :clean, :new_ui, integration: true do
+  context "no unauthorized users can see a student's in progress ETD" do
+    let(:ipe) { FactoryBot.create(:in_progress_etd, user_ppid: depositor.ppid) }
+    let(:depositor) { FactoryBot.create(:user) }
+    let(:another_user) { FactoryBot.create(:user) }
+
+    # An unauthenticated user should never be able to access
+    # an edit form
+    scenario "unauthenticated user visits edit form" do
+      visit "/in_progress_etds/#{ipe.id}/edit"
+      expect(current_url).to eq "#{new_user_session_url}?locale=en"
+    end
+    scenario "a user visits some else's edit form" do
+      login_as another_user
+      visit "/in_progress_etds/#{ipe.id}/edit"
+      expect(page).to have_content "Unauthorized"
+    end
+    # No one should be able to fish around for id numbers of
+    # in progress ETDs
+    scenario "a user visits a nonexistent edit form" do
+      login_as another_user
+      visit "/in_progress_etds/9999/edit"
+      expect(current_url).to eq "#{root_url}?locale=en"
+    end
+  end
+end


### PR DESCRIPTION
Previously, unauthenticated users could load an edit
form, but they couldn't submit it.
This adds an extra layer of security to ensure that
unauthenticated users who attempt to load an edit
form for an in progress ETD are redirected to the
main page.
Authenticated users who attempt to load an edit form
that isn't theirs were already getting an "Unauthorized"
message, and this behavior has been left the same.
Authenticated users who attempt to load an edit
form for a nonexistent in progress ETD are also
redirected to the main page to prevent exceptions
being thrown.

Fixes #1639 