### PR TITLE
Flag slow test as a smoke_test

### DIFF
--- a/spec/lib/workflow_setup_spec.rb
+++ b/spec/lib/workflow_setup_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe WorkflowSetup, :clean do
       end
     end
   end
-  context "creating all the admin sets" do
+  context "creating all the admin sets", smoke_test: true do
     let(:w) { described_class.new("#{fixture_path}/config/emory/superusers.yml", Rails.root.join('config', 'emory', 'admin_sets.yml'), "/dev/null") }
     it "doesn't miss any" do
       allow(w).to receive(:load_workflows)


### PR DESCRIPTION
This test doesn't test any code that isn't tested elsewhere,
it just tests it more times by runing the full production config file
that sets up 21 admin sets - i.e. it runs the same tests 21 times.

While it's somewhat useful to know that all currently configured
admin sets in config/emory/admin_sets.yml are setup correctly, that
can be manually verified in the dashboard on the page at
https://etd.library.emory.edu/schools

Long term, this check probably belongs in some kind of deployment check
rather than the main test suite.