### PR TITLE
Consistently index degree_awarded as a date

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -152,7 +152,24 @@ class Etd < ActiveFedora::Base
   end
 
   property :degree_awarded, predicate: "http://dublincore.org/documents/dcmi-terms/#terms-dateAccepted", multiple: false do |index|
-    index.as :stored_searchable, :facetable
+    index.as :stored_sortable
+  end
+
+  # override degree_awarded setter to always cast the value to a Date type object
+  def degree_awarded=(value)
+    case value
+    when Time, ActiveSupport::TimeWithZone
+      super(value.utc)
+    when Date
+      super(value.to_datetime.utc)
+    when String
+      Rails.logger.warn("Assigning #{__method__} to a string is deprecated. Casting to a Date.")
+      super(DateTime.parse(value).utc)
+    when NilClass
+      super(nil)
+    else
+      raise ArgumentError, "You attempted to set the property 'degree_awarded_date' for ETD id:#{id} to an unsupported value of type '#{value.class}'"
+    end
   end
 
   property :partnering_agency, predicate: "http://id.loc.gov/vocabulary/relators/ctb" do |index|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,7 +81,7 @@ class SolrDocument
   end
 
   def degree_awarded
-    self[Solrizer.solr_name('degree_awarded')]
+    self['degree_awarded_dtsi']
   end
 
   def department

--- a/spec/indexers/etd_indexer_spec.rb
+++ b/spec/indexers/etd_indexer_spec.rb
@@ -27,4 +27,9 @@ RSpec.describe EtdIndexer do
 
     expect(solr_doc['hidden?_bsi']).to be true
   end
+
+  it 'indexes degree_awarded as a sortable date' do
+    etd.degree_awarded = 'December 04, 2012'
+    expect(solr_doc['degree_awarded_dtsi']).to eq '2012-12-04T00:00:00Z'
+  end
 end

--- a/spec/jobs/proquest_job_spec.rb
+++ b/spec/jobs/proquest_job_spec.rb
@@ -47,7 +47,7 @@ describe ProquestJob, :clean do
       expect(etd.degree).to contain_exactly("PhD")
       expect(etd.to_sipity_entity.workflow_state_name).to eq "published"
       expect(etd.proquest_submission_date).to be_empty
-      expect(etd.degree_awarded).not_to be_empty
+      expect(etd.degree_awarded).to be_present
       expect(described_class.submit_to_proquest?(etd)).to eq true
     end
     it "does not submit a hidden work" do

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -318,17 +318,51 @@ RSpec.describe Etd do
     end
   end
 
-  context "degree_awarded" do
+  context "#degree_awarded" do
     let(:etd) { FactoryBot.build(:etd) }
-    it "says when it was awarded" do
-      etd.degree_awarded = "10 July 2017"
-      expect(etd.resource.dump(:ttl)).to match(/dublincore.org\/documents\/dcmi-terms\/#terms-dateAccepted/)
-      expect(etd.degree_awarded).to eq "10 July 2017"
+    it "has the expected RDF predicate" do
+      etd.degree_awarded = "July 10, 2017"
+      etd_json = JSON.parse(etd.resource.dump(:jsonld))
+      expected_predicate = "http://dublincore.org/documents/dcmi-terms/#terms-dateAccepted"
+      expect(etd_json.first[expected_predicate].first["@value"]).to eq "2017-07-10T00:00:00+00:00"
     end
-    it "says whether the student is post-graduation" do
+    it "value controls #post_graduation? response" do
       expect(etd.post_graduation?).to eq false
       etd.degree_awarded = "10 July 2017"
       expect(etd.post_graduation?).to eq true
+    end
+    it "returns a Date class object" do
+      etd.degree_awarded = "10 July 2017"
+      expect(etd.degree_awarded).to be_a_kind_of Date
+    end
+    it "stores Dates in UTC" do
+      tz = Time.zone # save the timezone before changing it
+      Time.zone = "Antarctica/McMurdo"
+      etd.degree_awarded = Time.zone.iso8601("1984-01-01")
+      expect(etd.degree_awarded.utc?).to eq true
+      expect(etd.degree_awarded.iso8601).to eq "1983-12-31T11:00:00+00:00"
+      Time.zone = tz # reset the timezone for the rest of the test suite
+    end
+    it "casts string dates to Date objects" do
+      etd.degree_awarded = "July 10, 2017"
+      july2017 = DateTime.new(2017, 0o7, 10, 0, 0, 0)
+      expect(etd.degree_awarded).to eq july2017
+    end
+    it "handles all Date and Time like classes", :aggregate_failures do
+      expect { etd.degree_awarded = Time.zone.local(1984) }.not_to raise_error
+      expect { etd.degree_awarded = Date.new(1984) }.not_to raise_error
+      expect { etd.degree_awarded = DateTime.new(1984) }.not_to raise_error
+      expect { etd.degree_awarded = Time.zone.iso8601('1984-01-01') }.not_to raise_error # ActiveSupport::TimeZone class
+    end
+    it "handles nil" do
+      expect { etd.degree_awarded = nil }.not_to raise_error
+      expect(etd.degree_awarded).to be_nil
+    end
+    it "raises an error when assigned an invalid object type" do
+      expect { etd.degree_awarded = [1, 2, 3] }.to raise_error(ArgumentError, /unsupported value of type 'Array'/)
+    end
+    it "raises an error when assigned an invalid string" do
+      expect { etd.degree_awarded = "not a real date" }.to raise_error(Date::Error, 'invalid date')
     end
   end
 

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -688,7 +688,7 @@ describe InProgressEtd do
 
       let(:new_data) do
         { 'title' => ['New ETD Title'],
-          'degree_awarded' => 'August 23, 2018',
+          'degree_awarded' => "2018-08-23T00:00:00.000+00:00",
           'embargo_length' => '1000 years',
           'keyword' => ['new keyword'],
           'department' => ['Some'],

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe ::SolrDocument, type: :model do
     end
   end
 
+  describe '#degree_awarded' do
+    subject(:solr_doc) { described_class.new(etd.to_solr) }
+    let(:etd)          { FactoryBot.build(:etd) }
+
+    it 'returns the degree_awarded in UTC' do
+      etd.degree_awarded = 'May 15, 1848'
+      expect(solr_doc.degree_awarded).to eq('1848-05-15T00:00:00Z')
+    end
+  end
+
   describe '#visibility' do
     subject(:solr_doc) { described_class.new(etd.to_solr) }
     let(:etd)          { FactoryBot.build(:etd) }

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -59,7 +59,7 @@ describe EtdPresenter do
                 FactoryBot.build(:etd_with_toc,
                                  embargo_id:     embargo.id,
                                  toc_embargoed:  true,
-                                 degree_awarded: true)
+                                 degree_awarded: '2017-05-31')
               end
 
               it 'lists the embargo' do


### PR DESCRIPTION
We need to use the value stored in `degree_awarded` to support
listing ETDs for indexing by Google Scholar.

Because the code sometimes treated the field as a string and sometimes
treated it as a date or time object, the data was not being consistently
indexed into solr.

The changes here ensure that the value stored in Fedora is always a
date type value and ensures that the serialization stored in Solr
is consistently sortable.