### PR TITLE
Don't require user agreement on edit screen

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -460,7 +460,11 @@ export const formStore = {
     this.agreement = !this.agreement
   },
   getUserAgreement () {
-    return this.agreement
+    if (!this.allowTabSave()) {
+      return true
+    } else {
+      return this.agreement
+    }
   },
   getPartneringChoices () {
     axios.get('/authorities/terms/local/partnering_agencies')

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -44,13 +44,14 @@ describe('formStore', () => {
     ])
   })
 
- it('returns a previously saved subfield the list', () => {
-   formStore.subfieldsEdit = true
-   formStore.allowTabSave = jest.fn(() => { return false })
-   expect(formStore.getSubfields()).toEqual(true)
- })
+  it('returns a previously saved subfield the list', () => {
+    formStore.subfieldsEdit = true
+    formStore.allowTabSave = jest.fn(() => { return false })
+    expect(formStore.getSubfields()).toEqual(true)
+  })
 
-  it('returns files_embargoed as the default type', () => {
-    expect(formStore.getSelectedEmbargoContents()).toEqual('files_embargoed')
+  it('returns true for user agreement when on the edit form', () => {
+    formStore.allowTabSave = jest.fn(() => { return false })
+    expect(formStore.getUserAgreement()).toEqual(true)
   })
 })


### PR DESCRIPTION
This commit will prefill the checkbox on the edit screen
so those editing it don't need to check it again.

Connected to #1688