### PR TITLE
Report form errors to honeybadger

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -112,8 +112,9 @@ module Hyrax
         render json: { errors: curation_concern.errors.messages }, status: 422
       end
     rescue StandardError => error
-      render json: { errors: error.to_s }, status: 422
       Rails.logger.error("Create from IPE error: #{error}, current_user: #{current_user}")
+      Honeybadger.notify(error, error_message: "current_user = #{current_user} #{error.message}")
+      render json: { errors: error.to_s }, status: 422
     end
 
     # Override from Hyrax:app/controllers/concerns/hyrax/curation_concern_controller.rb


### PR DESCRIPTION
And pass along the current_user so we know who has been affected

@jenlindner I meant to get this in before your last PR got merged.

1) I think we should report errors to honeybadger, not just put them in the log file. If they're in honeybadger we have a much better chance of seeing them
2) Don't we need to do the render last, after any error reporting? I thought once it does a render it won't do anything after. I could be wrong about that.