### PR TITLE
Changes default ordering of user notifications

### DIFF
--- a/app/views/hyrax/notifications/_notifications.html.erb
+++ b/app/views/hyrax/notifications/_notifications.html.erb
@@ -1,0 +1,39 @@
+<% if messages.present? %>
+  <div class="table-responsive">
+    <%# This file is copied from Hyrax. Notifications are ordered in ascending order of date by default. `data-order` attribute is used to change default order of date column to descending (most recent first) %>
+    <table class="table table-striped datatable" data-order='[[0,"desc"]]'>
+      <thead>
+        <tr>
+          <th><%= t('hyrax.mailbox.date') %></th>
+          <th><%= t('hyrax.mailbox.subject') %></th>
+          <th><%= t('hyrax.mailbox.message') %></th>
+          <th><span class="sr-only"><%= t('hyrax.mailbox.delete') %></span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% messages.each do |msg| %>
+          <tr>
+            <td data-sort="<%= msg.last_message.created_at.getutc.iso8601(5) %>">
+              <relative-time datetime="<%= msg.last_message.created_at.getutc.iso8601 %>" title="<%= msg.last_message.created_at.to_formatted_s(:standard) %>">
+                <%= msg.last_message.created_at.to_formatted_s(:long_ordinal) %>
+              </relative-time>
+            </td>
+            <td><%= sanitize msg.last_message.subject %></td>
+            <td><%= sanitize msg.last_message.body %></td>
+            <td>
+              <%= link_to hyrax.notification_path(msg.id),
+                      class: "itemicon itemtrash",
+                      title: t('hyrax.mailbox.delete'),
+                      method: :delete do %>
+                  <span class="sr-only"><%= I18n.t('hyrax.dashboard.delete_notification') %></span>
+                <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+                <% end %>
+            </td>
+          </tr>
+          <% end %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <p><%= t('hyrax.mailbox.empty') %></p>
+<% end %>


### PR DESCRIPTION
This commit orders user notifications by date (descending) to show most recent first.

Closes emory-libraries/etd-issues#57