### PR TITLE
returning and displaying user-friendly etd submission errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,6 +97,7 @@ RSpec/MessageSpies:
   Exclude:
     - 'spec/controllers/hyrax/admin/workflows_controller_spec.rb'
     - 'spec/actors/primary_file_title_actor_spec.rb'
+    - 'spec/controllers/hyrax/etds_controller_spec.rb'
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -91,7 +91,7 @@ export default class SaveAndSubmit {
         .catch(e => {
           this.formStore.submitEtd = true
           this.formStore.failedSubmission = true
-          this.errors.push(e)
+          this.formStore.errors.push(e.response.data.errors)
         })
 
     } catch (error) {

--- a/app/javascript/components/submit/FinalSubmission.vue
+++ b/app/javascript/components/submit/FinalSubmission.vue
@@ -6,13 +6,13 @@
         <span class="glyphicon glyphicon-info-sign"></span>
         <span aria-live="polite"> Submitting Your Thesis or Dissertation </span><span class="glyphicon glyphicon-refresh spinning"></span>
       </div>
-    </div>  
+    </div>
     <div v-if="sharedState.submitted && sharedState.failedSubmission">
       <div class="alert alert-danger">
         <span class="glyphicon glyphicon-exclamation-sign"></span>
-        <span aria-live="polite"> There was a problem submitting your thesis or dissertation.</span>
+        <span aria-live="polite"> There was a problem submitting your thesis or dissertation: {{ sharedState.errors.join(', ') }}. Please contact the ETD team at <a href="mailto:etd-help@LISTSERV.CC.EMORY.EDU">etd-help@LISTSERV.CC.EMORY.EDU</a> for help.</span>
       </div>
-    </div>  
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
This commit adds some code that will catch, display and log Etd submission errors. It will display the error messages in a user-friendly way (formatted, as a sentence) and includes the suggestion to contact the Etd submission help department via an email link. It also logs the error as 'Create from IPE', error type and current user. Closes #1723.