### PR TITLE
Refactor attribute "embargo_length" name for clarity

### DIFF
--- a/app/actors/hyrax/actors/pregrad_embargo.rb
+++ b/app/actors/hyrax/actors/pregrad_embargo.rb
@@ -14,10 +14,10 @@ module Hyrax
       private
 
         def pregraduation_embargo_attributes(env)
-          return {} unless env.attributes.key?(:embargo_length)
+          return {} unless env.attributes.key?(:requested_embargo_duration)
 
           return handle_malformed_data(env) if
-            env.attributes.fetch(:embargo_length, nil) == InProgressEtd::NO_EMBARGO
+            env.attributes.fetch(:requested_embargo_duration, nil) == InProgressEtd::NO_EMBARGO
 
           open = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
@@ -38,7 +38,7 @@ module Hyrax
         #   graduation.
         def handle_malformed_data(env)
           warn "#{self.class} is cleaning up non-date data passed to the " \
-               ":embargo_length attribute. #{env.attributes[:embargo_length]} " \
+               ":embargo_length attribute. #{env.attributes[:requested_embargo_duration]} " \
                "is being interpreted as a request for no embargo on " \
                "#{env.attributes[:title]}."
 

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -30,7 +30,7 @@ module Hyrax
     self.terms += [:other_copyrights]
     self.terms += [:patents]
     # my embargo terms
-    self.terms += [:embargo_length]
+    self.terms += [:requested_embargo_duration]
     self.terms += [:embargo_release_date]
     self.terms += [:embargo_type]
     self.terms += [:files_embargoed]

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -128,7 +128,7 @@ class Etd < ActiveFedora::Base
     EMBARGO_TRUTHINESS_VALUES.include?(super)
   end
 
-  property :embargo_length, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
+  property :requested_embargo_duration, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
     index.as :stored_sortable
   end
 

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -26,7 +26,7 @@ class FileSet < ActiveFedora::Base
   delegate :visibility,  to: :visibility_translator
   delegate :visibility=, to: :visibility_translator
 
-  property :embargo_length, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
+  property :requested_embargo_duration, predicate: "http://purl.org/spar/fabio/hasEmbargoDuration", multiple: false do |index|
     index.as :displayable
   end
 

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -105,7 +105,7 @@ class InProgressEtd < ApplicationRecord
   # currently the EtdForm uses the boolean param "no_embargoes", so we need to send or remove it (seems a good candidate for refactoring in EtdForm)
 
   def add_no_embargoes(new_data)
-    resulting_data = new_data[:embargo_length] == NO_EMBARGO ? new_data.merge("no_embargoes" => "1") : nil
+    resulting_data = new_data[:requested_embargo_duration] == NO_EMBARGO ? new_data.merge("no_embargoes" => "1") : nil
 
     resulting_data.nil? ? new_data : resulting_data
   end
@@ -114,8 +114,8 @@ class InProgressEtd < ApplicationRecord
   # Remove no_embargoes if new_data[:embargo_length] != NO_EMBARGO
 
   def remove_stale_embargo_data(existing_data, new_data)
-    existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:embargo_length] != NO_EMBARGO
-    existing_data.delete('embargo_type') if new_data[:embargo_length] == NO_EMBARGO && existing_data.keys.include?('embargo_type')
+    existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:requested_embargo_duration] != NO_EMBARGO
+    existing_data.delete('embargo_type') if new_data[:requested_embargo_duration] == NO_EMBARGO && existing_data.keys.include?('embargo_type')
     existing_data
   end
 

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -6,7 +6,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
            :degree,
            :degree_awarded,
            :department,
-           :embargo_length,
+           :requested_embargo_duration,
            :files_embargoed,
            :graduation_year,
            :language,

--- a/app/views/hyrax/base/_form_embargoes.html.erb
+++ b/app/views/hyrax/base/_form_embargoes.html.erb
@@ -33,5 +33,5 @@
   </div>
 
   <h4>How long will the embargo last?</h4>
-  <%= f.input :embargo_length, as: :select, collection: ["6 months", "1 year", "2 years", "6 years"], required: true, label: false, hint: "Choose the length of time for your embargo.", input_html: { class: 'form-control required-embargo' } %>
+  <%= f.input :requested_embargo_duration, as: :select, collection: ["6 months", "1 year", "2 years", "6 years"], required: true, label: false, hint: "Choose the length of time for your embargo.", input_html: { class: 'form-control required-embargo' } %>
 </div>

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -27,7 +27,7 @@
       <%= presenter.attribute_to_html(:files_embargoed, label: "Files Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:abstract_embargoed, label: "Abstract Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:toc_embargoed, label: "Table of Contents Under Embargo", include_empty: true)%>
-      <%= presenter.attribute_to_html(:embargo_length, label: "Length of Embargo")%>
+      <%= presenter.attribute_to_html(:requested_embargo_duration, label: "Length of Embargo")%>
     <% end %>
   </tbody>
 </table>

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -92,7 +92,7 @@ namespace :sample_data do
     upload1 = Hyrax::UploadedFile.create(user: user, file: file1, pcdm_use: 'primary')
     upload2 = Hyrax::UploadedFile.create(user: user, file: file2, pcdm_use: 'supplementary')
 
-    attributes_for_actor = { embargo_length: etd.embargo_length, uploaded_files: [upload1.id, upload2.id] }
+    attributes_for_actor = { requested_embargo_duration: etd.embargo_length, uploaded_files: [upload1.id, upload2.id] }
     env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
     Hyrax::CurationConcern.actor.create(env)
 

