### PR TITLE
Removing committee members

### DIFF
--- a/app/javascript/test/CommitteeMember.spec.js
+++ b/app/javascript/test/CommitteeMember.spec.js
@@ -7,7 +7,7 @@ import CommitteeMember from 'CommitteeMember'
 import { formStore } from 'formStore'
 
 formStore.savedData['committee_chair_attributes'] = {"0":{"affiliation_type":"Emory University","name":["Person"]},"1":{"affiliation_type":"Emory University","name":["Someone"]}}
-formStore.savedData['committee_member_attributes'] = {"0":{"affiliation_type":"Non-Emory University","name":["Member"]},"1":{"affiliation_type":"Emory University","name":["Someone"]}}
+formStore.savedData['committee_members_attributes'] = {"0":{"affiliation_type":"Non-Emory University","name":["Member"]},"1":{"affiliation_type":"Emory University","name":["Someone"]}}
 
 describe('CommitteeMember.vue', () => {
   it('renders two links to start with', () => {

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -49,10 +49,25 @@ class InProgressEtd < ApplicationRecord
     new_data = keep_last_completed_step(existing_data, new_data)
     new_data = keep_school_has_changed(existing_data, new_data)
     new_data = strip_blank_fields(new_data)
+    remove_blank_members(new_data)
 
     resulting_data = existing_data.merge(new_data)
     self.data = resulting_data.to_json
     resulting_data
+  end
+
+  # If we see the committee_chair_attributes key in
+  # the new_data, then we know that we are
+  # submitting data from the 'My Advisor' tab, so
+  # if (optional) committee members field is
+  # missing from the keys, we can assume the student
+  # deleted all the committee members off the form,
+  # and then we should delete the members from the
+  # cached data on the model.
+  def remove_blank_members(new_data)
+    return unless new_data.key?('committee_chair_attributes')
+    return unless new_data['committee_members_attributes'].blank?
+    new_data['committee_members_attributes'] = []
   end
 
   def strip_blank_fields(new_data)

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -421,6 +421,63 @@ describe InProgressEtd do
         })
       end
     end
+
+    context 'with committee chair, but no committee members' do
+      let(:old_data) do
+        { 'title' => 'The Old Title',
+          'committee_members_attributes' => { "0" => { "name" => ["member 1"] } } }
+      end
+
+      let(:new_data) do
+        { 'committee_chair_attributes' => { "0" => { "name" => ["chair 1"] } } }
+      end
+
+      it 'removes existing committee members' do
+        expect(resulting_data).to eq({
+          'title' => 'The Old Title',
+          'schoolHasChanged' => false,
+          'committee_chair_attributes' => { "0" => { "name" => ["chair 1"] } },
+          'committee_members_attributes' => []
+        })
+      end
+    end
+
+    context 'with committee chair, and committee members' do
+      let(:old_data) do
+        { 'title' => 'The Old Title',
+          'committee_members_attributes' => { "0" => { "name" => ["old member 1"] } } }
+      end
+
+      let(:new_data) do
+        { 'committee_chair_attributes' => { "0" => { "name" => ["chair 1"] } },
+          'committee_members_attributes' => { "0" => { "name" => ["new member 1"] } } }
+      end
+
+      it 'updates the committee members data' do
+        expect(resulting_data).to eq({
+          'title' => 'The Old Title',
+          'schoolHasChanged' => false,
+          'committee_chair_attributes' => { "0" => { "name" => ["chair 1"] } },
+          'committee_members_attributes' => { "0" => { "name" => ["new member 1"] } }
+        })
+      end
+    end
+
+    context 'with no committee chair, and no committee members' do
+      let(:old_data) do
+        { 'title' => 'The Old Title',
+          'committee_members_attributes' => { "0" => { "name" => ["member 1"] } } }
+      end
+      let(:new_data) { { 'title' => 'new title' } }
+
+      it 'keeps existing committee members' do
+        expect(resulting_data).to eq({
+          'title' => 'new title',
+          'schoolHasChanged' => false,
+          'committee_members_attributes' => { "0" => { "name" => ["member 1"] } }
+        })
+      end
+    end
   end
 
   describe '#refresh_from_etd!' do


### PR DESCRIPTION
Saving form data from a tab sends only the data from that tab.  This was
causing a problem when the student deletes all committee members from
the form because they weren't properly being deleted from the cached
data.

This solution looks for the committee_chair_attributes key, which is a
required field, so it should be among the data keys if we are submitting
from the 'My Advisors' tab.  If we're on that tab, and we don't see a
key for the committee members, then we can assume that the student
deleted the members from the form, so we should delete them from the
cached data as well.