### PR TITLE
Set up basic framework for deployment/smoke test

### DIFF
--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require_relative './spec_helper'
+
+username = ENV['HTTP_USERNAME'] || 'test'
+password = ENV['HTTP_PASSWORD'] || 'test'
+hostname = ENV['ETD_HOST']
+# use this SSLContext to use https URLs without verifying certificates
+# @ssl_context = OpenSSL::SSL::SSLContext.new
+# @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+ssl_context = OpenSSL::SSL::SSLContext.new
+ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+front_page_url = "https://#{username}:#{password}@#{hostname}"
+
+RSpec.describe "The ETD server at #{hostname}", type: :feature do
+  let (:uri) {"https://#{username}:#{password}@#{hostname}"}
+  it "loads the front page" do
+    visit uri
+    expect(page).to have_content("Emory Theses and Dissertations")
+  end
+end

--- a/smoke_spec/deploy_spec.rb
+++ b/smoke_spec/deploy_spec.rb
@@ -9,10 +9,9 @@ hostname = ENV['ETD_HOST']
 # @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
 ssl_context = OpenSSL::SSL::SSLContext.new
 ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
-front_page_url = "https://#{username}:#{password}@#{hostname}"
 
 RSpec.describe "The ETD server at #{hostname}", type: :feature do
-  let (:uri) {"https://#{username}:#{password}@#{hostname}"}
+  let(:uri) { "https://#{username}:#{password}@#{hostname}" }
   it "loads the front page" do
     visit uri
     expect(page).to have_content("Emory Theses and Dissertations")

--- a/smoke_spec/spec_helper.rb
+++ b/smoke_spec/spec_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'byebug'
+require 'capybara/rspec'
+require 'openssl'
+require 'selenium/webdriver'
+
+ENV['RAILS_ENV'] ||= 'test'
+
+Dir["#{File.expand_path(__dir__)}/support/**/*.rb"].each { |f| require f }
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_excluding deployed: true unless ENV['YUL_DC_SERVER']
+end

--- a/smoke_spec/support/capybara.rb
+++ b/smoke_spec/support/capybara.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+Capybara.configure do |config|
+  config.run_server = false
+  config.default_driver = :chrome_headless
+end
+
+Capybara.register_driver :chrome_headless do |app|
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.read_timeout = 120
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(accept_insecure_certs: true)
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client, desired_capabilities: capabilities)
+end
+
+Capybara.javascript_driver = :chrome_headless


### PR DESCRIPTION
Usage: Set environment variables for HTTP_USERNAME, HTTP_PASSWORD, 
ETD_HOST.  Then run `rspec smoke_spec`.  At present, only looks for 
existence of a front page with the "Emory Theses and Dissertations" 
title.