### PR TITLE
Restrict Manage Embargoes to users who can index embargoes

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   <% end %>
 
-  <% if can? :edit, Hydra::AccessControls::Embargo %>
+  <% if can?(:index, Hydra::AccessControls::Embargo) %>
     <%= menu.nav_link(hyrax.embargoes_path) do %>
       <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.embargoes.index.manage_embargoes') %></span>
     <% end %>

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -5,6 +5,19 @@ RSpec.feature 'Admin dashboard',
               integration: true,
               workflow: { admin_sets_config: 'spec/fixtures/config/emory/candler_admin_sets.yml' } do
 
+  context 'as a student user' do
+    let(:user) { FactoryBot.create(:nongraduated_user) }
+
+    before do
+      login_as user
+      visit '/dashboard'
+    end
+
+    scenario 'does not have manage embargo' do
+      expect(page).not_to have_link 'Manage Embargoes'
+    end
+  end
+
   context 'as an admin user' do
     let(:user) { FactoryBot.create(:admin) }
 


### PR DESCRIPTION
Students and other users who can deposit items have edit rights to the embargoes
for the items they have deposited. However, we don't want these users to have
access to the 'Manage Embargoes' dashboard item.

It turns out, in this case, that `:index` is more restrictive than `:edit`, and
is the appropriate control for access to this page.

Fixes #1766