### PR TITLE
Rollback yanked `qa` gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,7 +592,7 @@ GEM
     public_suffix (3.0.3)
     pul_uv_rails (2.0.1)
     puma (3.11.4)
-    qa (2.1.0)
+    qa (2.0.1)
       activerecord-import
       deprecation
       faraday


### PR DESCRIPTION
This release was yanked since it broke dependants (Hyrax).