### PR TITLE
Update VisibilityTranslator to handle various edge cases

### DIFF
--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -125,8 +125,17 @@ FactoryBot.define do
         patents { "true" }
       end
 
+      factory :sample_data_with_nothing_embargoed do
+        title { ["Sample Data With Nothing Embargoed: #{FFaker::Book.title}"] }
+        embargo { FactoryBot.create(:embargo, embargo_release_date: (Time.zone.today + 14.days)) }
+        embargo_length { "None - open access immediately" }
+        files_embargoed { "false" }
+        abstract_embargoed { "false" }
+        toc_embargoed { "false" }
+      end
+
       factory :sample_data_with_everything_embargoed do
-        title { ["Sample Data With Full Embargo: #{FFaker::Book.title}"] }
+        title { ["Sample Data With Everything Embargoed: #{FFaker::Book.title}"] }
         embargo { FactoryBot.create(:embargo, embargo_release_date: (Time.zone.today + 14.days)) }
         embargo_length { "6 months" }
         files_embargoed { "true" }


### PR DESCRIPTION
Addresses the issue described in #2065 

* Treat `embargo_length == nil` the same as `embargo_length == "None"`
* Restrict works with conflicting embargo settings - i.e. `embargo_length == "6 months"`
   BUT `files_embargoed == toc_embargoed == abstract_embargoed == false`
* Add logger warnings and errors to trace unexpected states

**BEFORE**
<img width="984" alt="image" src="https://user-images.githubusercontent.com/3064318/109105148-2cb9e980-76e2-11eb-94eb-b0c9fae22fa7.png">
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/3064318/109105199-45c29a80-76e2-11eb-8622-3e279900bacb.png">


**AFTER**
<img width="981" alt="image" src="https://user-images.githubusercontent.com/3064318/109105233-5a9f2e00-76e2-11eb-899c-2f8a308b4060.png">
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/3064318/109105268-6db1fe00-76e2-11eb-99ed-18e7f75ec147.png">
