### PR TITLE
Ignore RecordNotFound exception

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,12 +5,6 @@ class CatalogController < ApplicationController
   # This filter applies the hydra access controls
   before_action :enforce_show_permissions, only: :show
 
-  # If a requested url doesn't match any routes, send it here and raise a
-  # RoutingError, which gets caught by the ApplicationController
-  def catch_404
-    raise ActionController::RoutingError, params[:path]
-  end
-
   def self.uploaded_field
     solr_name('system_create', :stored_sortable, type: :date)
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  def error_404
+    flash[:alert] = 'The page you are looking for does not exist.'
+    render status: 404
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative 'boot'
+require_relative 'exception_middleware'
 
 require 'rails/all'
 
@@ -19,7 +20,9 @@ module Laevigata
       g.test_framework :rspec, spec: true
     end
     config.active_job.queue_adapter = :sidekiq
+    config.middleware.use(::ExceptionMiddleware)
     config.autoload_paths += %W[#{config.root}/lib]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/exception_middleware.rb
+++ b/config/exception_middleware.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ExceptionMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue Blacklight::Exceptions::RecordNotFound
+    # Redirect to non-existant location, which goes to the 404 page
+    [301, { 'Location' => '/not-found', 'Content-Type' => 'text/html' }, ['Moved Permanently']]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,5 +68,8 @@ Rails.application.routes.draw do
 
   get '/auth/box', to: 'box_auth#auth'
   post '/file/box', to: 'box_redirect#redirect_file'
-  match "*path", to: "catalog#catch_404", via: :all
+
+  get 'error_404', to: 'pages#error_404'
+  # If you go somewhere without a route, show a 404 page
+  match '*path', via: :all, to: 'pages#error_404'
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PagesController do
+  it 'has a flash alert & 404' do
+    get :error_404
+    expect(flash[:alert]).not_to be(nil)
+    expect(response).to have_http_status(404)
+  end
+end

--- a/spec/system/404_spec.rb
+++ b/spec/system/404_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Warden::Test::Helpers
+
+RSpec.describe 'Getting a 404 for RecordNotFound', type: :system do
+  before do
+  end
+  context 'visiting a work that does not exist' do
+    it 'has a 404 page' do
+      visit('/concern/works/s7526c41m?locale=pt-BR')
+      expect(page).to have_content('does not exist')
+    end
+  end
+
+  context 'visiting a route with no content' do
+    it 'has a 404 page' do
+      visit('/bla/bla/bla')
+      expect(page).to have_content('does not exist')
+    end
+  end
+end


### PR DESCRIPTION
Right now when you try to access a record
that does not exist it triggers a RecordNotFound exception
and returns a 500 instead of 404. This adds some
Rack middleware that will catch that exception and
return a 404 instead.

The code is also returning a 500 if you try
to go to a patch that does not exist. This adds
a route that will send you to a 404 page if you
go to a non-existant route.