### PR TITLE
Fix for Rollins submission

### DIFF
--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -5,7 +5,7 @@
     <div> {{ sharedState.getDepartmentLabelFromId(sharedState.getSavedOrSelectedDepartment()) }} </div>
     <div v-if="sharedState.getSavedOrSelectedSubfield() && sharedState.getSavedOrSelectedSubfield().length > 0">
           <h5>Subfield</h5>
-      <div> {{ sharedState.getSubfieldLabelFromId(sharedState.getSelectedSubfield()) }} </div>
+      <div> {{ sharedState.getSubfieldLabelFromId(sharedState.getSavedOrSelectedSubfield()) }} </div>
     </div>
     <div v-if="sharedState.getSavedOrSelectedSchool() === 'Rollins School of Public Health'">
       <h5>Partnering Agencies</h5>

--- a/spec/system/submit_etd_spec_rollins.rb
+++ b/spec/system/submit_etd_spec_rollins.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+include Warden::Test::Helpers
+
+RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
+  let(:student) { create :user }
+  let(:pdf) { Rails.root.join('spec', 'fixtures', 'joey', 'joey_thesis.pdf') }
+  let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
+
+  context 'a logged in user', js: true do
+    before do
+      login_as student
+      workflow_setup.setup
+    end
+
+    scenario "submitting a new ETD", js: true do
+      visit("/concern/etds/new")
+
+      # About Me
+      expect(page).to have_content('Post-Graduation Email')
+      fill_in 'Student Name', with: FFaker::Name.name
+      select 'Rollins School of Public Health', from: 'School'
+      select 'Spring 2018', from: 'Graduation Date'
+      fill_in 'Post-Graduation Email', with: FFaker::Internet.email
+      click_on 'Save and Continue'
+
+      # My Program
+      expect(page).to have_content('Department')
+      select 'Executive Masters of Public Health - MPH', from: 'Department'
+      select 'Applied Epidemiology', from: 'Subfield'
+      select 'MA', from: 'Degree'
+      select 'Honors Thesis', from: 'Submission Type'
+      click_on 'Save and Continue'
+
+      # My Advisor
+      expect(page).to have_content('Add a Committee Chair')
+      click_on 'Add a Committee Chair'
+      fill_in 'etd[committee_chair_attributes][0][name][]', with: FFaker::Name.name
+      click_on 'Add a Committee Member'
+      fill_in 'etd[committee_members_attributes][0][name][]', with: FFaker::Name.name
+      click_on 'Add a Committee Chair'
+      fill_in 'etd[committee_chair_attributes][1][name][]', with: FFaker::Name.name
+      click_on 'Add a Committee Member'
+      fill_in 'etd[committee_members_attributes][1][name][]', with: FFaker::Name.name
+      click_on 'Save and Continue'
+
+      # My ETD
+      expect(page).to have_content('Title')
+      fill_in 'Title', with: FFaker::Book.title
+      select 'English', from: 'Language'
+
+      first('div[contenteditable="true"].ql-editor').send_keys FFaker::CheesyLingo.paragraph
+      find(:xpath, '//*[@id="vue_form"]/div[4]/div/div[4]/div/div/div/div/div[2]/div[1]').send_keys FFaker::CheesyLingo.paragraph
+      click_on 'Save and Continue'
+
+      # Keywords
+      expect(page).to have_content('Select a Research Field')
+      execute_script("document.querySelector('select:nth-child(3)').selectedIndex = 1")
+      click_on 'Add a Keyword'
+      find(:xpath, '//*[@id="keywords"]/div/input').send_keys FFaker::CheesyLingo.word
+      click_on 'Save and Continue'
+      # Using the default copyright questions
+
+      # File Upload
+      page.attach_file('primary_files[]', pdf, make_visible: true)
+      expect(page).to have_content 'Save and Continue'
+      click_on 'Save and Continue'
+
+      # Embargoes
+
+      select '6 months', from: 'Requested Embargo Length'
+      click_on 'Save and Continue'
+
+      # Review
+      find('input[type="checkbox"]').set(true)
+      expect(page).to have_content 'My Program'
+      expect(page).to have_content 'Applied Epidemiology'
+    end
+  end
+end


### PR DESCRIPTION
There was a reference to a method called
`getSelectedSubfield` that was renamed to `getSavedOrSelectedSubfield`
at some point.

This renames the method and adds another system spec to test that
the subfield is showing up at the review screen.