### PR TITLE
validating for supplemental file metadata

### DIFF
--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -123,6 +123,9 @@
       </label>
       <button :disabled="sharedState.preventBoxSupplementalUpload" type="button" class="btn btn-primary" @click="boxOAuth('supplemental')"><span class="glyphicon glyphicon-plus"></span> Add a supplemental file from Box</button>
     </div>
+    <section class='errorMessage alert alert-danger' v-if="sharedState.hasError('supplementalFiles')">
+        <p><span class="glyphicon glyphicon-exclamation-sign"></span> {{ sharedState.getErrorMessage('supplementalFiles').supplementalFiles[0] }}</p>
+    </section>
     </section>
   </div>
 </template>

--- a/app/validators/my_files_validator.rb
+++ b/app/validators/my_files_validator.rb
@@ -2,6 +2,8 @@ class MyFilesValidator < ActiveModel::Validator
   def validate(record)
     return unless current_tab?(record)
     record.errors.add('files', "A thesis or dissertation file is required") if parsed_data(record)['files'].nil?
+
+    record.errors.add('supplementalFiles', "A title, description and file type are required for each Supplemental File.") if file_without_metadata(record)
   end
 
   def parsed_data(record)
@@ -11,5 +13,16 @@ class MyFilesValidator < ActiveModel::Validator
 
   def current_tab?(record)
     parsed_data(record)['currentTab'] == "My Files"
+  end
+
+  def file_without_metadata(record)
+    return false if parsed_data(record)['supplemental_files'].nil?
+    return true if parsed_data(record)['supplemental_file_metadata'].nil?
+
+    meta_missing = false
+    parsed_data(record)['supplemental_file_metadata'].each do |sf|
+      meta_missing = sf[1]['title'].blank? || sf[1]['description'].blank? || sf[1]['file_type'].blank? ? true : false
+    end
+    meta_missing
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -148,7 +148,17 @@ describe InProgressEtd do
   describe "My Files" do
     context "with valid data" do
       let(:data) do
-        { currentTab: "My Files", files: {} }
+        { currentTab: "My Files", "files": {} }
+      end
+
+      it "is valid" do
+        expect(in_progress_etd).to be_valid
+      end
+    end
+
+    context "with a supplemental file and complete metadata" do
+      let(:data) do
+        { currentTab: "My Files", "files": {}, "supplemental_files": ["file.jpg"], "supplemental_file_metadata": { "0": { "title": "Silent Spring", "description": "Ecology", "file_type": "Image" } } }
       end
 
       it "is valid" do
@@ -159,6 +169,36 @@ describe InProgressEtd do
     context "with invalid data" do
       let(:data) do
         { currentTab: "My Files", files: nil }
+      end
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+
+    context "with a supplemental file but no metadata" do
+      let(:data) do
+        { currentTab: "My Files", files: {}, supplemental_files: ["file.jpg"] }
+      end
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+
+    context "with a supplemental file but incomplete metadata" do
+      let(:data) do
+        { currentTab: "My Files", "files": {}, "supplemental_files": ["file.jpg"], "supplemental_file_metadata": { "0": { "description": "Ecology", "file_type": "Image" } } }
+      end
+
+      it "is not valid" do
+        expect(in_progress_etd).not_to be_valid
+      end
+    end
+
+    context "with a supplemental file but empty metadata" do
+      let(:data) do
+        { currentTab: "My Files", "files": {}, "supplemental_files": ["file.jpg"], "supplemental_file_metadata": { "0": { title: "", "description": "Ecology", "file_type": "Image" } } }
       end
 
       it "is not valid" do


### PR DESCRIPTION
This commit adds extra conditions to the back end Files validator so that supplemental files with missing or incomplete metadata will cause a validation error and prevent the data form being saved.

Connected to #1678 