### PR TITLE
Return files as the default embargo type

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -340,9 +340,10 @@ export const formStore = {
   getSelectedEmbargoContents () {
     if (this.selectedEmbargoContents) {
       return this.selectedEmbargoContents
-    }
-    if (this.savedData['embargo_type']) {
+    } else if (this.savedData['embargo_type']) {
       return this.savedData['embargo_type']
+    } else {
+      return 'files_embargoed'
     }
   },
   getSavedSchool () {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -49,4 +49,8 @@ describe('formStore', () => {
    formStore.allowTabSave = jest.fn(() => { return false })
    expect(formStore.getSubfields()).toEqual(true)
  })
+
+  it('returns files_embargoed as the default type', () => {
+    expect(formStore.getSelectedEmbargoContents()).toEqual('files_embargoed')
+  })
 })


### PR DESCRIPTION
This removes the blank option in the embargo type
dropdown and selects the first option, 'Files', by default.

Connected to #1683