### PR TITLE
Adds depositor name to notifications message body

### DIFF
--- a/app/services/hyrax/workflow/approved_notification.rb
+++ b/app/services/hyrax/workflow/approved_notification.rb
@@ -12,7 +12,7 @@ module Hyrax
       end
 
       def message
-        "The work titled \"#{title}\" has been approved by #{user.display_name}.
+        "The work titled \"#{title}\" deposited by #{depositor.display_name} has been approved by #{user.display_name}.
 
         Comments (if any):
          #{comment}

--- a/app/services/hyrax/workflow/changes_required_notification.rb
+++ b/app/services/hyrax/workflow/changes_required_notification.rb
@@ -12,7 +12,7 @@ module Hyrax
       end
 
       def message
-        "#{title} (#{link_to work_id, document_url}) requires additional changes before approval.\n\n '#{comment}'"
+        "#{title} (#{link_to work_id, document_url}) deposited by #{depositor.display_name} requires additional changes before approval.\n\n '#{comment}'"
       end
     end
   end

--- a/app/services/hyrax/workflow/comment_notification.rb
+++ b/app/services/hyrax/workflow/comment_notification.rb
@@ -10,7 +10,7 @@ module Hyrax
       end
 
       def message
-        "#{user.display_name} has added a comment to #{title} (#{link_to work_id, document_url}): \n\n #{comment}"
+        "#{user.display_name} has added a comment to #{title} (#{link_to work_id, document_url}) deposited by #{depositor.display_name}: \n\n #{comment}"
       end
     end
   end

--- a/app/services/hyrax/workflow/degree_awarded_notification.rb
+++ b/app/services/hyrax/workflow/degree_awarded_notification.rb
@@ -12,7 +12,7 @@ module Hyrax
       end
 
       def message
-        "The degree associated with #{title} (#{link_to document_url, document_url}) has been awarded."
+        "The degree associated with #{title} (#{link_to document_url, document_url}) deposited by #{depositor.display_name} has been awarded."
       end
     end
   end

--- a/app/services/hyrax/workflow/hidden_notification.rb
+++ b/app/services/hyrax/workflow/hidden_notification.rb
@@ -10,7 +10,7 @@ module Hyrax
       end
 
       def message
-        "#{title} (#{link_to work_id, document_url}) was hidden by #{user.display_name}  #{comment}"
+        "#{title} (#{link_to work_id, document_url}) deposited by #{depositor.display_name} was hidden by #{user.display_name}  #{comment}"
       end
 
       def users_to_notify

--- a/app/services/hyrax/workflow/reviewed_notification.rb
+++ b/app/services/hyrax/workflow/reviewed_notification.rb
@@ -10,7 +10,7 @@ module Hyrax
       end
 
       def message
-        "#{title} (#{link_to work_id, document_url}) has completed initial review and is awaiting final approval. #{comment}"
+        "#{title} (#{link_to work_id, document_url}) deposited by #{depositor.display_name} has completed initial review and is awaiting final approval. #{comment}"
       end
     end
   end

--- a/app/services/hyrax/workflow/unhidden_notification.rb
+++ b/app/services/hyrax/workflow/unhidden_notification.rb
@@ -10,7 +10,7 @@ module Hyrax
       end
 
       def message
-        "#{title} (#{link_to work_id, document_url}) was unhidden by #{user.display_name}  #{comment}"
+        "#{title} (#{link_to work_id, document_url}) deposited by #{depositor.display_name} was unhidden by #{user.display_name}  #{comment}"
       end
     end
   end

--- a/app/services/hyrax/workflow/virus_encountered_notification.rb
+++ b/app/services/hyrax/workflow/virus_encountered_notification.rb
@@ -12,7 +12,7 @@ module Hyrax
       end
 
       def message
-        "A virus has been detected in the work #{title} (#{link_to work_id, document_url}). " \
+        "A virus has been detected in the work #{title} (#{link_to work_id, document_url}) deposited by #{depositor.display_name}. " \
         "The infected file has been deleted and a clean version will need to be resubmitted."
       end
     end

