### PR TITLE
Enable user email visibility for approvers on the record view page.

### DIFF
--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -33,6 +33,11 @@ module EtdHelper
     end
   end
 
+  def post_graduation_email(f)
+    etd = Etd.find(f)
+    etd.post_graduation_email.first
+  end
+
     private
 
       def departments(school)

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -6,6 +6,10 @@
     </header>
 
     <span>Permanent URL: <%= main_app.hyrax_etd_url(@presenter.id) %></span>
+    <% if @presenter.current_ability_is_approver? %>
+    <br />
+    <span id="presenter-email">Email: <%= post_graduation_email(@presenter.id) %></span>
+    <% end %>
     <% unless @presenter.workflow.state_label == 'Approved' %>
       <br />
       <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>

--- a/spec/features/show_etd_spec.rb
+++ b/spec/features/show_etd_spec.rb
@@ -82,6 +82,9 @@ RSpec.feature 'Display ETD metadata', :clean, integration: true do
     expect(page).not_to have_content I18n.t("hyrax.works.requires_permissions_label")
     expect(page).not_to have_content I18n.t("hyrax.works.other_copyrights_label")
     expect(page).not_to have_content I18n.t("hyrax.works.patents_label")
+
+    # User email
+    expect(page).not_to have_content("Email: ")
   end
 
   scenario 'logged in approver sees copyright info' do
@@ -92,6 +95,9 @@ RSpec.feature 'Display ETD metadata', :clean, integration: true do
     expect(page).to have_content I18n.t("hyrax.works.requires_permissions_label")
     expect(page).to have_content I18n.t("hyrax.works.other_copyrights_label")
     expect(page).to have_content I18n.t("hyrax.works.patents_label")
+
+    # User email
+    expect(page).to have_content "Email: "
 
     # Embargo questions
     expect(find('li.attribute-files_embargoed')).to have_content false


### PR DESCRIPTION
From Fran: "As a School Approver/ADAP, I want to be able to see the Student/Alum's non-Emory email address, so I can contact them after their Emory email address is disable."