### PR TITLE
Display the subfield label in submit tab

### DIFF
--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -5,7 +5,7 @@
     <div> {{ sharedState.getSavedOrSelectedDepartment() }} </div>
     <div v-if="sharedState.getSelectedSubfield() && sharedState.getSelectedSubfield().length > 0">
           <h5>Subfield</h5>
-      <div> {{ sharedState.getSelectedSubfield () }} </div>
+      <div> {{ sharedState.getSubfieldLabelFromId(sharedState.getSelectedSubfield()) }} </div>
     </div>
     <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
       <h5>Partnering Agencies</h5>
@@ -25,7 +25,8 @@ import { formStore } from '../../formStore'
 export default {
   data() {
     return {
-      sharedState: formStore
+      sharedState: formStore,
+      subfields:  formStore.getSubfields()
     }
   },
   methods: {

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -394,7 +394,7 @@ export const formStore = {
     if (this.selectedSubfield === undefined) {
       this.selectedSubfield = ''
     }
-    return this.selectedSubfield.length === 0 ? this.savedData['subfield'] : this.selectedSubfield
+    return this.selectedSubfield.length === 0 ? this.subfields[this.savedData['subfield']] : this.selectedSubfield
   },
   setSelectedSubfield (subfield) {
     this.selectedSubfield = subfield
@@ -422,7 +422,9 @@ export const formStore = {
   clearSubfields () {
     this.subfields = []
   },
-
+  getSubfieldLabelFromId (id) {
+    return this.subfields.filter((subfield) => { return subfield.id === id })[0].label
+  },
   /* End of Schools, Departments & Subfields */
 
   getPrimaryFile () {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -70,4 +70,9 @@ describe('formStore', () => {
     formStore.allowTabSave = jest.fn(() => { return false })
     expect(formStore.getUserAgreement()).toEqual(true)
   })
+
+  it('returns the correct label for a subfield when given the id', () => {
+    formStore.subfields = [{ 'id': 'Biostatistics', 'label': 'Biostatistics - MPH & MSPH', 'active': true }, { 'id': 'Public Health Informatics', 'label': 'Public Health Informatics - MSPH', 'active': true }]
+    expect(formStore.getSubfieldLabelFromId('Public Health Informatics')).toEqual('Public Health Informatics - MSPH')
+  })
 })


### PR DESCRIPTION
This changes the display of the submit tab to show the subfield label
and not the ID.

Connected to #1748