### PR TITLE
Update yarn package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "vue-loader": "^15.7.0",
     "vue-quill-editor": "^3.0.6",
     "vue-template-compiler": "^2.6.10",
-    "vue-turbolinks": "^2.0.3"
+    "vue-turbolinks": "^2.0.3",
+    "webpack-cli": "^3.3.2"
   },
   "scripts": {
     "test": "jest"
@@ -33,7 +34,6 @@
     "source-map-support": "^0.5.6",
     "vue-jest": "^2.6.0",
     "vue-test-utils": "^1.0.0-beta.11",
-    "webpack-cli": "^3.3.2",
     "webpack-dev-server": "3.11.2"
   },
   "jest": {


### PR DESCRIPTION
Deploying the application is giving us a `webpack-cli` related warning
in production environments.  We're moving it to ensure it gets installed
when deploying to new environments.

Tested on staging-etd and this resolves our previous problem!