### PR TITLE
Update Nokogumbo version to address dependency warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'rack', '>= 2.1.4'
 gem 'rails', '>= 5.2.4.5'
 gem 'rsolr', '~> 1.0'
 gem 'rubyzip'
-gem 'sanitize', '~> 5.2'
+gem 'sanitize', '~> 6.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -879,10 +879,9 @@ GEM
     rubyzip (2.3.0)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
-    sanitize (5.2.3)
+    sanitize (6.0.0)
       crass (~> 1.0.2)
-      nokogiri (>= 1.8.0)
-      nokogumbo (~> 2.0)
+      nokogiri (>= 1.12.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -1101,7 +1100,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   rspec_junit_formatter
   rubyzip
-  sanitize (~> 5.2)
+  sanitize (~> 6.0)
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers


### PR DESCRIPTION
Addresses the following notification triggered on application launch
```
NOTE: nokogumbo: Using Nokogiri::HTML5 provided by Nokogiri. See https://github.com/sparklemotion/nokogiri/issues/2205 for more information.
```