### PR TITLE
Change clamby error setting in prod

### DIFF
--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -6,7 +6,7 @@ if Rails.env.production?
     daemonize: true,
     error_clamscan_missing: true,
     error_file_missing: true,
-    error_file_virus: true,
+    error_file_virus: false, # we trigger a custom virus error, this setting will cause that to never trigger if true in prod
     fdpass: true
   )
 end


### PR DESCRIPTION
We are triggering a custom virus error to do logging
and clean up, but if this clamby setting is set to
true there is a different error that is raised and
the logging and clean up code is never reached.

This commit changes the clamby error setting to false
in production, which will trigger the custom code.