### PR TITLE
Add ability to set GA code with ENV variable

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -36,7 +36,7 @@ Hyrax.config do |config|
   # config.analytics = false
 
   # Google Analytics tracking ID to gather usage statistics
-  # config.google_analytics_id = 'UA-99999999-1'
+  config.google_analytics_id = ENV['GA_TRACKING_CODE']
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -25,6 +25,10 @@ export NO_COVERAGE=true
 export _JAVA_OPTIONS="-Xmx600m"
 
 # For hyrax config
-export UPLOAD_PATH=tmp/uploads
-export CACHE_PATH=tmp/uploads/cache
-export WORKING_PATH=tmp/uploads
+
+UPLOAD_PATH=tmp/uploads
+CACHE_PATH=tmp/uploads/cache
+WORKING_PATH=tmp/uploads
+
+# Set this to turn on Google Analytics
+# GA_TRACKING_CODE=U-99991


### PR DESCRIPTION
This allows you to set the GA tracking code
with an environment variable. This can be
set during deployment with the ansible scripts.

Connected to laevigata#749