### PR TITLE
Do not lose department when we edit

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -3,7 +3,7 @@
     <!-- TODO: adding v-model='selected' enables the selected value to appear in the case of an ipe_etd, but it will not without it, with a hyrax etd. But we should refactor for a better solution. -->
     <label for="department">Department</label>
     <select name="etd[department]" class="form-control" id="department" aria-required="true" v-model="selected" v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
-      <option v-for="department in sharedState.departments" v-bind:value="department.id" v-bind:key="department.label" :disabled="department.disabled">
+      <option v-for="department in sharedState.departments" v-bind:value="department.label" v-bind:key="department.label" :disabled="department.disabled">
         {{ department.label }}
       </option>
     </select>
@@ -11,7 +11,7 @@
   <div v-else>
     <label for="department">Department</label>
     <select name="etd[department]" class="form-control" id="department" aria-required="true" v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
-      <option v-for="department in sharedState.departments" v-bind:value="department.id" v-bind:key="department.label" :disabled="department.disabled">
+      <option v-for="department in sharedState.departments" v-bind:value="department.label" v-bind:key="department.label" :disabled="department.disabled">
         {{ department.label }}
       </option>
     </select>

--- a/spec/system/edit_etd_spec.rb
+++ b/spec/system/edit_etd_spec.rb
@@ -1,0 +1,42 @@
+# Generated via
+#  `rails generate hyrax:work Etd`
+require 'rails_helper'
+require 'workflow_setup'
+include Warden::Test::Helpers
+
+RSpec.feature 'Edit an existing ETD',
+              :perform_jobs,
+              :clean,
+              :js,
+              integration: true,
+              type: :system do
+  let(:depositing_user) { FactoryBot.create(:user) }
+  let(:approving_user) { User.where(uid: "laneyadmin").first }
+  let(:file) { FactoryBot.create(:primary_uploaded_file, user_id: depositing_user.id) }
+  let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }
+  let(:etd) { FactoryBot.create(:sample_data, school: ["Laney Graduate School"], depositor: depositing_user.user_key) }
+  let(:admin_superuser) { User.where(uid: "tezprox").first } # uid from superuser.yml
+
+  context 'an admin user' do
+    before do
+      allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
+      w.setup
+      attributes_for_actor = { uploaded_files: [file.id] }
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), attributes_for_actor)
+      Hyrax::CurationConcern.actor.create(env)
+    end
+
+    scenario "edits an existing ETD" do
+      expect(etd.active_workflow.name).to eq "laney_graduate_school"
+      expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_review"
+      login_as admin_superuser
+      visit "/concern/etds/#{etd.id}?locale=en"
+      click_on "Edit"
+      expect(page).to have_content "Divinity"
+      expect(page).to have_content etd.degree.first
+      click_on "Submit Your Thesis or Dissertation"
+      expect(page).to have_content "Divinity"
+      expect(page).to have_content etd.degree.first
+    end
+  end
+end

--- a/spec/system/submit_etd_spec.rb
+++ b/spec/system/submit_etd_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
       click_on 'Submit Your Thesis or Dissertation'
 
       expect(page).to have_content 'Submitting'
+      expect(page).to have_content 'Playwriting'
     end
   end
 end


### PR DESCRIPTION
Under some circumstances, the form was losing the department field
after being edited. This fixes the problem and adds a system spec for
editing an existing ETD.