### PR TITLE
Remove control characters upon submission

### DIFF
--- a/lib/input_sanitizer.rb
+++ b/lib/input_sanitizer.rb
@@ -30,6 +30,7 @@ class InputSanitizer
         ]
       }
     )
-    CGI.unescapeHTML(clean_html.to_s)
+    # The final gsub removes any control characters.
+    CGI.unescapeHTML(clean_html.to_s).gsub!(/\p{Cc}/, "")
   end
 end


### PR DESCRIPTION
When there are control characters in strings it prevents
solr-reindexing and might cause other problems. As part
of our data sanitizing, remove all control characters.

Fixes #1776 