### PR TITLE
Speed up contact page test

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,12 @@ end
 RSpec.configure do |config|
   include Noid::Rails::RSpec
 
+  # Set the environment variable `SMOKE_TEST` to run slow running
+  # tests that provide additional information about configuration, integration
+  # with external services, or other checks that provide useful feedback,
+  # but don't impact core coverage
+  config.filter_run_excluding(smoke_test: true) unless ENV['SMOKE_TEST']
+
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   ENV['REGISTRAR_DATA_PATH'] = "#{::Rails.root}/spec/fixtures/registrar_sample.json"
   config.use_transactional_fixtures = true

--- a/spec/system/contact_form_spec.rb
+++ b/spec/system/contact_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'contact form page', integration: true, type: :system do
+RSpec.describe 'contact form page', integration: true, smoke_test: true, type: :system do
   scenario 'contact form creation from libwizard', js: true do
     visit "/contact"
 

--- a/spec/views/hyrax/contact_form/new.html.erb_spec.rb
+++ b/spec/views/hyrax/contact_form/new.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# NOTE: This spec tests the page linked from "ETD Help" in the application footer
+# (the "Contact Us" link in the footer connects out to a general SCO help page)
+# This spec tests that we are overriding the default Hyrax contact page,
+# For speed and isolation reasons, this test does not attempt to run the remote
+# javascript from libwizard or validate the remote script's results
+RSpec.describe 'hyrax/contact_form/new.html.erb', type: :view do
+  it 'overrides the default Hyrax page' do
+    render
+    # the replacement page should have instructions and a script that loads a form from libwizard
+    expect(rendered).to have_css('div.instructions')
+    expect(rendered).to match('src="//emory.libwizard.com/form_loader.php')
+  end
+end


### PR DESCRIPTION
The previous test loaded and executed remote javascript from the
libwizard site.  While it's useful to know that this code is running
successfully and inserting the expected iframe form into the ETD Help
page, the test takes a very long time to run and the javascript does
not always load from the remote site before the test times out.

This change flags that test as a smoke_test that is not run during
regular runs of the test suite.  It also adds a view test that ensures
the default Hyrax contact form is replaced by the local form which
embeds the expected libwizard script.