### PR TITLE
Adjust travis remove new ui false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ env:
   - COVERALLS_PARALLEL=true
   - QMAKE=/usr/lib/x86_64-linux-gnu/qt5/bin/qmake
   matrix:
-  - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=unit
-  - NEW_UI_ENABLED=false NO_COVERAGE=true TEST_SUITE=integration
   - NEW_UI_ENABLED=true NO_COVERAGE=true TEST_SUITE=unit
   - NEW_UI_ENABLED=true NO_COVERAGE=true TEST_SUITE=integration
 install:

--- a/spec/controllers/in_progress_etds_controller_spec.rb
+++ b/spec/controllers/in_progress_etds_controller_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe InProgressEtdsController, type: :controller do
   context 'logged in as a student' do
     before { sign_in student }
 
+    context 'GET NEW - read only mode' do
+      before { allow(Flipflop).to receive(:read_only?).and_return(true) }
+
+      it "displays read only message" do
+        get :new
+        expect(flash[:alert]).to eq("This system is in read-only mode for maintenance. No submissions or edits can be made at this time.")
+      end
+
+      it "does not display form" do
+        get :new
+        expect(response.body).not_to include('Submit Your Thesis or Dissertation')
+      end
+    end
+
     context 'GET NEW - when the student has no previously saved record' do
       before { InProgressEtd.destroy_all }
 


### PR DESCRIPTION
These commits remove the new_ui false builds from our Travis matrix and add a controller test for read-only mode, to replace the read-only feature test that can't run when new_ui is true.