### PR TITLE
Removes legacy ETD banner

### DIFF
--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,10 +1,4 @@
 <% if show_pagination? and @response.total_pages > 1 %>
-<div class="alert alert-info">
-  During our current ETD migration process, some ETD records may only be
-  available on our legacy ETD site. Please visit
-  <a href="https://legacy-etd.library.emory.edu">legacy-etd.library.emory.edu</a>
-  if you cannot find the ETD you are looking for on this new site.
-</div>
  <div class="row record-padding">
   <div class="col-md-12">
     <div class="pagination">

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -2,9 +2,3 @@
   <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
   <%= render_results_collection_tools wrapping_class: "search-widgets pull-right" %>
 </div>
-<div class="alert alert-info">
-  During our current ETD migration process, some ETD records may only be
-  available on our legacy ETD site. Please visit
-  <a href="https://legacy-etd.library.emory.edu">legacy-etd.library.emory.edu</a>
-  if you cannot find the ETD you are looking for on this new site.
-</div>

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -11,10 +11,4 @@
     <%- end %>
 
   </ul>
-  <div class="alert alert-info">
-    During our current ETD migration process, some ETD records may only be
-    available on our legacy ETD site. Please visit
-    <a href="https://legacy-etd.library.emory.edu">legacy-etd.library.emory.edu</a>
-    if you cannot find the ETD you are looking for on this new site.
-  </div>
 </div>


### PR DESCRIPTION
This commit removes legacy ETD banner from search results pages

Closes emory-libraries/etd-issues#77