### PR TITLE
Update indexing

### DIFF
--- a/app/models/schemas/emory_etd_schema.rb
+++ b/app/models/schemas/emory_etd_schema.rb
@@ -5,15 +5,15 @@ module Schemas
     property :abstract,              predicate: "http://purl.org/dc/terms/abstract"
     property :table_of_contents,     predicate: "http://purl.org/dc/terms/tableOfContents"
     property :creator,               predicate: "http://id.loc.gov/vocabulary/relators/aut"
-    property :graduation_year,       predicate: "http://purl.org/dc/terms/issued", multiple: false
+    # property :graduation_year,       predicate: "http://purl.org/dc/terms/issued", multiple: false
     property :keyword,               predicate: "http://schema.org/keywords"
-    property :email,                 predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#officeEmailAddress"
-    property :post_graduation_email, predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateEmailAddress"
+    # property :email,                 predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#officeEmailAddress"
+    # property :post_graduation_email, predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateEmailAddress"
     property :graduation_date,       predicate: "http://purl.org/dc/terms/issued"
-    property :hidden,                predicate: "http://emory.edu/local/hidden", multiple: false
-    property :files_embargoed,       predicate: "http://purl.org/spar/pso/embargoed#files", multiple: false
-    property :abstract_embargoed,    predicate: "http://purl.org/spar/pso/embargoed#abstract", multiple: false
-    property :toc_embargoed,         predicate: "http://purl.org/spar/pso/embargoed#toc", multiple: false
-    property :embargo_length,        predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false
+    # property :hidden,                predicate: "http://emory.edu/local/hidden", multiple: false
+    # property :files_embargoed,       predicate: "http://purl.org/spar/pso/embargoed#files", multiple: false
+    # property :abstract_embargoed,    predicate: "http://purl.org/spar/pso/embargoed#abstract", multiple: false
+    # property :toc_embargoed,         predicate: "http://purl.org/spar/pso/embargoed#toc", multiple: false
+    # property :embargo_length,        predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false
   end
 end

--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -125,8 +125,17 @@ FactoryBot.define do
         patents { "true" }
       end
 
+      factory :sample_data_with_nothing_embargoed do
+        title { ["Sample Data With Nothing Embargoed: #{FFaker::Book.title}"] }
+        embargo { FactoryBot.create(:embargo, embargo_release_date: (Time.zone.today + 14.days)) }
+        embargo_length { "None - open access immediately" }
+        files_embargoed { "false" }
+        abstract_embargoed { "false" }
+        toc_embargoed { "false" }
+      end
+
       factory :sample_data_with_everything_embargoed do
-        title { ["Sample Data With Full Embargo: #{FFaker::Book.title}"] }
+        title { ["Sample Data With Everything Embargoed: #{FFaker::Book.title}"] }
         embargo { FactoryBot.create(:embargo, embargo_release_date: (Time.zone.today + 14.days)) }
         embargo_length { "6 months" }
         files_embargoed { "true" }


### PR DESCRIPTION
bab9817
All of the attributes here are defined in both
**/app/models/schemas/emory_etd_schema.rb**
and
**/app/models/etd.rb**

This is the first step to defining all attributes in a single location.

This PR also resolves this type of warning message in logs:
```
W, [2021-02-24T20:01:54.009886 #962]  WARN -- : Same predicate (http://purl.org/spar/pso/embargoed#abstract) used for properties abstract_embargoed and abstract_embargoed
```