### PR TITLE
Match DCE standard capybara setup

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -113,14 +113,6 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers, type: :feature
   config.after(:each, type: :feature) { Warden.test_reset! }
 
-  config.before(:each, type: :system) do
-    driven_by :rack_test
-  end
-
-  config.before(:each, type: :system, js: true) do
-    driven_by :selenium, using: :chrome, options: { args: ["headless", "disable-gpu", "no-sandbox", "disable-dev-shm-usage"] }
-  end
-
   # Gets around a bug in RSpec where helper methods that are defined in views aren't
   # getting scoped correctly and RSpec returns "does not implement" errors. So we
   # can disable verify_partial_doubles if a particular test is giving us problems.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# Setup chrome headless driver
+Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+# Setup rspec
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
+  end
+end

--- a/spec/system/submit_etd_spec.rb
+++ b/spec/system/submit_etd_spec.rb
@@ -4,18 +4,18 @@ require "rails_helper"
 
 include Warden::Test::Helpers
 
-RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
+RSpec.describe "Logged in student can submit an ETD", :clean, type: :system, js: true do
   let(:student) { create :user }
   let(:pdf) { Rails.root.join('spec', 'fixtures', 'joey', 'joey_thesis.pdf') }
   let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
 
-  context 'a logged in user', js: true do
+  context 'a logged in user' do
     before do
       login_as student
       workflow_setup.setup
     end
 
-    scenario "submitting a new ETD", js: true do
+    scenario "submitting a new ETD" do
       visit("/concern/etds/new")
 
       # About Me


### PR DESCRIPTION
Put capybara config in its own file.
Configure to match what we did for ursus, which is the emerging DCE
standard.