### PR TITLE
Remove unused show actions

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -6,39 +6,6 @@
   <% if presenter.editor? %>
     <%= etd_edit_link(presenter) %>
     <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete %>
-    <% if presenter.member_presenters.size > 1 %>
-      <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-default' %>
-    <% end %>
-    <% if presenter.valid_child_concerns.length > 0 %>
-      <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Attach Child <span class="caret"></span>
-        </button>
-
-        <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
-        <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
-          class: 'btn btn-default submits-batches submits-batches-add',
-          data: { toggle: "modal", target: "#collection-list-container" } %>
-
-        <ul class="dropdown-menu">
-          <% presenter.valid_child_concerns.each do |concern| %>
-            <li>
-              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular], parent_id: presenter.id) %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-  <% end %>
-
-  <% if presenter.work_featurable? %>
-    <%= link_to "Feature", hyrax.featured_work_path(presenter, format: :json),
-      data: { behavior: 'feature' },
-      class: presenter.display_unfeature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
-
-    <%= link_to "Unfeature", hyrax.featured_work_path(presenter, format: :json),
-      data: { behavior: 'unfeature' },
-      class: presenter.display_feature_link? ? 'btn btn-default collapse' : 'btn btn-default' %>
   <% end %>
 </div>
 
@@ -46,4 +13,3 @@
 <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
 <!-- Render Modals -->
 <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>
-


### PR DESCRIPTION
Do not give the user buttons for actions we
don't want them clicking.
Remove Add to Collection, Add Child Work, etc.

Per request from Mark

![remove_show_actions](https://user-images.githubusercontent.com/65608/44310964-4eb5b100-a3ad-11e8-8076-92f89a69543c.png)
