### PR TITLE
Use feature flipper to hide "Edit" option in menu

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -13,11 +13,11 @@
     <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
 
     <% if can?(:edit, file_set.id) %>
-      <li role="menuitem" tabindex="-1">
-        <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
-          { title: "Edit #{file_set}" } %>
-      </li>
-      <% if Flipflop.versions_link? %>
+      <% if Flipflop.versions_and_edit_links? %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
+            { title: "Edit #{file_set}" } %>
+        </li>
         <li role="menuitem" tabindex="-1">
           <%= link_to 'Versions',  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
             { title: "Display previous versions" } %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -3,7 +3,7 @@ Flipflop.configure do
           default: false,
           description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled. For use in "
 
-  feature :versions_link,
+  feature :versions_and_edit_links,
           default: false,
-          description: "Display the 'Versions' link under the 'Actions' menu"
+          description: "Display the 'Versions' and 'Edit' links under the 'Actions' menu"
 end

--- a/spec/system/embargo_show_spec.rb
+++ b/spec/system/embargo_show_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
   end
 
   scenario "viewed by approver pre-graduation" do
-    allow(Flipflop).to receive(:versions_link?).and_return(false)
+    allow(Flipflop).to receive(:versions_and_edit_links?).and_return(false)
     etd.embargo_length = "6 months"
     etd.save
     expect(etd.degree_awarded).to eq nil
@@ -103,10 +103,11 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
     click_on "Select an action"
     expect(page).to have_content "Download"
     expect(page).not_to have_content "Versions"
+    expect(page).not_to have_content "Edit"
   end
 
   scenario "viewed by approver with Versions enabled" do
-    allow(Flipflop).to receive(:versions_link?).and_return(true)
+    allow(Flipflop).to receive(:versions_and_edit_links?).and_return(true)
     etd.embargo_length = "6 months"
     etd.save
     login_as approving_user
@@ -114,6 +115,7 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
     click_on "Select an action"
     expect(page).to have_content "Download"
     expect(page).to have_content "Versions"
+    expect(page).to have_content "Edit"
   end
 
   scenario "viewed by a school approver post-graduation" do

--- a/spec/system/feature_set_spec.rb
+++ b/spec/system/feature_set_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Feature configuration', type: :system, integration: true do
       expect(Flipflop.proxy_deposit?).to eq false
       expect(Flipflop.transfer_works?).to eq false
       expect(Flipflop.batch_upload?).to eq false
-      expect(Flipflop.versions_link?).to eq false
+      expect(Flipflop.versions_and_edit_links?).to eq false
     end
   end
 end


### PR DESCRIPTION
Connected to https://github.com/curationexperts/laevigata/issues/2159

Feature flipper off:
![image](https://user-images.githubusercontent.com/45948126/126502755-c70a13dd-4428-444e-85bb-ae832dbd7da2.png)

Feature flipper on:
![image](https://user-images.githubusercontent.com/45948126/126502921-2e84c7b5-627f-495a-963f-34f7a2393828.png)
