### PR TITLE
Index `embargo_length` as a singluar, searchable, stored value in Solr

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -129,7 +129,7 @@ class Etd < ActiveFedora::Base
   end
 
   property :embargo_length, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
-    index.as :displayable
+    index.as :stored_sortable
   end
 
   # should always be Emory University (http://id.loc.gov/vocabulary/organizations/geu)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -93,7 +93,7 @@ class SolrDocument
   end
 
   def embargo_length
-    self['embargo_length_ssm']
+    self['embargo_length_ssi']
   end
 
   def graduation_year

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -120,7 +120,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
         if degree_awarded
           "[Abstract embargoed until #{formatted_embargo_release_date}] "
         elsif embargo_length
-          "[Abstract embargoed until #{embargo_length.first} post-graduation] "
+          "[Abstract embargoed until #{embargo_length} post-graduation] "
         else
           "[Abstract embargoed until post-graduation] "
         end
@@ -154,7 +154,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     if embargo_release_date && toc_embargoed
       admin_return_message +=
         if embargo_length && !degree_awarded
-          "[Table of contents embargoed until #{embargo_length.first} post-graduation] "
+          "[Table of contents embargoed until #{embargo_length} post-graduation] "
         elsif embargo_release_date
           "[Table of contents embargoed until #{formatted_embargo_release_date}] "
         else


### PR DESCRIPTION
Previously `embargo_length` was indexed as a stored, but not indexed,
symbol (`_ssm`).  This prevents searching Solr for the attribute,
which has made debugging certain embargo and graduation bugs difficult.

The changes index the attribute as a single-value symbol (`_ssi`).
Since the student can only choose one value for the requested embargo
duration, this aligns the data model more closely with the problem domain.