### PR TITLE
Display date_uploaded as EST

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -68,6 +68,10 @@ class SolrDocument
     self[Solrizer.solr_name('committee_members_names')]
   end
 
+  def date_uploaded
+    ActiveSupport::TimeZone['US/Eastern'].parse(self['date_uploaded_ssi'])
+  end
+
   def degree
     self[Solrizer.solr_name('degree')]
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe ::SolrDocument, type: :model do
     end
   end
 
+  describe '#date_uploaded' do
+    subject(:solr_doc) { described_class.new(etd.to_solr) }
+    let(:etd)          { FactoryBot.build(:etd, hidden: true) }
+
+    it 'returns the date uploaded as EST' do
+      etd.date_uploaded = '01/01/2019 3 AM'.to_date.in_time_zone.to_s
+      expect(solr_doc.date_uploaded).to eq('2018-12-31 19:00:00 -0500')
+    end
+  end
+
   describe '#visibility' do
     subject(:solr_doc) { described_class.new(etd.to_solr) }
     let(:etd)          { FactoryBot.build(:etd) }


### PR DESCRIPTION
This field is stored in Fedora and Solr as UTC.

This alters the `SolrDocument` class so that it will display as EST.