### PR TITLE
Do not try to facet on table_of_contents

### DIFF
--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -16,10 +16,10 @@ class EtdIndexer < Hyrax::WorkIndexer
 
   class IndexingService < Hyrax::BasicMetadataIndexer
     self.stored_fields +=
-      [:abstract, :email, :post_graduation_email, :hidden?]
+      [:abstract, :email, :post_graduation_email, :table_of_contents, :hidden?]
 
     self.stored_and_facetable_fields +=
-      [:creator, :graduation_year, :table_of_contents, :files_embargoed,
+      [:creator, :graduation_year, :files_embargoed,
        :abstract_embargoed, :toc_embargoed]
   end
 end


### PR DESCRIPTION
The table_of_contents field should be stored but
should not be facetable. Attempting to index table
of contents as facetable was causing objects with
large table of contents to fail to reindex.

Connected to #1768 