### PR TITLE
Only run ActiveFedora cleaner once per example

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,9 +88,9 @@ RSpec.configure do |config|
     ActiveFedora::Cleaner.clean!
   end
 
-  config.after clean: true do
-    ActiveFedora::Cleaner.clean!
-  end
+  # config.after clean: true do
+  #   ActiveFedora::Cleaner.clean!
+  # end
 
   config.before perform_jobs: true do
     ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
@@ -116,9 +116,9 @@ RSpec.configure do |config|
     WorkflowSetup.new(*setup_args).setup
   end
 
-  config.after(:example, :workflow) do |example|
-    ActiveFedora::Cleaner.clean!
-  end
+  # config.after(:example, :workflow) do |example|
+  #   ActiveFedora::Cleaner.clean!
+  # end
 
   config.before do
     class_double("Clamby").as_stubbed_const


### PR DESCRIPTION
In trying to mimic transactional database rollback behavior, the
`clean` tag was set up to wipe out Fedora data both before and
after examples were run.  Cleaning Fedora is different than rolling
back transactions that occured during the test (and takes more time).

Our long-term goal is to run clean only where absolutely necessary.
This change starts that process by eliminating unnecessary cleaning
after examples.