### PR TITLE
 Cast `#*_embargoed` values to boolean in the model

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -88,6 +88,9 @@ class Etd < ActiveFedora::Base
   end
 
   def files_embargoed=(value)
+    Rails.logger.warn("Setting #{__method__} to #{value} is deprecated. Casting to `true`.") if
+      ['true', 'TRUE'].include?(value)
+
     super(EMBARGO_TRUTHINESS_VALUES.include?(value))
   end
 
@@ -100,6 +103,9 @@ class Etd < ActiveFedora::Base
   end
 
   def abstract_embargoed=(value)
+    Rails.logger.warn("Setting #{__method__} to #{value} is deprecated. Casting to `true`.") if
+      ['true', 'TRUE'].include?(value)
+
     super(EMBARGO_TRUTHINESS_VALUES.include?(value))
   end
 
@@ -112,6 +118,9 @@ class Etd < ActiveFedora::Base
   end
 
   def toc_embargoed=(value)
+    Rails.logger.warn("Setting #{__method__} to #{value} is deprecated. Casting to `true`.") if
+      ['true', 'TRUE'].include?(value)
+
     super(EMBARGO_TRUTHINESS_VALUES.include?(value))
   end
 

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -4,6 +4,8 @@ class Etd < ActiveFedora::Base
   include ::ProquestBehaviors
   include ::Hyrax::WorkBehavior
 
+  EMBARGO_TRUTHINESS_VALUES = [true, 'true', 'TRUE'].freeze
+
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
 
@@ -85,12 +87,36 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  def files_embargoed=(value)
+    super(EMBARGO_TRUTHINESS_VALUES.include?(value))
+  end
+
+  def files_embargoed
+    EMBARGO_TRUTHINESS_VALUES.include?(super)
+  end
+
   property :abstract_embargoed, predicate: "http://purl.org/spar/pso/embargoed#abstract", multiple: false do |index|
     index.as :stored_searchable
   end
 
+  def abstract_embargoed=(value)
+    super(EMBARGO_TRUTHINESS_VALUES.include?(value))
+  end
+
+  def abstract_embargoed
+    EMBARGO_TRUTHINESS_VALUES.include?(super)
+  end
+
   property :toc_embargoed, predicate: "http://purl.org/spar/pso/embargoed#toc", multiple: false do |index|
     index.as :stored_searchable, :facetable
+  end
+
+  def toc_embargoed=(value)
+    super(EMBARGO_TRUTHINESS_VALUES.include?(value))
+  end
+
+  def toc_embargoed
+    EMBARGO_TRUTHINESS_VALUES.include?(super)
   end
 
   property :embargo_length, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -73,18 +73,21 @@ RSpec.describe Etd do
 
   context "three kinds of embargo" do
     let(:etd) { FactoryBot.build(:etd) }
+
     it "#files_embargoed" do
-      expect(etd.files_embargoed).to eq nil
+      expect(etd.files_embargoed).to be_falsey
       etd.files_embargoed = true
       expect(etd.files_embargoed).to eq true
     end
+
     it "#abstract_embargoed" do
-      expect(etd.abstract_embargoed).to eq nil
+      expect(etd.abstract_embargoed).to be_falsey
       etd.abstract_embargoed = true
       expect(etd.abstract_embargoed).to eq true
     end
+
     it "#toc_embargoed" do
-      expect(etd.toc_embargoed).to eq nil
+      expect(etd.toc_embargoed).to be_falsey
       etd.toc_embargoed = true
       expect(etd.toc_embargoed).to eq true
     end

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -23,7 +23,7 @@ describe EtdPresenter do
         end
         it "returns the toc if the toc is not under embargo" do
           allow(presenter).to receive(:current_ability_is_approver?).and_return(false)
-          expect(etd.toc_embargoed).to eq nil
+          expect(etd.toc_embargoed).to be_falsey
           expect(presenter.toc_with_embargo_check).to eq etd.table_of_contents.first
         end
 
@@ -79,7 +79,7 @@ describe EtdPresenter do
             described_class.new(SolrDocument.new(etd.to_solr), ability)
           end
           it "returns the toc if it is not under embargo" do
-            expect(etd.toc_embargoed).to eq nil
+            expect(etd.toc_embargoed).to be_falsey
             expect(presenter.toc_with_embargo_check).to eq etd.table_of_contents.first
           end
           context "pre-graduation" do
@@ -128,7 +128,7 @@ describe EtdPresenter do
         end
         before { allow(presenter).to receive(:current_ability_is_approver?).and_return(false) }
         it "returns the abstract if it is not under embargo" do
-          expect(etd.abstract_embargoed).to eq nil
+          expect(etd.abstract_embargoed).to be_falsey
           expect(presenter.abstract_with_embargo_check).to eq etd.abstract.first
         end
         context "with an abstract embargo pre-graduation" do
@@ -158,7 +158,7 @@ describe EtdPresenter do
           described_class.new(SolrDocument.new(etd.to_solr), ability)
         end
         it "returns the abstract if it is not under embargo" do
-          expect(etd.abstract_embargoed).to eq nil
+          expect(etd.abstract_embargoed).to be_falsey
           expect(presenter.abstract_with_embargo_check).to eq etd.abstract.first
         end
 


### PR DESCRIPTION
Various parts of the codebase set these flags to `true`/`false` or
`"true"`/(`""`|`"false"`|`nil`). These are interpreted in `SolrDocument`, but the
model itself is unable to tell a caller whether these values are embargoed with
any reliability.

The fix included here is to override the setters and getters for these values
to cast aggressively to a Boolean value. Since `SolrDocument` already has this
logic baked in, this ensures both the model and the index give the intended
value. We can deprecate setting with string values and remove the overrides once
users of this approach (notably the submission forms) have been cleaned up.

Fixes #1763