### PR TITLE
Migrated works should stay in the default admin set

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -266,9 +266,19 @@ class Etd < ActiveFedora::Base
   # department it belongs to
   # @return [String] the name of an admin set
   def determine_admin_set(school = self.school, department = self.department)
+    return "Default Admin Set" if migrated?
     as_name = AdminSetChooser.new.determine_admin_set(school, department)
     raise "Cannot find admin set config where school = #{school.first} and department = #{department.first}" unless as_name
     as_name
+  end
+
+  # Works that were migrated from the previous system were put into the default admin set,
+  # and have been marked as published. When they are edited, they should stay in the default
+  # admin set -- we should not try to assign them to a different one based on their school and
+  # department.
+  def migrated?
+    return false unless self&.admin_set&.title&.first == "Default Admin Set"
+    true
   end
 
   # Assign an admin_set based on what is returned by #determine_admin_set

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Etd do
   context "determining admin set" do
     let(:etd) { FactoryBot.build(:etd) }
     let(:epidemiology_admin_set) { FactoryBot.create(:admin_set, title: ["Epidemiology"]) }
+    let(:default_admin_set) { FactoryBot.create(:admin_set, title: ["Default Admin Set"]) }
     it "assigns the laney admin set when the school is laney" do
       etd.school = ["Laney Graduate School"]
       expect(etd.determine_admin_set).to eq "Laney Graduate School"
@@ -36,6 +37,13 @@ RSpec.describe Etd do
     it "assigns the emory college admin set when the school is emory college" do
       etd.school = ["Emory College"]
       expect(etd.determine_admin_set).to eq "Emory College"
+    end
+    # Works that were migrated from the previous system were put into the default admin set,
+    # and have been marked as published. If someone tries to edit them, we shouldn't try to put
+    # them in a different admin set.
+    it 'assigns the default admin set if the etd already uses the default admin set and has been published' do
+      etd.admin_set = default_admin_set
+      expect(etd.determine_admin_set).to eq "Default Admin Set"
     end
     it "assigns according to department for Rollins" do
       etd.school = ["Rollins School of Public Health"]


### PR DESCRIPTION
We have been encountering errors when editing migrated works that do not
fit cleanly into our current system for assigning admin sets. For
migrated works, instead of attempting to put them in an admin set based
on their school and department, leave them in the default admin set
where they were before the edit attempt.

Connected to #1855 