### PR TITLE
Renames QueryService to Statistics::QueryService

### DIFF
--- a/app/services/hyrax/statistics/depositors/summary.rb
+++ b/app/services/hyrax/statistics/depositors/summary.rb
@@ -55,7 +55,8 @@ module Hyrax
           end
 
           def date_query
-            Hyrax::QueryService.new.build_date_query(start_dt, end_dt) unless start_dt.blank?
+            # QueryService was renamed to Statistics::QueryService in Hyrax-2.0.0 update
+            Hyrax::Statistics::QueryService.new.build_date_query(start_dt, end_dt) unless start_dt.blank?
           end
       end
     end


### PR DESCRIPTION
In Hyrax-2.0.0 update, QueryService was renamed to Statistics::QueryService. This update in our file is necessary to make sure date_query executes as intended.

Resolves emory-libraries/etd-issues#67