### PR TITLE
Fix flaky GraduationJob tests

### DIFF
--- a/spec/jobs/graduation_job_with_embargo_spec.rb
+++ b/spec/jobs/graduation_job_with_embargo_spec.rb
@@ -43,6 +43,7 @@ describe GraduationJob, :perform_jobs, integration: true do
     }
 
     before :all do
+      ActiveFedora::Cleaner.clean!
       WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null").setup
     end
 


### PR DESCRIPTION
All tests in the GraduationJob test group are periodically failing
with the same error:
```
ActiveRecord::RecordNotFound:
  Couldn't find Hyrax::PermissionTemplate
./lib/workflow_setup.rb:156:in `block in everyone_can_deposit_everywhere'
./lib/workflow_setup.rb:154:in `everyone_can_deposit_everywhere'
./lib/workflow_setup.rb:44:in `setup'
./spec/jobs/graduation_job_with_embargo_spec.rb:46:in `block (3 levels) in <top (required)>'
```

This failure is occuring in the workflow setup called in the `before` block
for the test group.  It appears that depending on the randomized order of other
tests, the AdminSets and Workflow may be left in a state incompatible with
the workflow setup for this test group, causing the setup to silently fail.

Explicitly resetting Fedora to a clean state allows the workflow setup
to run successfully and leave Workflows in the state expected by
the rest of the test group.