### PR TITLE
Handle 1.x style visibility settings

### DIFF
--- a/app/services/visibility_translator.rb
+++ b/app/services/visibility_translator.rb
@@ -32,10 +32,15 @@ class VisibilityTranslator
     new(obj: obj).visibility
   end
 
+  # There are visibility bugs caused by setting the value of obj.abstract_embargoed
+  # to "true" (a String) instead of true (a Boolean). This is only true for works
+  # created in Hyrax 1.x, but it's enough of our content under management that we need
+  # to account for it.
+  # When checking whether a value is true, check whether it has a "true" string too.
   def visibility
     return proxy.visibility if obj.hidden? || !obj.under_embargo?
-    return ALL_EMBARGOED    if obj.abstract_embargoed
-    return TOC_EMBARGOED    if obj.toc_embargoed
+    return ALL_EMBARGOED    if obj.abstract_embargoed.to_s == "true"
+    return TOC_EMBARGOED    if obj.toc_embargoed.to_s == "true"
 
     FILES_EMBARGOED
   end


### PR DESCRIPTION
In Laevigata 1.x, many objects have their
embargo type set with "true" (a String)
instead of true (a Boolean). When determining
visibility, we need to take this into account.

I can't figure out how to write a test for this because in Laevigata 2.x it 
is impossible to create an object with these mis-matched visibility settings
(as it should be). 

Fixes #1681 