### PR TITLE
Fix occassional spec failure in EtdEmbargoService tests

### DIFF
--- a/spec/services/etd_embargo_service_spec.rb
+++ b/spec/services/etd_embargo_service_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe EtdEmbargoService do
-  describe '.assets_under_embargo' do
+  describe '.assets_under_embargo', :clean do
     before { FactoryBot.create(:etd) }
 
     context 'when no works are under embargo' do
@@ -11,7 +11,7 @@ describe EtdEmbargoService do
       end
     end
 
-    context 'when there are embargoed etds', :clean do
+    context 'when there are embargoed etds' do
       let(:embargoed_etd) do
         FactoryBot.create(:sample_data_with_everything_embargoed)
       end


### PR DESCRIPTION
If an embargo already exists when this file is run (some other test has failed
to clean up), there's a chance for this test to fail since the empty case is
false. Since we're already cleaning up the other examples, we can just clean
everything.

Connected to #1656 