### PR TITLE
During various debugging processes, we've had difficulty differentiat…

### DIFF
--- a/app/actors/hyrax/actors/pregrad_embargo.rb
+++ b/app/actors/hyrax/actors/pregrad_embargo.rb
@@ -4,6 +4,8 @@ module Hyrax
     # Sets pregraduation embargo attributes for interpretation by the rest of
     # the stack.
     class PregradEmbargo < AbstractActor
+      LENGTH = 500.years
+
       def create(env)
         env.attributes.merge!(pregraduation_embargo_attributes(env)) &&
           next_actor.create(env)
@@ -20,7 +22,7 @@ module Hyrax
           open = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
 
-          { embargo_release_date:      (Time.zone.today + 6.years).to_s,
+          { embargo_release_date:      (Time.zone.today + LENGTH).to_s,
             visibility:                embargo,
             visibility_after_embargo:  open,
             visibility_during_embargo: open }

--- a/spec/actors/hyrax/actors/pregrad_embargo_spec.rb
+++ b/spec/actors/hyrax/actors/pregrad_embargo_spec.rb
@@ -43,7 +43,7 @@ describe Hyrax::Actors::PregradEmbargo do
     end
 
     context 'with a requested embargo' do
-      let(:six_years_from_today) { Time.zone.today + 6.years }
+      let(:provisional_release_date) { Time.zone.today + described_class::LENGTH }
 
       let(:attributes) do
         { 'title' => ['good fun'],
@@ -63,7 +63,7 @@ describe Hyrax::Actors::PregradEmbargo do
       it 'sets pre-graduation embargo attributes' do
         expect { middleware.create(env) }
           .to change { env.attributes }
-          .to include embargo_release_date: six_years_from_today.to_s,
+          .to include embargo_release_date: provisional_release_date.to_s,
                       visibility_during_embargo: open,
                       visibility_after_embargo: open,
                       visibility: embargo


### PR DESCRIPTION
During various debugging processes, we've had difficulty differentiating between 
valid 6-year school based embargoes and left-over 6-year embargoes applied 
during the pre-graduation approval process.

This commit makes the pre-graduation embargoes 500 years in length so they're
easy to distinguish from other embargoes.