### PR TITLE
Remove duplicate attribute definitions

### DIFF
--- a/app/models/schemas/emory_etd_schema.rb
+++ b/app/models/schemas/emory_etd_schema.rb
@@ -5,15 +5,7 @@ module Schemas
     property :abstract,              predicate: "http://purl.org/dc/terms/abstract"
     property :table_of_contents,     predicate: "http://purl.org/dc/terms/tableOfContents"
     property :creator,               predicate: "http://id.loc.gov/vocabulary/relators/aut"
-    property :graduation_year,       predicate: "http://purl.org/dc/terms/issued", multiple: false
     property :keyword,               predicate: "http://schema.org/keywords"
-    property :email,                 predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#officeEmailAddress"
-    property :post_graduation_email, predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateEmailAddress"
     property :graduation_date,       predicate: "http://purl.org/dc/terms/issued"
-    property :hidden,                predicate: "http://emory.edu/local/hidden", multiple: false
-    property :files_embargoed,       predicate: "http://purl.org/spar/pso/embargoed#files", multiple: false
-    property :abstract_embargoed,    predicate: "http://purl.org/spar/pso/embargoed#abstract", multiple: false
-    property :toc_embargoed,         predicate: "http://purl.org/spar/pso/embargoed#toc", multiple: false
-    property :embargo_length,        predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false
   end
 end


### PR DESCRIPTION
All of the attributes removed from
**/app/models/schemas/emory_etd_schema.rb**
are also defined (duplicated) in
**/app/models/etd.rb**

This is the first step to defining all attributes in a single location.

This PR also resolves a number of occurences of this type of
warning message in logs:
```
W, [2021-02-24T20:01:54.009886 #962]  WARN -- : Same predicate (http://purl.org/spar/pso/embargoed#abstract) used for properties abstract_embargoed and abstract_embargoed
```