### PR TITLE
Refactor the GraduationService for improved performance [debug-qa]

### DIFF
--- a/app/services/graduationdate_service.rb
+++ b/app/services/graduationdate_service.rb
@@ -1,6 +1,0 @@
-# services/graduationdate_service.rb
-class GraduationdateService < Hyrax::LaevigataAuthorityService
-  def initialize
-    super('graduation_dates')
-  end
-end


### PR DESCRIPTION
The current GraduationService takes over 30 minutes to run against
production data.  Analysis indicated that the current query for
candiate ETD works takes over 10 minutes to process and returns
over 6000 ETDs that have already been processed by the service and
are already in a 'published' state.

This PR queries only for ETDs that are 'approved' which is the only
group that are eligible for graduation and publication.  Querying in
this way also eliminates the need for additional error handling code,
thereby simplifying the overall service.