### PR TITLE
Fix departments after refresh

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -384,11 +384,8 @@ export const formStore = {
     }
   },
   loadDepartments () {
-    if (this.savedData['department'] !== undefined) {
-      var schoolEndpoint = this.schools[this.savedData['school']]
-
-      this.getDepartments(schoolEndpoint)
-    }
+    var schoolEndpoint = this.schools[this.getSavedOrSelectedSchool()]
+    this.getDepartments(schoolEndpoint)
   },
   getSelectedSubfield () {
     if (this.selectedSubfield === undefined) {

--- a/app/javascript/test/Department.spec.js
+++ b/app/javascript/test/Department.spec.js
@@ -13,13 +13,15 @@ window.localStorage.getItem = jest.fn()
 window.localStorage.setItem = jest.fn()
 
 formStore.departments = [{"id":"Divinity","label":"Divinity","active":true},{"id":"Ministry","label":"Ministry","active":true},{"id":"Pastoral Counseling","label":"Pastoral Counseling","active":true},{"id":"Theological Studies","label":"Theological Studies","active":true}]
+const resp =  [{"id":"Divinity","label":"Divinity","active":true},{"id":"Ministry","label":"Ministry","active":true},{"id":"Pastoral Counseling","label":"Pastoral Counseling","active":true},{"id":"Theological Studies","label":"Theological Studies","active":true}]
+axios.get.mockResolvedValue(resp)
 formStore.getSavedOrSelectedDepartment = () => { return 'Divinity' }
 describe('Department.vue', () => {
   it('it restores the correct value', () => {
     const wrapper = mount(Department, {
     })
+    wrapper.vm.$data.school = "Candler School of Theology"
     wrapper.vm.$data.selected = formStore.getSavedOrSelectedDepartment()
-    
     expect(wrapper.html()).toContain('Divinity')
   })
 })


### PR DESCRIPTION
This fixes an issue where the deptartments
dropdown is blank when you are on the tab
and refresh.

Connected to #1668