### PR TITLE
manage no partnering agency

### DIFF
--- a/app/javascript/PartneringAgency.vue
+++ b/app/javascript/PartneringAgency.vue
@@ -3,10 +3,10 @@
   <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
     <label>Partnering Agency
     <div  v-if="sharedState.partneringAgencies.partneringAgencies()">
-      <input name="etd[partnering_agency][]" type="hidden" value="No partnering agency." />
+      <input name="etd[partnering_agency][]" type="hidden" value="Does not apply (no collaborating organization)" />
     </div>
     <div class="agency-container" v-for="partneringAgency in sharedState.partneringAgencies.partneringAgencies()">
-    <div v-if="partneringAgency.value != 'No partnering agency.'">
+    <div v-if="partneringAgency.value != 'Does not apply (no collaborating organization)'">
     <select name="etd[partnering_agency][]" class="form-control" v-model="partneringAgency.value">
       <option>{{ partneringAgency.value }}</option>
       <option v-for="agency in sharedState.partneringAgencyChoices">
@@ -24,7 +24,7 @@
     </div>
   </div>
   <div v-else>
-    <input name="etd[partnering_agency][]" type="hidden" value="No partnering agency." />
+    <input name="etd[partnering_agency][]" type="hidden" value="Does not apply (no collaborating organization)" />
   </div>
 </div>
 </template>

--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -9,7 +9,7 @@
     </div>
     <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
       <h5>Partnering Agencies</h5>
-      <div> {{ sharedState.savedData['partnering_agency'].join(', ') }} </div>
+      <div> {{ managePartneringAgency() }} </div>
     </div>
     <h5>Degree</h5>
     <div> {{ sharedState.getSavedDegree() }} </div>
@@ -26,6 +26,24 @@ export default {
   data() {
     return {
       sharedState: formStore
+    }
+  },
+  methods: {
+    managePartneringAgency: function(){
+      // if there is anything besides 'does not apply', remove 'does not apply'
+      let agencies = ''
+      if (this.sharedState.savedData['partnering_agency'].length >= 2) {
+
+        const validPartneringAgency =   this.sharedState.savedData['partnering_agency'].filter(
+          item => item != "Does not apply (no collaborating organization)")
+
+        if (validPartneringAgency) {
+          agencies = validPartneringAgency.join(', ')
+        }
+      } else {
+        agencies = this.sharedState.savedData['partnering_agency'].join(', ')
+      }
+      return agencies
     }
   }
 }

--- a/app/javascript/test/components/submit/MyProgram.spec.js
+++ b/app/javascript/test/components/submit/MyProgram.spec.js
@@ -8,12 +8,15 @@ import { formStore } from '../../../formStore'
 
 window.localStorage = jest.fn()
 window.localStorage.getItem = jest.fn((value) =>{ return 'Rollins School of Public Health' })
-formStore.savedData['partnering_agency'] = ['CDC']
+formStore.savedData['partnering_agency'] = ['CDC', 'Does not apply (no collaborating organization)']
 
 describe('MyProgram.vue', () => {
   it('has the correct label', () => {
     const wrapper = shallowMount(MyProgram, {
     })
+    wrapper.vm.managePartneringAgency()
+
     expect(wrapper.html()).toContain('My Program')
+    expect(wrapper.html()).not.toContain('Does not apply (no collaborating organization)')
   })
 })

--- a/app/javascript/test/components/submit/MyProgramNoAgencies.spec.js
+++ b/app/javascript/test/components/submit/MyProgramNoAgencies.spec.js
@@ -1,0 +1,23 @@
+/* global describe */
+/* global it */
+/* global expect */
+import Vue from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import MyProgram from '../../../components/submit/MyProgram'
+import { formStore } from '../../../formStore'
+
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn((value) =>{ return 'Rollins School of Public Health' })
+formStore.savedData['partnering_agency'] = ['Does not apply (no collaborating organization)']
+
+describe('MyProgram.vue with no agencies', () => {
+
+  it('has the correct label', () => {
+    const wrapper = shallowMount(MyProgram, {
+    })
+    wrapper.vm.managePartneringAgency()
+
+    expect(wrapper.html()).toContain('Does not apply (no collaborating organization)')
+  })
+
+})


### PR DESCRIPTION
This commit changes the value submitted to an InProgressEtd for a Partnering Agency, in the case of not selecting a Partnering Agency, to the vocab string currently used for this case ('Does not apply (no collaborating organization)'). It also removes the string from display on the review tab when there are Partnering Agencies being submitted. Fixes #1703 