### PR TITLE
On the ETD edit form, separate the display names on the tabs from the tab label.

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -4,7 +4,7 @@
       <h1>Submit Your Thesis or Dissertation</h1>
     <ul class="nav navtabs" v-if="allowTabSave()">
       <li v-for="(value, index) in sharedState.tabs" v-bind:key="index">
-        <button type="button" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.label }}
+        <button type="button" class="tab" v-bind:class="{ disabled: value.disabled }" v-on:click="setCurrentStep(value.label, $event)">{{ value.displayName || value.label }}
          <i class="fa fa-check-circle" aria-hidden="true" v-if="sharedState.isValid(index)" ></i>
         </button>
       </li>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -63,7 +63,8 @@ export const formStore = {
       }
     },
     my_etd: {
-      label: 'My ETD',
+      label: 'My Etd',
+      displayName: 'My ETD',
       help_text: helpText.myEtd,
       disabled: true,
       valid: '',

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -11,6 +11,22 @@ window.localStorage.setItem = jest.fn()
 formStore.getSavedOrSelectedSchool = jest.fn(() => {return 'Emory College'})
 describe('formStore', () => {
 
+  // If you change a tab's label, make sure to find
+  // all the places in the code (both front-end and
+  // back-end) that use that label.  If you just want
+  // to change the text on a tab, don't change the
+  // label, use displayName instead.
+  it('has correct labels', () => {
+    expect(formStore.tabs.about_me.label).toEqual('About Me')
+    expect(formStore.tabs.my_program.label).toEqual('My Program')
+    expect(formStore.tabs.my_advisor.label).toEqual('My Advisor')
+    expect(formStore.tabs.my_etd.label).toEqual('My Etd')
+    expect(formStore.tabs.keywords.label).toEqual('Keywords')
+    expect(formStore.tabs.my_files.label).toEqual('My Files')
+    expect(formStore.tabs.embargo.label).toEqual('Embargo')
+    expect(formStore.tabs.submit.label).toEqual('Submit')
+  })
+
   it('loads the saved department as the first choice', () => {
 
     formStore.allowTabSave = jest.fn(() => { return false })


### PR DESCRIPTION
This solves a problem where changing the text that is displayed on the
tab would break the tab validation code because the label is used as an
identifier as well as a display name.

Connected to #1749