### PR TITLE
Previously, the embargo tests were running expensive setup once for

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,7 +1,7 @@
 <% if presenter.files_embargo_check %>
-  <%= image_tag "No_Preview.png", class: "representative-media thumbnail" %>
+  <%= image_tag "No_Preview.png", class: "representative-media thumbnail", alt: "Preview image embargoed" %>
 <% elsif presenter.representative_id.present? && presenter.representative_presenter.present? %>
-  <%= media_display presenter.representative_presenter %>
+  <%= media_display presenter.representative_presenter, alt: "Preview image" %>
 <% else %>
-  <%= image_tag 'default.png', class: "canonical-image" %>
+  <%= image_tag 'default.png', class: "canonical-image", alt: "No preview image available" %>
 <% end %>


### PR DESCRIPTION
test example.  This change refactors the setup to only run once per
test group.  Overall, this results in over 50% faster testing time.

**BEFORE**
```
% bundle exec rspec ./spec/system/embargo_show_spec.rb
Run options: exclude {:smoke_test=>true}

Randomized with seed 38550
.....

Top 5 slowest examples (396.2 seconds, 100.0% of total time):
  Display an ETD with embargoed content viewed by depositor pre-graduation
    93.76 seconds ./spec/system/embargo_show_spec.rb:62
  Display an ETD with embargoed content viewed by unauthenticated user post-graduation
    89.25 seconds ./spec/system/embargo_show_spec.rb:138
  Display an ETD with embargoed content viewed by approver with Versions enabled
    84.82 seconds ./spec/system/embargo_show_spec.rb:109
  Display an ETD with embargoed content viewed by a school approver post-graduation
    64.39 seconds ./spec/system/embargo_show_spec.rb:121
  Display an ETD with embargoed content viewed by approver pre-graduation
    63.98 seconds ./spec/system/embargo_show_spec.rb:87

Finished in 6 minutes 36 seconds (files took 15.28 seconds to load)
5 examples, 0 failures

Randomized with seed 38550

```

**AFTER**
```
% bundle exec rspec ./spec/system/embargo_show_spec.rb --seed 38550
Run options: exclude {:smoke_test=>true}

Randomized with seed 38550
.....

Top 5 slowest examples (72.11 seconds, 54.1% of total time):
  Display an ETD with embargoed content post graduation
    22.21 seconds ./spec/system/embargo_show_spec.rb:112
  Display an ETD with embargoed content viewed by approver pre-graduation
    15.97 seconds ./spec/system/embargo_show_spec.rb:83
  Display an ETD with embargoed content viewed by depositor pre-graduation
    13.81 seconds ./spec/system/embargo_show_spec.rb:61
  Display an ETD with embargoed content base etd has expected embargo values after creation
    10.12 seconds ./spec/system/embargo_show_spec.rb:47
  Display an ETD with embargoed content viewed by approver with Versions enabled
    10 seconds ./spec/system/embargo_show_spec.rb:102

Finished in 2 minutes 13.3 seconds (files took 15.44 seconds to load)
5 examples, 0 failures

Randomized with seed 38550

```