### PR TITLE
adding guard clauses to label-from-id formstore functions

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -391,8 +391,9 @@ export const formStore = {
     this.getDepartments(schoolEndpoint)
   },
   getDepartmentLabelFromId (id) {
-    console.log(this.departments)
-    return this.departments.filter((department) => { return department.id === id })[0].label
+    if(this.departments.length > 0){
+      return this.departments.filter((department) => { return department.id === id })[0].label
+    }
   },
   getSelectedSubfield () {
     if (this.selectedSubfield === undefined) {
@@ -427,7 +428,9 @@ export const formStore = {
     this.subfields = []
   },
   getSubfieldLabelFromId (id) {
-    return this.subfields.filter((subfield) => { return subfield.id === id })[0].label
+    if (this.subfields.length > 0){
+      return this.subfields.filter((subfield) => { return subfield.id === id })[0].label
+    }
   },
   /* End of Schools, Departments & Subfields */
 


### PR DESCRIPTION
There are functions that translate the term from the id for both departments and subfields, used in the My Program submit component that ensures they match the selected values in the My Program form tab. This commit fixes bugs that prevented the My Program submit from displaying if there aren't any departments and subfields. 