--- a/spec/features/candler_workflow_etd_spec.rb
+++ b/spec/features/candler_workflow_etd_spec.rb
@@ -73,14 +73,14 @@ RSpec.feature 'Candler approval workflow', :perform_jobs, :clean, integration: t
       # Check notifications for approving user
       visit("/notifications?locale=en")
       expect(page).to have_content "Deposit #{etd.title.first} has been approved"
-      expect(page).to have_content "#{etd.title.first}\" has been approved by"
+      expect(page).to have_content "#{etd.title.first}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Check notifications for depositor again
       logout
       login_as depositing_user
       visit("/notifications?locale=en")
       expect(page).to have_content "Deposit #{etd.title.first} has been approved"
-      expect(page).to have_content "#{etd.title.first}\" has been approved by"
+      expect(page).to have_content "#{etd.title.first}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")

--- a/spec/features/laney_workflow_etd_spec.rb
+++ b/spec/features/laney_workflow_etd_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Laney Graduate School two step approval workflow',
 
       # Check notifications for approving user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{etd.title.first} (#{etd.id}) has completed initial review and is awaiting final approval."
+      expect(page).to have_content "#{etd.title.first} (#{etd.id}) deposited by #{depositing_user.display_name} has completed initial review and is awaiting final approval."
 
       # The approving user marks the etd as approved
       subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
@@ -104,18 +104,18 @@ RSpec.feature 'Laney Graduate School two step approval workflow',
 
       # Check notifications for approving user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{etd.title.first}\" has been approved by"
-      expect(page).to have_content "#{etd.title.first} (#{etd.id}) was hidden by"
+      expect(page).to have_content "#{etd.title.first}\" deposited by #{depositing_user.display_name} has been approved by"
+      expect(page).to have_content "#{etd.title.first} (#{etd.id}) deposited by #{depositing_user.display_name} was hidden by"
       expect(page).to have_content "hiding for reasons"
-      expect(page).to have_content "#{etd.title.first} (#{etd.id}) was unhidden by"
+      expect(page).to have_content "#{etd.title.first} (#{etd.id}) deposited by #{depositing_user.display_name} was unhidden by"
       expect(page).to have_content "unhiding for reasons"
 
       # Check notifications for depositor again
       logout
       login_as depositing_user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{etd.title.first} (#{etd.id}) has completed initial review and is awaiting final approval."
-      expect(page).to have_content "#{etd.title.first}\" has been approved by"
+      expect(page).to have_content "#{etd.title.first} (#{etd.id}) deposited by #{depositing_user.display_name} has completed initial review and is awaiting final approval."
+      expect(page).to have_content "#{etd.title.first}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")

--- a/spec/features/rollins_workflow_etd_spec.rb
+++ b/spec/features/rollins_workflow_etd_spec.rb
@@ -72,13 +72,13 @@ RSpec.feature 'Create a Rollins ETD', :perform_jobs, :clean, :js, integration: t
 
       # Check notifications for approving user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{truncate_title(etd.title.first)}\" has been approved by"
+      expect(page).to have_content "#{truncate_title(etd.title.first)}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Check notifications for depositor again
       logout
       login_as depositing_user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{truncate_title(etd.title.first)}\" has been approved by"
+      expect(page).to have_content "#{truncate_title(etd.title.first)}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")

--- a/spec/features/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/features/undergrad_honors_workflow_etd_spec.rb
@@ -72,13 +72,13 @@ RSpec.feature 'Emory College approval workflow', :perform_jobs, :clean, :js, int
 
       # Check notifications for approving user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{etd.title.first}\" has been approved by"
+      expect(page).to have_content "#{etd.title.first}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Check notifications for depositor again
       logout
       login_as depositing_user
       visit("/notifications?locale=en")
-      expect(page).to have_content "#{etd.title.first}\" has been approved by"
+      expect(page).to have_content "#{etd.title.first}\" deposited by #{depositing_user.display_name} has been approved by"
 
       # Depositing user should be able to see their work, even if it hasn't been approved yet
       visit("/concern/etds/#{etd.id}")


### PR DESCRIPTION
This commit adds display_name of the ETD depositor to messages in notifications so that all notifications are searchable via depositor name.

Resolves emory-libraries/etd-issues#17 for now.