### PR TITLE
Show department label on Submit tab

### DIFF
--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -2,7 +2,7 @@
   <section>
     <h4>My Program</h4>
     <h5>Department</h5>
-    <div> {{ sharedState.getSavedOrSelectedDepartment() }} </div>
+    <div> {{ sharedState.getDepartmentLabelFromId(sharedState.getSavedOrSelectedDepartment()) }} </div>
     <div v-if="sharedState.getSelectedSubfield() && sharedState.getSelectedSubfield().length > 0">
           <h5>Subfield</h5>
       <div> {{ sharedState.getSubfieldLabelFromId(sharedState.getSelectedSubfield()) }} </div>
@@ -26,7 +26,8 @@ export default {
   data() {
     return {
       sharedState: formStore,
-      subfields:  formStore.getSubfields()
+      subfields:  formStore.getSubfields(),
+      departments: formStore.loadDepartments()
     }
   },
   methods: {

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -390,6 +390,10 @@ export const formStore = {
     var schoolEndpoint = this.schools[this.getSavedOrSelectedSchool()]
     this.getDepartments(schoolEndpoint)
   },
+  getDepartmentLabelFromId (id) {
+    console.log(this.departments)
+    return this.departments.filter((department) => { return department.id === id })[0].label
+  },
   getSelectedSubfield () {
     if (this.selectedSubfield === undefined) {
       this.selectedSubfield = ''

--- a/app/javascript/test/components/submit/MyProgram.spec.js
+++ b/app/javascript/test/components/submit/MyProgram.spec.js
@@ -9,7 +9,7 @@ import { formStore } from '../../../formStore'
 window.localStorage = jest.fn()
 window.localStorage.getItem = jest.fn((value) =>{ return 'Rollins School of Public Health' })
 formStore.savedData['partnering_agency'] = ['CDC', 'Does not apply (no collaborating organization)']
-
+formStore.departments = [{'value':1,'active':true,'label':'Select a Department','disabled':'disabled','selected':'selected'},{'id':'Divinity','label':'Divinity','active':true},{'id':'Ministry','label':'Ministry','active':true},{'id':'Pastoral Counseling','label':'Pastoral Counseling','active':true},{'id':'Theological Studies','label':'Theological Studies','active':true}]
 describe('MyProgram.vue', () => {
   it('has the correct label', () => {
     const wrapper = shallowMount(MyProgram, {

--- a/app/javascript/test/components/submit/MyProgramNoAgencies.spec.js
+++ b/app/javascript/test/components/submit/MyProgramNoAgencies.spec.js
@@ -9,7 +9,7 @@ import { formStore } from '../../../formStore'
 window.localStorage = jest.fn()
 window.localStorage.getItem = jest.fn((value) =>{ return 'Rollins School of Public Health' })
 formStore.savedData['partnering_agency'] = ['Does not apply (no collaborating organization)']
-
+formStore.departments = [{'value':1,'active':true,'label':'Select a Department','disabled':'disabled','selected':'selected'},{'id':'Divinity','label':'Divinity','active':true},{'id':'Ministry','label':'Ministry','active':true},{'id':'Pastoral Counseling','label':'Pastoral Counseling','active':true},{'id':'Theological Studies','label':'Theological Studies','active':true}]
 describe('MyProgram.vue with no agencies', () => {
 
   it('has the correct label', () => {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -75,4 +75,9 @@ describe('formStore', () => {
     formStore.subfields = [{ 'id': 'Biostatistics', 'label': 'Biostatistics - MPH & MSPH', 'active': true }, { 'id': 'Public Health Informatics', 'label': 'Public Health Informatics - MSPH', 'active': true }]
     expect(formStore.getSubfieldLabelFromId('Public Health Informatics')).toEqual('Public Health Informatics - MSPH')
   })
+
+  it('returns the correct label for a department name when given the id', () => {
+    formStore.departments = [{ 'id': 'Some Id', 'label': 'Some Label', 'active': true }]
+    expect(formStore.getDepartmentLabelFromId('Some Id')).toEqual('Some Label')
+  })
 })


### PR DESCRIPTION
This commit shows the department label instead of the
id on the submit tab in the same
way that subfields are shown.

This also fixes a problem where
the My Program section might be missing on the submit tab. Now
the My Program section loads
the deparments so that it can
determine the correct label. Previously they were only loaded into
memory on the actual My Program tab.

Connected to #1748
Connected to #1782