### PR TITLE
Clean up expired embargo UI

### DIFF
--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -131,4 +131,8 @@ div#supplemental_fileupload table#supplemental_files_metadata input{
   padding-left: 0px;
 }
 
-
+input.update_child_embargoes {
+  margin-left: 0.5rem;
+  margin-top: 1rem;
+  margin-right: 1rem;
+}

--- a/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
@@ -1,0 +1,48 @@
+<% if assets_with_expired_embargoes.blank? %>
+
+  <table class="embargoes table">
+    <thead>
+      <tr>
+        <%= render partial: 'table_headers' %>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td colspan="5" class="text-center">
+          <p><%= t('.missing') %></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+<% else %>
+
+  <%= form_tag embargoes_path, method: :patch do %>
+    <%= submit_tag t('.deactivate_selected'), class: 'btn btn-primary' %>
+    <table class="embargoes table datatable">
+      <thead>
+        <tr>
+          <th><input type="checkbox" id="checkAllBox" class="batch_document_selector"/> Select All</th>
+          <%= render partial: 'table_headers' %>
+        </tr>
+      </thead>
+      <tbody>
+      <% assets_with_expired_embargoes.each_with_index do |curation_concern, i| %>
+        <tr>
+          <td><%= render 'hyrax/batch_select/add_button', document: curation_concern %></td>
+          <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
+          <td class="title"><%= link_to curation_concern, edit_embargo_path(curation_concern) %></td>
+          <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
+          <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
+          <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
+          <td class="actions"><%= link_to t('.deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-primary' %><br/>
+            <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true, class: "update_child_embargoes" %>
+            <%= t('.change_all', cc: curation_concern) %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+<% end %>

--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -9,3 +9,9 @@ en:
       etd:
         name:               "ETD"
         description:        "Emory Theses and Dissertations"
+    embargoes:
+      list_expired_active_embargoes:
+        change_all: 'Include child objects'
+        deactivate: Release Embargo
+        deactivate_selected: Release Selected Embargoes
+        missing: There are no expired embargoes currently awaiting release.


### PR DESCRIPTION
Update the table layout and language to clarify the function of the
second checkbox in each row.

Default to updating all child works and files when updating embargoes.

**BEFORE**
![image](https://user-images.githubusercontent.com/3064318/150025582-757a8ed7-3630-4855-bbe3-c393388aba38.png)

**AFTER** (Clarify function of second checkbox and default it on)
![image](https://user-images.githubusercontent.com/3064318/150025634-21eee2e8-474e-49ed-b556-212180b401bb.png)