### PR TITLE
Update logging in GraduationJob

### DIFF
--- a/app/jobs/proquest_job.rb
+++ b/app/jobs/proquest_job.rb
@@ -16,7 +16,7 @@ class ProquestJob < ActiveJob::Base
   def perform(work_id, transmit: true, cleanup: true, retransmit: false)
     @work = Etd.find(work_id)
     return unless ProquestJob.submit_to_proquest?(@work, retransmit)
-    Rails.logger.info "Submitting #{work_id} to ProQuest"
+    Rails.logger.info "ETD #{work_id} beginning submission to ProQuest"
     # 1. Create a directory. Done. See config/environments
     # 2. Write XML file there Done.
     # 3. Write PDF and supplementary files there. Done.
@@ -26,6 +26,7 @@ class ProquestJob < ActiveJob::Base
     transmit_file if transmit
     cleanup_file if cleanup
     ProquestCompletionJob.perform_later(work_id)
+    Rails.logger.info "ETD #{work_id} finished submission to ProQuest"
   end
 
   # Does this work meet the criteria required for ProQuest submission?


### PR DESCRIPTION
This moves logging to the end of methods to record successful process
completion and/or adds begin and end process notification bracketing.

This change also removes redundant references to GraduationJob since
those are automatically provided by the ActiveJob logging process:

BEFORE:
```
W, [2021-04-19T11:47:50.152095 #13000]  WARN -- : [ActiveJob] [GraduationJob] [b9647bd8-4899-4e21-baee-86c0925e80fe] Graduation Job: ETD bv73c168z graduation recorded as 2021-01-04
```

AFTER:
```
W, [2021-04-19T11:47:50.152095 #13000]  WARN -- : [ActiveJob] [GraduationJob] [b9647bd8-4899-4e21-baee-86c0925e80fe] ETD bv73c168z graduation recorded as 2021-01-04
```