### PR TITLE
Changes the link to workshops

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -10,7 +10,7 @@ The theses and dissertations of the Wallace H. Coulter Department of Biomedical 
   <div class="news-and-announcements">
   <h2>News & Announcements</h2>
   <h3>ETD Copyright Workshops</h3>
-Visit the Woodruff Library's <a href=" http://web.library.emory.edu/news-events/upcoming-classes.html">class calendar</a> for upcoming ETD copyright workshops for your thesis/dissertation.
+Visit the Woodruff Library's <a href="http://sco.library.emory.edu/about/workshops.html">class calendar</a> for upcoming ETD copyright workshops for your thesis/dissertation.
 
 <h3>Submission Forms For All Participants</h3>
 All students depositing their thesis or dissertation must complete the ETD Submission form:


### PR DESCRIPTION
Old link leads to a page in the old website, which forwards to a less-than-stellar substitute.