### PR TITLE
Moves submission form links to SCO website

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -16,19 +16,19 @@ Visit the Woodruff Library's <a href="http://sco.library.emory.edu/about/worksho
 All students depositing their thesis or dissertation must complete the ETD Submission form:
 <ul class="submission-forms">
   <li>
-    <a href="http://web.library.emory.edu/etd-static/docs/Laney_ETD_Submission_Form_revised_2015.pdf">Laney Graduate School submission form</a>
+    <a href="http://sco.library.emory.edu/etd-static/docs/Laney_ETD_Submission_Form_revised_2015.pdf">Laney Graduate School submission form</a>
   </li>
   <li>
-    <a href="http://web.library.emory.edu/etd-static/docs/Honors_ETD_Submission_Form_revised_2015.pdf">College Honors Program submission form</a>
+    <a href="http://sco.library.emory.edu/etd-static/docs/Honors_ETD_Submission_Form_revised_2015.pdf">College Honors Program submission form</a>
   </li>
   <li>
-    <a href="http://web.library.emory.edu/etd-static/docs/Candler_ETD_Submission_Form_revised_2015.pdf">Candler School of Theology submission form</a>
+    <a href="http://sco.library.emory.edu/etd-static/docs/Candler_ETD_Submission_Form_revised_2015.pdf">Candler School of Theology submission form</a>
   </li>
   <li>
-    <a href="http://web.library.emory.edu/etd-static/docs/Rollins_ETD_Submission_Form_revised_2015.pdf">Rollins School of Public Health submission form</a>
+    <a href="http://sco.library.emory.edu/etd-static/docs/Rollins_ETD_Submission_Form_revised_2015.pdf">Rollins School of Public Health submission form</a>
   </li>
   <li>
-    <a href="http://web.library.emory.edu/etd-static/docs/Nursing_ETD_Submission_Form_revised_2015.pdf">Nell Hodgson Woodruff School of Nursing submission form</a>
+    <a href="http://sco.library.emory.edu/etd-static/docs/Nursing_ETD_Submission_Form_revised_2015.pdf">Nell Hodgson Woodruff School of Nursing submission form</a>
   </li>
 </ul>
 This form WHICH REQUIRES THE SIGNATURE OF YOUR ADVISOR gives the library permission to publish your thesis or dissertation on the web; confirms access restrictions -- if any; and certifies that you have secured rights to all content that you will be publishing.


### PR DESCRIPTION
The ETD section of the Library website is ready for decommission, so these documents should live in the SCO website. This will allow SCO staff to continue to update them independent of the ETD application.