### PR TITLE
Edit or remove committee members. Connected to stories #1616 and #1675.

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -77,6 +77,8 @@ module Hyrax
       end
 
       if params['request_from_form'] == 'true'
+        curation_concern.committee_chair = nil
+        curation_concern.committee_members = nil
         update_with_response_for_form
       else
         super

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -209,12 +209,10 @@ class Etd < ActiveFedora::Base
   end
 
   def index_committee_chair_name
-    return unless committee_chair && committee_chair.first
     self.committee_chair_name = committee_chair.map(&:name_and_affiliation)
   end
 
   def index_committee_members_names
-    return unless committee_members && committee_members.first
     self.committee_members_names = committee_members.map(&:name_and_affiliation)
   end
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -192,6 +192,22 @@ RSpec.describe Etd do
       etd.reload # Make sure the new data is persisted
       expect(etd.committee_chair_name).to contain_exactly('New Name, Emory University')
     end
+
+    it "updates committee_members_names when committee members are deleted" do
+      expect(etd.committee_members_names).to contain_exactly("Manns, Joseph, Emory University", "Craighead, W Edward, Emory University")
+      etd.committee_members = nil
+      etd.save!
+      etd.reload # Make sure the new data is persisted
+      expect(etd.committee_members_names).to eq []
+    end
+
+    it "updates committee_chair_name when committee chairs are deleted" do
+      expect(etd.committee_chair_name).to eq ['Treadway, Michael T, Emory University']
+      etd.committee_chair = nil
+      etd.save!
+      etd.reload # Make sure the new data is persisted
+      expect(etd.committee_chair_name).to eq []
+    end
   end
 
   context "committee members" do


### PR DESCRIPTION
I cleared the committee members and chairs before passing the new params
from the form to the actor.

I fixed the methods that keep the committee_chair_name and
committee_members_names in sync with the committee_chair and
committee_members fields.