### PR TITLE
Update yarn dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,22 @@
 {
   "dependencies": {
     "@rails/webpacker": "^4",
+    "acorn": "^6.4.1",
     "axios": "^0.19.0",
     "caniuse-lite": "^1.0.30000865",
     "core-js": "2",
     "css-loader": "^1.0.0",
     "formdata-polyfill": "^3.0.11",
+    "kind-of": "^6.0.3",
     "lodash": "^4.17.13",
+    "minimist": "^0.2.1",
     "postcss-cssnext": "^3.1.0",
     "vue": "^2.6.10",
     "vue-axios": "^2.1.1",
-    "vue-quill-editor": "^3.0.6",
-    "vue-turbolinks": "^2.0.3",
     "vue-loader": "^15.7.0",
-    "vue-template-compiler": "^2.6.10"
+    "vue-quill-editor": "^3.0.6",
+    "vue-template-compiler": "^2.6.10",
+    "vue-turbolinks": "^2.0.3"
   },
   "scripts": {
     "test": "jest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,6 +982,11 @@ acorn@^6.0.1, acorn@^6.0.5:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
+acorn@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -5081,6 +5086,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+kind-of@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
 kleur@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
@@ -5507,6 +5517,11 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
+  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Addresses:

kind-of:
CVE-2019-20149
moderate severity
Vulnerable versions: >= 6.0.0, < 6.0.3
Patched version: 6.0.3

ctorName in index.js in kind-of v6.0.0 - v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by 'constructor': {'name':'Symbol'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.

acorn:
GHSA-6chw-6frg-f759
moderate severity
Vulnerable versions: >= 6.0.0, < 6.4.1
Patched version: 6.4.1

Affected versions of acorn are vulnerable to Regular Expression Denial of Service.
A regex in the form of /[x-\ud800]/u causes the parser to enter an infinite loop.
The string is not valid UTF16 which usually results in it being sanitized before reaching the parser.
If an application processes untrusted input and passes it directly to acorn,
attackers may leverage the vulnerability leading to Denial of Service.

minimist:

CVE-2020-7598
moderate severity
Vulnerable versions: < 0.2.1
Patched version: 0.2.1

minimist before 1.2.2 could be tricked into adding or modifying properties of Object.prototype using a "constructor" or "proto" payload.