### PR TITLE
Fix for partnering agencies

### DIFF
--- a/app/javascript/PartneringAgency.vue
+++ b/app/javascript/PartneringAgency.vue
@@ -2,7 +2,11 @@
 <div>
   <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
     <label>Partnering Agency
+    <div  v-if="sharedState.partneringAgencies.partneringAgencies()">
+      <input name="etd[partnering_agency][]" type="hidden" value="No partnering agency." />
+    </div>
     <div class="agency-container" v-for="partneringAgency in sharedState.partneringAgencies.partneringAgencies()">
+    <div v-if="partneringAgency.value != 'No partnering agency.'">
     <select name="etd[partnering_agency][]" class="form-control" v-model="partneringAgency.value">
       <option>{{ partneringAgency.value }}</option>
       <option v-for="agency in sharedState.partneringAgencyChoices">
@@ -11,6 +15,7 @@
     </select>
     <button type="button" class="btn btn-danger remove-partner agency-remove" @click="sharedState.partneringAgencies.remove(partneringAgency)">
       <span class="glyphicon glyphicon-trash"></span> Remove This Partnering Agency</button>
+    </div>
     </div>
     </label>
     <div>
@@ -21,7 +26,7 @@
   <div v-else>
     <input name="etd[partnering_agency][]" type="hidden" value="No partnering agency." />
   </div>
-  </div>
+</div>
 </template>
 
 <script>

--- a/app/javascript/test/PartneringAgency.spec.js
+++ b/app/javascript/test/PartneringAgency.spec.js
@@ -5,9 +5,11 @@
 
 import { shallowMount } from '@vue/test-utils'
 import PartneringAgency from 'PartneringAgency'
+import { formStore } from '../formStore'
 
 window.localStorage = jest.fn()
 window.localStorage.getItem = jest.fn((value) =>{ return 'Rollins School of Public Health' })
+formStore.partneringAgencies.partneringAgencies = jest.fn(() => { return true })
 
 describe('PartneringAgency.vue', () => {
   const wrapper = shallowMount(PartneringAgency, {
@@ -15,5 +17,9 @@ describe('PartneringAgency.vue', () => {
 
   it('has the correct html', () => {
     expect(wrapper.html()).toContain('Add Another Partnering Agency')
+  })
+
+  it('has a hidden input in nothing is seleceted', () => {
+    expect(wrapper.html()).toContain('hidden')
   })
 })


### PR DESCRIPTION
This is a fix for not being able to continue the form without entering
a parterning agency.

Partnering agencies are required on the server and this was returning an
an error if you didn't pick one for Rollins. On the other
tabs we have a hidden input for no agency. This changes the agency
component a little bit so that users can't end up not progressing if they
don't enter an agency for rollins.

Connected to #1709