### PR TITLE
Prioritize Box downloads by putting them on the ingest queue

### DIFF
--- a/app/jobs/fetch_remote_file_job.rb
+++ b/app/jobs/fetch_remote_file_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FetchRemoteFileJob < ApplicationJob
-  queue_as Hyrax.config.ingest_queue_name
+  queue_as :ingest
 
   # Fetch the remote file from Box and store it in a
   # local file on the hard drive.


### PR DESCRIPTION
Our strategy for downloading files from Box has changed in the new form. We no
longer need to create a FileSet prior to running the download job. This saves
time and prevents issues with `InProgressEtd` objects.

To avoid leaving these jobs on the queue while the Box auth token times out,
this puts them in the prioritized `:ingest` queue.

Closes #1769