### PR TITLE
Refactor workflow setup to improve performance

### DIFF
--- a/lib/workflow_setup.rb
+++ b/lib/workflow_setup.rb
@@ -40,6 +40,7 @@ class WorkflowSetup
       @logger.debug "Attempting to make admin set for #{as}"
       make_admin_set_from_config(as)
     end
+    load_workflows
     everyone_can_deposit_everywhere
     give_superusers_superpowers
   end
@@ -208,14 +209,10 @@ class WorkflowSetup
   def make_admin_set(admin_set_title)
     if AdminSet.where(title_sim: admin_set_title).count > 0
       @logger.debug "AdminSet #{admin_set_title} already exists."
-      load_workflows # Load workflows even if the AdminSet exists already, in case new workflows have appeared
       return AdminSet.where(title_sim: admin_set_title).first
     end
-    a = AdminSet.new
-    a.title = [admin_set_title]
-    a.save
+    a = AdminSet.create(title: [admin_set_title])
     Hyrax::AdminSetCreateService.call(admin_set: a, creating_user: @admin_set_owner)
-    load_workflows # You must load_workflows after every AdminSet creation
     a
   end
 


### PR DESCRIPTION
## Overview
This change moves a relatively expensive operation that loads
workflow configuration from the inside of a loop that gets executed
many times and runs it only once afterwards.

Invoking load_workflows reloads workflows for all existing admin_sets.
If we do this after each new admin set, the first call runs for 1 set,
the second call for 2 sets, the third for 3 sets, etc. resulting in
1+2+3+...+n reloads.  This exponential performance gives us a cost of
n(n+1)/2 for the whole process.

Since we're not running any other operations in between, we can just
reload all the workflows after we've created all the admin sets for
a linear cost of n (the number of admin sets) for the whole process.

The intent of this change is to improve performance without changing
behavior, so the test suite should run (faster) without needing to
be modified.

## Test Suite
Test suite statistics from runs on Mark's local system: `bundle exec rspec`

**BEFORE ~63 minutes**
```
Finished in 62 minutes 59 seconds (files took 18.18 seconds to load)
710 examples, 0 failures, 9 pending

Randomized with seed 41307
```

**AFTER ~31 minutes**
```
Finished in 30 minutes 34 seconds (files took 17.01 seconds to load)
710 examples, 0 failures, 9 pending

Randomized with seed 4098
```

## Deployment
Capistrano deployment to the QA server: `bundle exec cap qa deploy`

**BEFORE ~7 minutes**
```
06:56 deploy:log_revision
      01 echo "Branch main (at 7b65ef2d51e9c8f1c556e4c96f6f6b3046905bb7) deployed as release 20210315023628 by mark" >…
    ✔ 01 deploy@qa-etd.library.emory.edu 0.103s
```

**AFTER ~ 4 minutes**
```
03:59 deploy:log_revision
      01 echo "Branch debug-qa (at a2f4ebda6c5e87c4301bd00ac29ebeccfcec9baf) deployed as release 20210315024627 by mar…
    ✔ 01 deploy@qa-etd.library.emory.edu 0.105s
