### PR TITLE
DO NOT MERGE Approvers should always have edit rights

### DIFF
--- a/app/services/hyrax/workflow/grant_edit_to_approvers.rb
+++ b/app/services/hyrax/workflow/grant_edit_to_approvers.rb
@@ -1,0 +1,23 @@
+require 'workflow_setup'
+
+module Hyrax
+  module Workflow
+    # This is a customized workflow step for Emory so their approvers can edit works
+    module GrantEditToApprovers
+      # @param [#read_users=, #read_users] target (likely an ActiveRecord::Base) to which we are adding edit_users for the depositor
+      # @return void
+      def self.call(target:, **)
+        workflow = target.active_workflow
+        approving_role = Sipity::Role.where(name: "approving").first
+        wf_role = Sipity::WorkflowRole.find_by(workflow: workflow, role_id: approving_role)
+        approving_agents = wf_role.workflow_responsibilities.pluck(:agent_id)
+        sipity_agents = approving_agents.map { |a| Sipity::Agent.find(a).proxy_for_id }
+        approving_users = sipity_agents.map { |a| ::User.find(a).user_key }
+        target.edit_users += approving_users
+        # If there are a lot of members, granting access to each could take a
+        # long time. Do this work in the background.
+        GrantEditToMembersJob.perform_later(target, target.depositor)
+      end
+    end
+  end
+end

--- a/config/workflows/laney_graduate_school.json
+++ b/config/workflows/laney_graduate_school.json
@@ -20,7 +20,8 @@
                     "methods": [
                       "Hyrax::Workflow::DeactivateObject",
                       "Hyrax::Workflow::RevokeEditFromDepositor",
-                      "Hyrax::Workflow::GrantReadToDepositor"
+                      "Hyrax::Workflow::GrantReadToDepositor",
+                      "Hyrax::Workflow::GrantEditToApprovers"
                     ]
                 },
                 {
@@ -35,7 +36,8 @@
                         }
                     ],
                     "methods": [
-                        "Hyrax::Workflow::DeactivateObject"
+                        "Hyrax::Workflow::DeactivateObject",
+                        "Hyrax::Workflow::GrantEditToApprovers"
                     ]
                 },
 

--- a/spec/system/laney_approvers_can_replace_files_spec.rb
+++ b/spec/system/laney_approvers_can_replace_files_spec.rb
@@ -1,0 +1,44 @@
+# Generated via
+#  `rails generate hyrax:work Etd`
+require 'rails_helper'
+require 'workflow_setup'
+include Warden::Test::Helpers
+
+RSpec.feature 'Laney approvers can replace files',
+              :perform_jobs,
+              :clean,
+              :js,
+              integration: true,
+              type: :system do
+  let(:depositing_user) { FactoryBot.create(:user) }
+  let(:approving_user) { User.where(uid: "laneyadmin").first }
+  let(:file) { FactoryBot.create(:primary_uploaded_file, user_id: depositing_user.id) }
+  let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }
+  let(:etd) { FactoryBot.create(:sample_data, school: ["Laney Graduate School"], depositor: depositing_user.user_key) }
+
+  context 'a logged in user' do
+    before do
+      allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
+      w.setup
+      attributes_for_actor = { uploaded_files: [file.id] }
+      env = Hyrax::Actors::Environment.new(etd, ::Ability.new(depositing_user), attributes_for_actor)
+      Hyrax::CurationConcern.actor.create(env)
+    end
+
+    scenario "an approver wants to replace a file on a pending_approval work" do
+      expect(etd.active_workflow.name).to eq "laney_graduate_school"
+      expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_review"
+
+      login_as approving_user
+
+      # The approving user marks the etd as reviewed
+      subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
+      sipity_workflow_action = PowerConverter.convert_to_sipity_action("mark_as_reviewed", scope: subject.entity.workflow) { nil }
+      Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
+      expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_approval"
+
+      visit("/concern/etds/#{etd.id}")
+      expect(etd.edit_users).to include(approving_user.user_key)
+    end
+  end
+end


### PR DESCRIPTION
Alter the Laney workflow so that people who are approvers will always
have edit rights on the object.

DO NOT MERGE until we've heard back from Emory staff that this fixes the problem they reported.

Connected to https://github.com/curationexperts/in-house/issues/575