### PR TITLE
Translate `FileSet#visibility`

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -6,6 +6,26 @@ class FileSet < ActiveFedora::Base
   SUPPLEMENTARY = 'supplementary'.freeze
   SUPPLEMENTAL  = 'supplementary'.freeze
 
+  ##
+  # @!attribute [rw] visibility_translator_class
+  #   @return [Class]
+  attr_writer :visibility_translator_class
+
+  ##
+  # @return [Class]
+  def visibility_translator_class
+    @visibility_translator_class ||= FileSetVisibilityTranslator
+  end
+
+  ##
+  # @return [VisibilityTranslator]
+  def visibility_translator
+    visibility_translator_class.new(obj: self)
+  end
+
+  delegate :visibility,  to: :visibility_translator
+  delegate :visibility=, to: :visibility_translator
+
   property :embargo_length, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
     index.as :displayable
   end

--- a/app/services/file_set_visibility_translator.rb
+++ b/app/services/file_set_visibility_translator.rb
@@ -1,0 +1,25 @@
+##
+# Determines visibily for a given FileSet
+#
+# When users of a FileSet try to copy visibility from a Work, they may try to
+# copy custom visibilities, which the FileSet does not support.
+#
+# This translator supports the visibility extensions in `VisibilityTranslator`
+# are within `FileSet`. It maps all of the extended visibilities to
+# `restricted`, ensuring FileSets for embargoed/restricted works are kept
+# private.
+class FileSetVisibilityTranslator < VisibilityTranslator
+  RESTRICTED_TEXT   = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+  RESTRICTED_VALUES = [FILES_EMBARGOED, TOC_EMBARGOED, ALL_EMBARGOED].freeze
+
+  delegate :visibility, to: :proxy
+
+  ##
+  # @param  [String] value
+  # @return [String]
+  def visibility=(value)
+    value = RESTRICTED_TEXT if RESTRICTED_VALUES.include? value
+
+    proxy.visibility = value
+  end
+end

--- a/app/services/visibility_translator.rb
+++ b/app/services/visibility_translator.rb
@@ -22,8 +22,13 @@ class VisibilityTranslator
   TOC_EMBARGOED   = 'toc_restricted'.freeze
   OPEN            = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
 
+  ##
+  # @!attribute [rw] obj
+  #   @return [FileSet]
   attr_accessor :obj
 
+  ##
+  # @param [FileSet] obj
   def initialize(obj:)
     self.obj = obj
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -23,6 +23,37 @@ RSpec.describe FileSet do
     end
   end
 
+  describe '#visibility' do
+    subject(:file_set) { FactoryBot.build(:file_set, visibility: open) }
+
+    let(:open)       { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    let(:restricted) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+
+    it 'can set to restricted' do
+      expect { file_set.visibility = restricted }
+        .to change { file_set.visibility }
+        .to restricted
+    end
+
+    it 'sets visibility to restricted for file restricted' do
+      expect { file_set.visibility = VisibilityTranslator::FILES_EMBARGOED }
+        .to change { file_set.visibility }
+        .to restricted
+    end
+
+    it 'sets visibility to restricted for toc restricted' do
+      expect { file_set.visibility = VisibilityTranslator::TOC_EMBARGOED }
+        .to change { file_set.visibility }
+        .to restricted
+    end
+
+    it 'sets visibility to restricted for all restricted' do
+      expect { file_set.visibility = VisibilityTranslator::ALL_EMBARGOED }
+        .to change { file_set.visibility }
+        .to restricted
+    end
+  end
+
   describe '#hidden' do
     it 'is false without a parent' do
       expect(file_set).not_to be_hidden

--- a/spec/services/file_set_visibility_translator_spec.rb
+++ b/spec/services/file_set_visibility_translator_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe FileSetVisibilityTranslator do
+  subject(:translator) { described_class.new(obj: obj) }
+  let(:obj) { FactoryBot.build(:file_set) }
+
+  let(:open)       { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+  let(:restricted) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+
+  describe '.visibility' do
+    it 'passes through to object visibility' do
+      expect(described_class.visibility(obj: obj)).to eq obj.visibility
+    end
+  end
+
+  describe '#visibility' do
+    it 'passes through to object visibility' do
+      expect(translator.visibility).to eq obj.visibility
+    end
+  end
+
+  describe '#visibility=' do
+    it 'can set to open' do
+      expect { translator.visibility = open }
+        .to change { obj.visibility }
+        .to open
+    end
+
+    context 'when open' do
+      let(:obj) { FactoryBot.build(:file_set, visibility: open) }
+
+      it 'can set to restricted' do
+        expect { translator.visibility = restricted }
+          .to change { obj.visibility }
+          .to restricted
+      end
+
+      it 'sets visibility to restricted for file restricted' do
+        expect { translator.visibility = VisibilityTranslator::FILES_EMBARGOED }
+          .to change { obj.visibility }
+          .to restricted
+      end
+
+      it 'sets visibility to restricted for toc restricted' do
+        expect { translator.visibility = VisibilityTranslator::TOC_EMBARGOED }
+          .to change { obj.visibility }
+          .to restricted
+      end
+
+      it 'sets visibility to restricted for all restricted' do
+        expect { translator.visibility = VisibilityTranslator::ALL_EMBARGOED }
+          .to change { obj.visibility }
+          .to restricted
+      end
+    end
+  end
+end


### PR DESCRIPTION
Various callers attempt to set `FileSet#visilibity` to match a parent work on update or other actions; especially they call `FileSetActor#update_metadata`. Since we have extended `Etd#visibility` with a
translator, we want to do the same for `FileSet`, translating the special `Etd` values to ones that are valid on the `FileSet`.

Specifically, we translate all the Work embargo values to `"restricted"` for `FileSet`s.

Fixes #1791.