### PR TITLE
prevent users from uploading from Box after uploading supplemental fi…

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -115,12 +115,13 @@
       </table>
     </div>
     <div class="alert alert-info"><span class="glyphicon glyphicon-info-sign"></span> Please add files larger than 100MB with Box.</div>
+    <div v-if="sharedState.preventBoxSupplementalUpload" class="alert alert-warning" id="box-warning"><span class="glyphicon glyphicon-warning-sign"></span> Save and Continue before uploading any (more) files from Box.</div>
     <div class="form-inline">
       <input class="input-file btn-primary" id="add-supplemental-file" name="supplemental_files[]" type="file" ref="fileInput" @change="onSupplementalFileChange"/>
       <label class="btn btn-primary" for="add-supplemental-file"><span class='glyphicon glyphicon-plus'></span>
       Add a supplemental file from your computer
       </label>
-      <button type="button" class="btn btn-primary" @click="boxOAuth('supplemental')"><span class="glyphicon glyphicon-plus"></span> Add a supplemental file from Box</button>
+      <button :disabled="sharedState.preventBoxSupplementalUpload" type="button" class="btn btn-primary" @click="boxOAuth('supplemental')"><span class="glyphicon glyphicon-plus"></span> Add a supplemental file from Box</button>
     </div>
     </section>
   </div>
@@ -148,9 +149,9 @@ export default {
   },
   created() {
      if (formStore.allowTabSave()) {
-     if (localStorage.getItem('files')) {
-        this.sharedState.files = [[JSON.parse(localStorage.getItem('files')).files[0]]]
-      }
+       if (localStorage.getItem('files')) {
+          this.sharedState.files = [[JSON.parse(localStorage.getItem('files')).files[0]]]
+        }
      }
   },
   mounted () {
@@ -167,14 +168,19 @@ export default {
         logoUrl: 'box',
         canCreateNewFolder: false
       })
+      filePicker.addListener('cancel', (event) => {
+        filePicker.hide()
+      })
 
       filePicker.addListener('choose', (event) => {
         var boxFileUploader = new BoxSupplementalFileUploader({
           boxAccessToken: accessToken,
           event: event,
           csrfToken: this.sharedState.token,
-          formStore: this.sharedState
+          formStore: this.sharedState,
+          filePicker: filePicker
       })
+
 
       boxFileUploader.getUrlFromBox()
       })

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -41,6 +41,8 @@ export default class SaveAndSubmit {
 
         // populate form in order to use its inputs
         this.formStore.loadSavedData()
+        // upon any successful tab save, this flag becomes true
+        this.formStore.enableBoxForSupplementalFiles()
 
         this.formStore.setValid(response.data.tab_name, true)
         this.formStore.setComplete(response.data.tab_name)

--- a/app/javascript/SupplementalFileUploader.js
+++ b/app/javascript/SupplementalFileUploader.js
@@ -5,7 +5,7 @@ export default class SupplementalFileUploader extends FileUploader {
     if (isSafari11()) {
       this.formData.delete('primary_files[]')
     }
-    // this should not submit a school 
+    // this should not submit a school
     try {
       this.formData.delete('etd[school]')
     } catch (error) {}
@@ -27,6 +27,7 @@ export default class SupplementalFileUploader extends FileUploader {
             file_type: ''
           }
         )
+        this.formStore.disableBoxForSupplementalFiles()
       }
     }
     xhr.send(this.formData)

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -376,7 +376,7 @@ export const formStore = {
         this.departments = response.data
         if (!this.allowTabSave()) {
           this.departments.unshift(savedValue)
-        } 
+        }
       })
       return savedValue
     } else {
@@ -475,6 +475,14 @@ export const formStore = {
       .then((response) => {
         this.partneringAgencyChoices = response.data
       })
+  },
+  preventBoxSupplementalUpload: false,
+  disableBoxForSupplementalFiles () {
+    this.preventBoxSupplementalUpload = true
+  },
+
+  enableBoxForSupplementalFiles () {
+    this.preventBoxSupplementalUpload = false
   },
 
   setSupplementalFileMetadata (key, field, newValue) {

--- a/app/javascript/lib/BoxFileUploader.js
+++ b/app/javascript/lib/BoxFileUploader.js
@@ -5,6 +5,7 @@ export default class BoxFileUploader {
     this.event = options.event
     this.csrfToken = options.csrfToken
     this.sharedState = options.formStore
+    this.filePicker = options.filePicker
   }
 
   getUrlFromBox () {
@@ -54,6 +55,8 @@ export default class BoxFileUploader {
             }
           )
         }
+        this.sharedState.disableBoxForSupplementalFiles()
+        this.filePicker.hide()
       }
     }
   }

--- a/app/javascript/test/SupplementalFileUploader.spec.js
+++ b/app/javascript/test/SupplementalFileUploader.spec.js
@@ -2,8 +2,10 @@
 /* global it */
 /* global expect */
 /* global jest */
-
+import { shallowMount } from '@vue/test-utils'
 import SupplementalFileUploader from '../SupplementalFileUploader'
+import Files from 'Files'
+import { formStore } from 'formStore'
 
 const mockXHR = {
   open: jest.fn(),
@@ -11,6 +13,8 @@ const mockXHR = {
   setRequestHeader: jest.fn()
 }
 
+window.localStorage = jest.fn()
+window.localStorage.getItem = jest.fn((value) => { return undefined })
 window.XMLHttpRequest = jest.fn(() => mockXHR)
 
 describe('SupplementalFileUploader', () => {
@@ -23,5 +27,19 @@ describe('SupplementalFileUploader', () => {
     })
     fileUploader.uploadFile()
     expect(mockXHR.open).toBeCalledWith('POST', '/uploads/', true)
+  })
+
+  it('prevents the user from uploading from Box until they save their supplemental file data', () => {
+    const wrapper = shallowMount(Files, {
+    })
+    var fileUploader = new SupplementalFileUploader({
+      token: 'token',
+      formStore: formStore,
+      event: {target: { files: ['test.pdf'] }}
+    })
+    fileUploader.uploadFile()
+    fileUploader.formStore.disableBoxForSupplementalFiles()
+
+    expect(wrapper.html()).toContain('Save and Continue before uploading any (more) files from Box.')
   })
 })


### PR DESCRIPTION
…les until they save. This commit tells the user to save the files tab after uploading each supplemental file and disables the box uploader button. This ensures their data is not lost by navigating away from the page to Box for authentication. It also makes the cancel button close the Box uploader window and clears its state.

Connected to #1758 