### PR TITLE
Fixed a problem where when you delete all the partnering_agencys from the form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Style/SafeNavigation:
   Enabled: false
 # END; Disabled in move to 2.3 sytax linter
 
+Style/SymbolProc:
+  Enabled: false
+
 Layout/SpaceAroundOperators:
   Exclude:
     - 'spec/fixtures/form_submission_params/*'

--- a/app/javascript/PartneringAgency.vue
+++ b/app/javascript/PartneringAgency.vue
@@ -3,7 +3,7 @@
   <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
     <label>Partnering Agency</label>
     <div  v-if="sharedState.partneringAgencies.partneringAgencies()">
-      <input name="etd[partnering_agency][]" type="hidden" value="Does not apply (no collaborating organization)" />
+      <input name="etd[partnering_agency][]" type="hidden" value="" />
     </div>
     <div v-for="partneringAgency in sharedState.partneringAgencies.partneringAgencies()">
     <div class="agency-container" v-if="partneringAgency.value != 'Does not apply (no collaborating organization)'">
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div v-else>
-    <input name="etd[partnering_agency][]" type="hidden" value="Does not apply (no collaborating organization)" />
+    <input name="etd[partnering_agency][]" type="hidden" value="" />
   </div>
 </div>
 </template>

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -47,11 +47,20 @@ class InProgressEtd < ApplicationRecord
     new_data = add_no_embargoes(new_data)
     existing_data = remove_stale_embargo_data(existing_data, new_data)
     new_data = keep_last_completed_step(existing_data, new_data)
-
     new_data = keep_school_has_changed(existing_data, new_data)
+    new_data = strip_blank_fields(new_data)
+
     resulting_data = existing_data.merge(new_data)
     self.data = resulting_data.to_json
     resulting_data
+  end
+
+  def strip_blank_fields(new_data)
+    new_data.each do |key, value|
+      next unless value.respond_to?(:reject)
+      new_data[key] = value.reject(&:blank?)
+    end
+    new_data
   end
 
   # currently the EtdForm uses the boolean param "no_embargoes", so we need to send or remove it (seems a good candidate for refactoring in EtdForm)
@@ -72,6 +81,7 @@ class InProgressEtd < ApplicationRecord
   end
 
   def keep_last_completed_step(existing_data, new_data)
+    return new_data unless new_data[:currentStep]
     new_data[:currentStep] = existing_data['currentStep'] if existing_data.keys.include?('currentStep') && existing_data['currentStep'] >= new_data[:currentStep]
     new_data
   end

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -58,7 +58,7 @@ class InProgressEtd < ApplicationRecord
   def strip_blank_fields(new_data)
     new_data.each do |key, value|
       next unless value.respond_to?(:reject)
-      new_data[key] = value.reject(&:blank?)
+      new_data[key] = value.reject { |v| v.blank? }
     end
     new_data
   end

--- a/app/validators/my_program_validator.rb
+++ b/app/validators/my_program_validator.rb
@@ -1,7 +1,8 @@
 class MyProgramValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
-    ::Hyrax::EtdForm.my_program_terms.each do |field|
+    fields_to_validate = ::Hyrax::EtdForm.my_program_terms - [:partnering_agency]
+    fields_to_validate.each do |field|
       # TODO: confirm whether subfields are never required by Emory
       next if field == :subfield
       record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -407,13 +407,15 @@ describe InProgressEtd do
 
       let(:new_data) do
         { 'partnering_agency' => ['', 'partner 1'],
-          'keyword' => ['', nil] }
+          'keyword' => ['', nil],
+          'committee_members_attributes' => { "0" => { "name" => ["member 1"] } } }
       end
 
       it 'removes the blank fields' do
         expect(resulting_data).to eq({
           'title' => 'The Old Title',
           'schoolHasChanged' => false,
+          'committee_members_attributes' => { "0" => { "name" => ["member 1"] } },
           'partnering_agency' => ['partner 1'],
           'keyword' => []
         })

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -398,6 +398,27 @@ describe InProgressEtd do
         expect(resulting_data).to eq({ "schoolHasChanged" => false })
       end
     end
+
+    context 'with blank values' do
+      let(:old_data) do
+        { 'title' => 'The Old Title',
+          'keyword' => ['old keyword'] }
+      end
+
+      let(:new_data) do
+        { 'partnering_agency' => ['', 'partner 1'],
+          'keyword' => ['', nil] }
+      end
+
+      it 'removes the blank fields' do
+        expect(resulting_data).to eq({
+          'title' => 'The Old Title',
+          'schoolHasChanged' => false,
+          'partnering_agency' => ['partner 1'],
+          'keyword' => []
+        })
+      end
+    end
   end
 
   describe '#refresh_from_etd!' do


### PR DESCRIPTION
the old values are cached in the InProgressEtd record, so when
you reload the form, the old values still show up.

If you submit blank strings from the front end, you can effectively
delete the old values.