### PR TITLE
Infer Emory affilliation for committee members & chairs in migration

### DIFF
--- a/app/lib/importer/migration_mapper.rb
+++ b/app/lib/importer/migration_mapper.rb
@@ -124,6 +124,7 @@ module Importer
         attrs[count] = {}
         attrs[count][:netid]       = [member.attribute('ID')&.value].compact
         attrs[count][:affiliation] = member.xpath('./mods:affiliation').map(&:content)
+        attrs[count][:affiliation] = ['Emory University'] if attrs[count][:affiliation].empty?
         attrs[count][:name]        = member.xpath('./mods:displayForm')
                                        .map(&:content).reject { |name| name == ', ' }
         count += 1
@@ -137,6 +138,7 @@ module Importer
         attrs[count] = {}
         attrs[count][:netid]       = [member.attribute('ID')&.value].compact
         attrs[count][:affiliation] = member.xpath('./mods:affiliation').map(&:content)
+        attrs[count][:affiliation] = ['Emory University'] if attrs[count][:affiliation].empty?
         attrs[count][:name]        = member.xpath('./mods:displayForm')
                                        .map(&:content).reject { |name| name == ', ' }
         count += 1

--- a/spec/importer/migration_mapper_spec.rb
+++ b/spec/importer/migration_mapper_spec.rb
@@ -89,11 +89,21 @@ RSpec.describe Importer::MigrationMapper do
       expect(mapper.committee_chair_attributes[0][:name])
         .to contain_exactly 'Conner, Richard'
     end
+
+    it 'has emory affiliation' do
+      expect(mapper.committee_chair_attributes[0][:affiliation])
+        .to contain_exactly 'Emory University'
+    end
   end
 
   describe '#committee_members_attributes' do
     it 'adds all committee members' do
       expect(mapper.committee_members_attributes.count).to eq 4
+    end
+
+    it 'has emory affiliation' do
+      expect(mapper.committee_members_attributes[0][:affiliation])
+        .to contain_exactly 'Emory University'
     end
   end
 


### PR DESCRIPTION
Committee members with no affiliation in legacy are to be inferred as Emory
affiliated. This hard codes that information into the mapper. 

Connected to #1734.