### PR TITLE
Delete embargo when user updates the record to no embargo

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -121,6 +121,8 @@ module Hyrax
       params["files_embargoed"] = "false"
       params["abstract_embargoed"] = "false"
       params["toc_embargoed"] = "false"
+      params["toc_embargoed"] = "false"
+      params["embargo_length"] = ""
     end
 
     # Select the correct affiliation type for committee member

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Hyrax::EtdForm do
         expect(params["files_embargoed"]).to eq "false"
         expect(params["abstract_embargoed"]).to eq "false"
         expect(params["toc_embargoed"]).to eq "false"
+        expect(params["embargo_length"]).to eq ""
       end
     end
   end


### PR DESCRIPTION
From Fran: "as an Approver requested changes to un-embargo, I un-embargoed the files and re-submitted and chose "Request Review" but the changes to the embargo were NOT saved."