### PR TITLE
Hard code fpici as an email cc default

### DIFF
--- a/app/services/hyrax/workflow/embargo_notification_behavior.rb
+++ b/app/services/hyrax/workflow/embargo_notification_behavior.rb
@@ -62,8 +62,9 @@ module Hyrax
 
         # EMBARGO_NOTIFICATION_CC should be set via an environment variable. It should be
         # the uid of a user who should be copied on all embargo expiration notifications.
+        # We are hard-coding fpici as a fallback default, just in case the environment variable ever gets un-set.
         def embargo_notification_cc
-          ::User.find_by_uid(ENV['EMBARGO_NOTIFICATION_CC'])
+          ::User.find_by_uid(ENV['EMBARGO_NOTIFICATION_CC'] || 'fpici')
         end
       end
     end


### PR DESCRIPTION
Notifications cc should be set via ENV['EMBARGO_NOTIFICATION_CC']
However, should that environment variable ever become un-set, we should
have a sensible default in place.

Connected to https://github.com/curationexperts/laevigata/issues/1956