### PR TITLE
Fix for missing submission button

### DIFF
--- a/app/javascript/components/submit/FinalSubmission.vue
+++ b/app/javascript/components/submit/FinalSubmission.vue
@@ -1,8 +1,6 @@
 <template>
   <div>
-    <div v-if="sharedState.getUserAgreement()">   
-      <input v-if="!sharedState.submitted" type="button" class="btn btn-primary" value="Submit Your Thesis or Dissertation" @click="sharedState.submit()"/>
-    </div>
+    <input v-if="!sharedState.submitted" :disabled="!sharedState.getUserAgreement()" type="button" class="btn btn-primary" value="Submit Your Thesis or Dissertation" @click="sharedState.submit()"/>
     <div v-if="sharedState.submitted && !sharedState.failedSubmission">
       <div class="alert alert-info">
         <span class="glyphicon glyphicon-info-sign"></span>

--- a/app/javascript/components/submit/UserAgreement.vue
+++ b/app/javascript/components/submit/UserAgreement.vue
@@ -10,7 +10,7 @@
     </p>
     <div class="well">
       <label class="form-inline">
-        <input type="checkbox" @change="sharedState.setUserAgreement()" />
+        <input type="checkbox" v-model="checked" @change="sharedState.setUserAgreement()" />
          I HAVE READ AND AGREE TO THE SUBMISSION AGREEMENT
      </label>
     </div>
@@ -27,11 +27,15 @@ import FinalSubmission from './FinalSubmission'
 export default {
   data() {
     return {
+      checked: formStore.getUserAgreement(),
       sharedState: formStore
     }
   },
   components: { 
     finalSubmission: FinalSubmission
+  },
+  mounted() {
+
   }
 }
 </script>

--- a/app/javascript/test/components/submit/FinalSubmission.spec.js
+++ b/app/javascript/test/components/submit/FinalSubmission.spec.js
@@ -5,11 +5,20 @@ import { shallowMount } from '@vue/test-utils'
 import FinalSubmission from '../../../components/submit/FinalSubmission'
 import { formStore } from '../../../formStore'
 
+formStore.getUserAgreement = jest.fn(() => { return false })
+
 describe('FinalSubmission.vue', () => {
   it('has the correct label', () => {
     formStore.agreement = true
     const wrapper = shallowMount(FinalSubmission, {
     })
     expect(wrapper.html()).toContain('Submit Your Thesis or Dissertation')
+  })
+
+  it('has the correct label', () => {
+    formStore.agreement = false
+    const wrapper = shallowMount(FinalSubmission, {
+    })
+    expect(wrapper.html()).toContain('disabled')
   })
 })


### PR DESCRIPTION
This commit retains whatever you have checked the agreement checkbox
as you click around. If a user
refreshes, they will need to check the box again.

The button is disabled now instead of being hidden.

It's no longer possible to end up in a state where the checkbox is out of sync with the button.

Connected to #1687