### PR TITLE
fix for displaying departments when editing an Etd

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,7 +1,16 @@
 <template>
-  <div>
+  <div v-if="sharedState.allowTabSave()">
+    <!-- TODO: adding v-model='selected' enables the selected value to appear in the case of an ipe_etd, but it will not without it, with a hyrax etd. But we should refactor for a better solution. -->
     <label for="department">Department</label>
-    <select name="etd[department]" class="form-control" id="department" v-model="selected" aria-required="true" v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
+    <select name="etd[department]" class="form-control" id="department" aria-required="true" v-model="selected" v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
+      <option v-for="department in sharedState.departments" v-bind:value="department.id" v-bind:key="department.label" :disabled="department.disabled">
+        {{ department.label }}
+      </option>
+    </select>
+  </div>
+  <div v-else>
+    <label for="department">Department</label>
+    <select name="etd[department]" class="form-control" id="department" aria-required="true" v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
       <option v-for="department in sharedState.departments" v-bind:value="department.id" v-bind:key="department.label" :disabled="department.disabled">
         {{ department.label }}
       </option>
@@ -29,7 +38,7 @@ export default {
   },
   beforeMount: function(){
       this.sharedState.loadDepartments()
-      this.selected = this.sharedState.getSavedOrSelectedSchool()
+      this.selected = this.sharedState.getSavedOrSelectedDepartment()
   },
   mounted: function (){
     this.$nextTick(function () {

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -50,15 +50,7 @@ export default {
   },
   mounted: function() {
     this.$nextTick(function() {
-      //this needs to be saved or selected
-      var selected = this.sharedState.getSavedOrSelectedSchool()
-
-      // TODO: fix model to return string not array
-      if (_.has(this.sharedState.savedData, 'etd_id')) {
-        var schoolValue = this.sharedState.getSchoolValue(selected[0])
-        selected = schoolValue
-      }
-      this.selected = selected
+      this.selected = this.sharedState.getSavedOrSelectedSchool()
     })
   },
   watch: {

--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -56,6 +56,6 @@ h4 {
 }
 h5 {
   font-weight: 700;
-  
+
 }
 </style>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -359,7 +359,13 @@ export const formStore = {
   },
 
   getSavedOrSelectedDepartment () {
-    return this.selectedDepartment.length === 0 ? this.savedData['department'] : this.selectedDepartment
+    var savedDepartment = ""
+    if (_.isArray(this.savedData['department'])){
+      savedDepartment = this.savedData['department'][0]
+    } else {
+      savedDepartment = this.savedData['department']
+    }
+    return this.selectedDepartment.length === 0 ? savedDepartment : this.selectedDepartment
   },
 
   getSavedDepartment () {


### PR DESCRIPTION
This commit ensures departments display their selected values whether creating an or editing an Etd. It also removes some old code in the School component that has been obviated by us not allowing any editing of the school selection, which seemed to be causing bugs in the creation form. And it adds a template conditional in the Department.vue file that contributes to a bug fix, but has been marked as a todo for refactoring.