### PR TITLE
Optionally cc embargo expiration notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ running as expected.**
 If an email address is bouncing, or if someone prefers not to receive email notifications,
 add the email address to the list in `config/emory/do_not_send.yml`
 
+## Copying embargo notification emails to a staff member
+
+To send a copy of all notification expiration emails to a staff member, add that
+person's uid to an environment variable called EMBARGO_NOTIFICATION_CC in the
+.env.production file on the production server (other servers are configured not to
+  send email).
+
 ## Developer Setup
 
 1. Change to your working directory for new development projects

--- a/app/services/hyrax/workflow/embargo_notification_behavior.rb
+++ b/app/services/hyrax/workflow/embargo_notification_behavior.rb
@@ -44,9 +44,13 @@ module Hyrax
           end
         end
 
-        # Send this to the depositor only
+        # Send this to the depositor and the uid specified in EMBARGO_NOTIFICATION_CC
         def recipients
-          Array.wrap(@user)
+          recipients = []
+          recipients << @user
+          cc = embargo_notification_cc
+          recipients << cc unless cc.nil?
+          recipients
         end
 
         # Get the full URL for email notifications
@@ -54,6 +58,12 @@ module Hyrax
         def document_url
           key = @work.model_name.singular_route_key
           Rails.application.routes.url_helpers.send(key + "_url", @work.id)
+        end
+
+        # EMBARGO_NOTIFICATION_CC should be set via an environment variable. It should be
+        # the uid of a user who should be copied on all embargo expiration notifications.
+        def embargo_notification_cc
+          ::User.find_by_uid(ENV['EMBARGO_NOTIFICATION_CC'])
         end
       end
     end

--- a/spec/services/hyrax/workflow/sixty_day_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/sixty_day_embargo_notification_spec.rb
@@ -7,11 +7,16 @@ RSpec.describe Hyrax::Workflow::SixtyDayEmbargoNotification, :clean do
     ActionMailer::Base.deliveries.clear
   end
   let(:user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin) }
   let(:etd) { FactoryBot.create(:etd, depositor: user.user_key, post_graduation_email: ["post@graduation.email"]) }
   let(:notification) { described_class.new(etd.id) }
   context "notifications" do
     it "sends notifications to the post-graduation email address" do
       expect(notification.recipients.pluck(:email)).to include(etd.post_graduation_email.first)
+    end
+    it "sends notifications to the list of people in EMBARGO_NOTIFICATION_CC" do
+      ENV['EMBARGO_NOTIFICATION_CC'] = admin.uid
+      expect(notification.recipients.pluck(:email)).to include(admin.email)
     end
     it "can be invoked at the Class level" do
       n = described_class.send_notification(etd.id)


### PR DESCRIPTION
By adding a uid to an environment variable EMBARGO_NOTIFICATION_CC
the system will now send all embargo expiration notifications
to that user as well as the author of the ETD whose embargo
is expiring.

Set this value in .env.production on the production server.

Connected to #1851 