### PR TITLE
displaying validation errors for Abstract and TOC

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -49,12 +49,18 @@
               <richTextEditor :parentLabel="input.label"
               v-bind:parentValue="input.value" :parentIndex="input.index"
               parentName="etd[table_of_contents]"></richTextEditor>
+              <section class='errorMessage alert alert-danger' v-if="sharedState.hasError(index)">
+                  <p><span class="glyphicon glyphicon-exclamation-sign"></span> {{ input.label }} is required</p>
+              </section>
             </div>
             <div v-else-if="input.label === 'Abstract'">
               <label>{{ input.label }}</label>
               <richTextEditor :parentLabel="input.label"
               v-bind:parentValue="input.value" :parentIndex="input.index"
               parentName="etd[abstract]"></richTextEditor>
+              <section class='errorMessage alert alert-danger' v-if="sharedState.hasError(index)">
+                  <p><span class="glyphicon glyphicon-exclamation-sign"></span> {{ input.label }} is required</p>
+              </section>              
             </div>
 
              <div v-else-if="input.label === 'Graduation Date'">
@@ -137,7 +143,7 @@
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
           <input name="request_from_form" type="hidden" value="true" />
           <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-primary" autofocus>Save and Continue</button>
-          
+
         </div>
       </div>
     </form>

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -98,6 +98,7 @@ describe('App.vue', () => {
     })
   })
 
+
   describe('Tabs reflect saved progress', () => {
     beforeEach(() => {
       const wrapper = shallowMount(App, {
@@ -121,6 +122,26 @@ describe('App.vue', () => {
       expect(wrapper.vm.$data.sharedState.tabs.my_advisor.currentStep).toBe(true)
     })
 
+  })
+  describe('Abstract and TOC validation', () => {
+    it('displays their error messages', () => {
+      const wrapper = shallowMount(App, {
+      })
+      wrapper.vm.$data.sharedState.tabs.about_me.complete = true
+      wrapper.vm.$data.sharedState.tabs.my_program.complete = true
+      wrapper.vm.$data.sharedState.tabs.my_advisor.complete = true
+      wrapper.vm.$data.sharedState.tabs.my_advisor.currentStep = false
+      wrapper.vm.$data.sharedState.tabs.my_etd.complete = false
+      wrapper.vm.$data.sharedState.tabs.my_etd.currentStep = true
+      wrapper.vm.$data.sharedState.tabs.keywords.complete = false
+      wrapper.vm.$data.sharedState.tabs.my_files.complete = false
+      wrapper.vm.$data.sharedState.tabs.embargo.complete = false
+
+      wrapper.vm.$data.sharedState.hasError = jest.fn((value) => { return true })
+
+      expect(wrapper.html()).toContain('Table of Contents is required')
+      expect(wrapper.html()).toContain('Abstract is required')      
+    })
   })
 
   describe('Edit form:', () => {


### PR DESCRIPTION
This commit adds the display code for error messages for the Abstract and Table of Contents fields.

Connected to #1765 