--- a/spec/jobs/graduation_job_with_embargo_spec.rb
+++ b/spec/jobs/graduation_job_with_embargo_spec.rb
@@ -30,7 +30,7 @@ describe GraduationJob, :perform_jobs, integration: true do
         files_embargoed: true,
         abstract_embargoed: true,
         toc_embargoed: true,
-        embargo_length: '6 months'
+        requested_embargo_duration: '6 months'
       ]
     }
     let(:open_access) {
@@ -38,7 +38,7 @@ describe GraduationJob, :perform_jobs, integration: true do
         files_embargoed: false,
         abstract_embargoed: false,
         toc_embargoed: false,
-        embargo_length: InProgressEtd::NO_EMBARGO
+        requested_embargo_duration: InProgressEtd::NO_EMBARGO
       ]
     }
 

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe FileSet do
 
   context 'with a new FileSet' do
     its(:pcdm_use) { is_expected.to be_nil }
-    its(:embargo_length) { is_expected.to be_nil }
+    its(:requested_embargo_duration) { is_expected.to be_nil }
     its(:premis?) { is_expected.to be false }
     its(:primary?) { is_expected.to be false }
     its(:supplementary?) { is_expected.to be true }

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -343,7 +343,7 @@ describe InProgressEtd do
     describe 'no embargoes' do
       context 'with existing no_embargoes data and new embargo data' do
         let(:old_data) { { no_embargoes: '1' } }
-        let(:new_data) { { 'embargo_length': '1 Year', 'embargo_type': 'Files' } }
+        let(:new_data) { { requested_embargo_duration: '1 Year', 'embargo_type': 'Files' } }
 
         it "removes the old no_embargoes parameter and adds the new embargo lengths and types" do
           expect(resulting_data).to eq({
@@ -356,7 +356,7 @@ describe InProgressEtd do
 
       context 'with existing no_embargoes and new no_embargoes' do
         let(:old_data) { { no_embargoes: '1' } }
-        let(:new_data) { { 'embargo_length': described_class::NO_EMBARGO } }
+        let(:new_data) { { requested_embargo_duration: described_class::NO_EMBARGO } }
 
         it "preserves the no_embargoes and adds the new embargo_length data" do
           expect(resulting_data).to eq({
@@ -368,8 +368,8 @@ describe InProgressEtd do
       end
 
       context 'with existing embargoes and new embargo data' do
-        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
-        let(:new_data) { { 'embargo_length': '2 Years', 'embargo_type': 'files_embargoed, toc_embargoed' } }
+        let(:old_data) { { requested_embargo_duration: '1 Year', 'embargo_type': 'files_embargoed' } }
+        let(:new_data) { { requested_embargo_duration: '2 Years', 'embargo_type': 'files_embargoed, toc_embargoed' } }
 
         it 'sets new embargo length and type and does not set no_embargoes' do
           expect(resulting_data).to eq({
@@ -381,9 +381,9 @@ describe InProgressEtd do
       end
 
       context 'with existing embargoes and new no embargo data' do
-        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
+        let(:old_data) { { requested_embargo_duration: '1 Year', 'embargo_type': 'files_embargoed' } }
 
-        let(:new_data) { { 'embargo_length': described_class::NO_EMBARGO } }
+        let(:new_data) { { requested_embargo_duration: described_class::NO_EMBARGO } }
 
         it 'removes old embargo lengths and types and sets no_embargoes' do
           expect(resulting_data).to eq({
@@ -675,14 +675,14 @@ describe InProgressEtd do
     context 'with stale data in data store' do
       let(:stale_data) {
         {
-        title: 'Stale Title from IPE',
-        partnering_agency: ['Stale parter agency'],
-        embargo_length: '1000 years',
-        department: ['Some'],
-        other_copyrights: 'true',
-        requires_permissions: 'true',
-        patents: 'true',
-        research_field: 'Cryptozoology'
+          title: 'Stale Title from IPE',
+          partnering_agency: ['Stale parter agency'],
+          requested_embargo_duration: '1000 years',
+          department: ['Some'],
+          other_copyrights: 'true',
+          requires_permissions: 'true',
+          patents: 'true',
+          research_field: 'Cryptozoology'
         }
       }
 

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -164,7 +164,7 @@ describe EtdPresenter do
 
         context 'with an abstract embargo' do
           let(:degree_awarded) { nil }
-          let(:embargo_length) { '6 months' }
+          let(:requested_embargo_duration) { '6 months' }
 
           before do
             etd.embargo_length     = embargo_length
@@ -192,7 +192,7 @@ describe EtdPresenter do
           end
 
           context "but no #embargo_length" do
-            let(:embargo_length) { nil }
+            let(:requested_embargo_duration) { nil }
 
             it "displays the abstract with embargo_length" do
               expect(presenter.abstract_with_embargo_check)

--- a/spec/system/show_etd_spec.rb
+++ b/spec/system/show_etd_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system 
     FactoryBot.create(:sample_data_with_copyright_questions,
                       partnering_agency: ["CDC"],
                       school: ["Candler School of Theology"],
-                      embargo_length: "6 months",
+                      requested_embargo_duration: "6 months",
                       files_embargoed: false,
                       toc_embargoed: nil,
                       abstract_embargoed: '')


### PR DESCRIPTION
We've had a term named `embargo_length` which stores the embargo
duration a student is requesting be applied once they graduate.

This term reads very similar to `embargo_release_date` which is
the actual date an embargo will expire once a student has graduated.
Both of these fields frequently occur in close proximilty in the code
making it hard to remember which is the requestsed, but not final,
value and which is the actual value applied when the work is published.

This change just renames the requested value from
`embargo_length` to `requested_embargo_duration`
in order to help make it easier to distinquish role of the two values
in the code.