### PR TITLE
Fix truncated embargo notification message

### DIFF
--- a/app/services/hyrax/workflow/seven_day_embargo_notification.rb
+++ b/app/services/hyrax/workflow/seven_day_embargo_notification.rb
@@ -10,18 +10,21 @@ module Hyrax
       end
 
       def message
-        "Dear #{@user.display_name},\n\n" \
-        "The embargo on your dissertation or thesis, #{title}, will expire in seven days.\n" \
-        "Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url} \n\n" \
-        "If you need your record to remain restricted/embargoed, please contact your school administrators " \
-        "located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n" \
-        "Please do not reply directly to this email.\n\n" \
+        %(
+        Dear #{@user.display_name},\n\n
+        The embargo on your dissertation or thesis, #{title}, will expire in seven days.
+        Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url}
 
-        "FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:\n" \
-        "To extend your access restriction/embargo in the ProQuest database, you " \
-        "will need to contact ProQuest's Author Relations department to request " \
-        "an extended access restriction/embargo in their database. You can reach them at 1-800-521-0600 ext. 77020 " \
-        "or via email at disspub@proquest.com<mailto:disspub@proquest.com>."
+        If you need your record to remain restricted/embargoed, please contact your school administrators
+        located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n
+        Please do not reply directly to this email.
+
+        FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:
+        To extend your access restriction/embargo in the ProQuest database, you
+        will need to contact ProQuest's Author Relations department to request
+        an extended access restriction/embargo in their database. You can reach them at 1-800-521-0600 ext. 77020
+        or via email at disspub@proquest.com<mailto:disspub@proquest.com>.
+      )
       end
     end
   end

--- a/app/services/hyrax/workflow/sixty_day_embargo_notification.rb
+++ b/app/services/hyrax/workflow/sixty_day_embargo_notification.rb
@@ -10,18 +10,21 @@ module Hyrax
       end
 
       def message
-        "Dear #{@user.display_name},\n\n" \
-        "The embargo on your dissertation or thesis, #{title}, will expire in sixty days.\n" \
-        "Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url} \n\n" \
-        "If you need your record to remain restricted/embargoed, please contact your school administrators " \
-        "located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n" \
-        "Please do not reply directly to this email.\n\n" \
+        %(
+        Dear #{@user.display_name},\n\n
+        The embargo on your dissertation or thesis, #{title}, will expire in sixty days.
+        Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url}
 
-        "FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:\n" \
-        "To extend your access restriction/embargo in the ProQuest database, you " \
-        "will need to contact ProQuest's Author Relations department to request " \
-        "an extended access restriction/embargo in their database. You can reach them at 1-800-521-0600 ext. 77020 " \
-        "or via email at disspub@proquest.com<mailto:disspub@proquest.com>."
+        If you need your record to remain restricted/embargoed, please contact your school administrators
+        located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n
+        Please do not reply directly to this email.
+
+        FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:
+        To extend your access restriction/embargo in the ProQuest database, you
+        will need to contact ProQuest's Author Relations department to request
+        an extended access restriction/embargo in their database. You can reach them at 1-800-521-0600 ext. 77020
+        or via email at disspub@proquest.com<mailto:disspub@proquest.com>.
+      )
       end
     end
   end

--- a/app/services/hyrax/workflow/today_embargo_notification.rb
+++ b/app/services/hyrax/workflow/today_embargo_notification.rb
@@ -11,20 +11,24 @@ module Hyrax
       end
 
       def message
-        "Dear #{@user.display_name},\n\n" \
-        "The access restriction on your dissertation or thesis, #{title}, expires today." \
-        "We have not been informed that you wish to extend your access restriction period " \
-        "and therefore your dissertation or thesis is now available in full text form in our repository.\n\n" \
-        "Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url} \n\n" \
-        "If you need your record to remain restricted/embargoed, please contact your school administrators " \
-        "located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n" \
-        "Please do not reply directly to this email.\n\n" \
+        %(
+        Dear #{@user.display_name},\n\n
+        The access restriction on your dissertation or thesis, #{title}, expires today.
+        We have not been informed that you wish to extend your access restriction period
+        and therefore your dissertation or thesis is now available in full text form in our repository.
 
-        "FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:\n" \
-        "To extend your access restriction/embargo in the ProQuest database, you " \
-        "will need to contact ProQuest's Author Relations department to request " \
-        "an extended access restriction/embargo in their database. You can reach them at 1-800-521-0600 ext. 77020 " \
-        "or via email at disspub@proquest.com<mailto:disspub@proquest.com>."
+        Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url}
+
+        If you need your record to remain restricted/embargoed, please contact your school administrators
+        located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request.
+        Please do not reply directly to this email.
+
+        FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:
+        To extend your access restriction/embargo in the ProQuest database, you
+        will need to contact ProQuest's Author Relations department to request
+        an extended access restriction/embargo in their database. You can reach them at 1-800-521-0600 ext. 77020
+        or via email at disspub@proquest.com<mailto:disspub@proquest.com>.
+      )
       end
     end
   end

--- a/spec/services/hyrax/workflow/seven_day_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/seven_day_embargo_notification_spec.rb
@@ -18,5 +18,10 @@ RSpec.describe Hyrax::Workflow::SevenDayEmbargoNotification, :clean do
       expect(n).to be_instance_of(described_class)
       expect(ActionMailer::Base.deliveries.map(&:subject)).to include(n.subject)
     end
+    it "doesn't truncate the message" do
+      expect(notification.message).to match(/Dear #{user.display_name}/)
+      expect(notification.message).to match(/#{etd.title.first}/)
+      expect(notification.message).to match(/proquest.com/)
+    end
   end
 end

--- a/spec/services/hyrax/workflow/sixty_day_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/sixty_day_embargo_notification_spec.rb
@@ -23,5 +23,10 @@ RSpec.describe Hyrax::Workflow::SixtyDayEmbargoNotification, :clean do
       expect(n).to be_instance_of(described_class)
       expect(ActionMailer::Base.deliveries.map(&:subject)).to include(n.subject)
     end
+    it "doesn't truncate the message" do
+      expect(notification.message).to match(/Dear #{user.display_name}/)
+      expect(notification.message).to match(/#{etd.title.first}/)
+      expect(notification.message).to match(/proquest.com/)
+    end
   end
 end

--- a/spec/services/hyrax/workflow/today_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/today_embargo_notification_spec.rb
@@ -18,5 +18,10 @@ RSpec.describe Hyrax::Workflow::TodayEmbargoNotification, :clean do
       expect(n).to be_instance_of(described_class)
       expect(ActionMailer::Base.deliveries.map(&:subject)).to include(n.subject)
     end
+    it "doesn't truncate the message" do
+      expect(notification.message).to match(/Dear #{user.display_name}/)
+      expect(notification.message).to match(/#{etd.title.first}/)
+      expect(notification.message).to match(/proquest.com/)
+    end
   end
 end


### PR DESCRIPTION
This fixes a bug where the embargo notification message was being
truncated.

Fixes #1859 