### PR TITLE
Fix intermittent failures in GraduationJob test

### DIFF
--- a/spec/jobs/graduation_job_with_embargo_spec.rb
+++ b/spec/jobs/graduation_job_with_embargo_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 # * update the embargo release date to the user's graduation date plus their requested embargo length
 # * expire the embargo if it has already passed (sometimes happens when graduation is delayed)
 # * send notifications
-describe GraduationJob, :perform_jobs, integration: true do
+describe GraduationJob, :perform_jobs, integration: true, clean: true do
   context "standard cases" do
     let(:user)        { FactoryBot.create(:user) }
     let(:ability)     { ::Ability.new(user) }


### PR DESCRIPTION
The GraduationJob test group is failing intermittently with an error
in workflow setup code outside the test examples.

This seems to be due to adminsets and other workflow setup left in an
unstable state by other tests in certain randomized orderings.
Although it's a somewhat expesive operation, ading the `clean: true` tag
to the test group ensures that Fedora is cleared before the group and
workflow setup can run successfully.

The specific failure this change is intended to address is
```
Failure/Error:
  next if Hyrax::PermissionTemplateAccess
            .find_by(permission_template_id: admin_set.permission_template.id,
                     agent_id:   'registered',
                     access:     'deposit',
                     agent_type: 'group')

ActiveRecord::RecordNotFound:
  Couldn't find Hyrax::PermissionTemplate
./lib/workflow_setup.rb:156:in `block in everyone_can_deposit_everywhere'
./lib/workflow_setup.rb:154:in `everyone_can_deposit_everywhere'
./lib/workflow_setup.rb:44:in `setup'
./spec/jobs/graduation_job_with_embargo_spec.rb:46:in `block (3 levels) in <top (required)>'
```