### PR TITLE
Format date in workflow admin page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
+  def formatted_date(time:)
+    I18n.l(time.in_time_zone('Eastern Time (US & Canada)'), format: '%D %I.%m %p')
+  end
 end

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,0 +1,92 @@
+<% provide :page_header do %>
+  <h1><span class="glyphicon glyphicon-ok-circle"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default tabs">
+      <ul class="nav nav-tabs" role="tablist">
+        <li class="active">
+          <a href="#under-review" role="tab" data-toggle="tab"><%= t('.tabs.under_review') %></a>
+        </li>
+        <li>
+          <a href="#published" role="tab" data-toggle="tab"><%= t('.tabs.published') %></a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div id="under-review" class="tab-pane active">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-condensed table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @status_list.each do |document| %>
+                      <tr>
+                        <td>
+                          <%= link_to document, [main_app, document] %>
+                        </td>
+                        <td>
+                          <%= safe_join(document.creator, tag(:br)) %>
+                        </td>
+                        <td>
+                          <%= document.date_modified %>
+                        </td>
+                        <td>
+                          <span class="state state-pending"><%= document.workflow_state %></span>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="published" class="tab-pane">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-condensed table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @published_list.each do |document| %>
+                      <tr>
+                        <td>
+                          <%= link_to document, [main_app, document] %>
+                        </td>
+                        <td>
+                          <%= safe_join(document.creator, tag(:br)) %>
+                        </td>
+                        <td>
+                          <%= formatted_date(time: document.date_modified) %>
+                        </td>
+                        <td>
+                          <span class="state state-pending"><%= document.workflow_state %></span>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  let(:time) { '2019-07-17 17:08:08 -0400' }
+  let(:est_time) { '07/17/19 05.07 PM' }
+  describe '#formatted_date' do
+    it 'returns an EST date/time with AM and PM' do
+      expect(helper.formatted_date(time: time)). to eq(est_time)
+    end
+  end
+end


### PR DESCRIPTION
This adds a helper to format the
date in the workflow admin page so that
is displays the time in EST and using AM/PM.

Connected to #1939