### PR TITLE
Show the graduation date when approvers view ETDs

### DIFF
--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -4,7 +4,6 @@ class EtdPresenter < Hyrax::WorkShowPresenter
            :committee_chair_name,
            :committee_members_names,
            :degree,
-           :degree_awarded,
            :department,
            :embargo_length,
            :files_embargoed,
@@ -14,7 +13,6 @@ class EtdPresenter < Hyrax::WorkShowPresenter
            :partnering_agency,
            :research_field,
            :rights_statement,
-           :submitting_type,
            :table_of_contents,
            :toc_embargoed,
            :requires_permissions,
@@ -78,6 +76,16 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     embargo_release_date.strftime("%d %B %Y")
   end
 
+  def degree_awarded
+    return "graduation pending" unless solr_document.degree_awarded
+    solr_document.degree_awarded.to_date.strftime("%d %B %Y")
+  end
+
+  def submitting_type
+    return "ETD" unless solr_document.submitting_type
+    solr_document.submitting_type.first
+  end
+
   def current_user_roles
     # Note: AdminSets need an exact, non-tokenized solr query. A query like
     # AdminSet.where(title: admin_set) is too broad and might match the wrong AdminSet,
@@ -117,7 +125,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     admin_return_message = ""
     if embargo_release_date && abstract_embargoed
       admin_return_message +=
-        if degree_awarded
+        if solr_document.degree_awarded
           "[Abstract embargoed until #{formatted_embargo_release_date}] "
         elsif embargo_length
           "[Abstract embargoed until #{embargo_length} post-graduation] "
@@ -153,7 +161,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     admin_return_message = ""
     if embargo_release_date && toc_embargoed
       admin_return_message +=
-        if embargo_length && !degree_awarded
+        if embargo_length && solr_document.degree_awarded.blank?
           "[Table of contents embargoed until #{embargo_length} post-graduation] "
         elsif embargo_release_date
           "[Table of contents embargoed until #{formatted_embargo_release_date}] "

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -1,25 +1,19 @@
-<h2>About this
-  <% if presenter.submitting_type %>
-    <%= presenter.submitting_type.first %>
-  <% else %>
-    Work
-  <% end %>
-</h2>
+<h2>About this <%= presenter.submitting_type %> </h2>
 <table class="work-show <%= dom_class(presenter) %> attributes" <%= presenter.microdata_type_to_html %>>
   <tbody>
+    <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
     <%= presenter.attribute_to_html(:school, render_as: :faceted) %>
     <%= presenter.attribute_to_html(:department, render_as: :faceted) %>
     <%= presenter.attribute_to_html(:subfield, label: "Subfield / Discipline", render_as: :faceted) %>
     <%= presenter.attribute_to_html(:degree, render_as: :faceted) %>
     <%= presenter.attribute_to_html(:submitting_type, label: "Submission", render_as: :faceted) %>
     <%= presenter.attribute_to_html(:language) %>
-    <%= presenter.attribute_to_html(:research_field, render_as: :faceted) %>
+    <%= presenter.attribute_to_html(:research_field, label: "Research Field", render_as: :faceted) %>
     <%= presenter.attribute_to_html(:keyword, label: "Keywords", render_as: :faceted) %>
     <%= presenter.attribute_to_html(:committee_chair_name, label: "Committee Chair / Thesis Advisor", render_as: :faceted) %>
     <%= presenter.attribute_to_html(:committee_members_names, label: "Committee Members", render_as: :faceted) %>
-    <%= presenter.attribute_to_html(:partnering_agency, label: "Partnering Agencies", render_as: :faceted) if presenter.school.first =~ /Rollins/ %>
+    <%= presenter.attribute_to_html(:partnering_agency, label: "Partnering Agencies", render_as: :faceted) if presenter.school&.first =~ /Rollins/ %>
     <%= presenter.attribute_to_html(:permanent_url, label: "Permanent URL") %>
-    <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
     <% if presenter.current_ability_is_approver? %>
       <%= presenter.attribute_to_html(:requires_permissions, label: t("hyrax.works.requires_permissions_label"))%>
       <%= presenter.attribute_to_html(:other_copyrights, label: t("hyrax.works.other_copyrights_label"))%>
@@ -27,7 +21,8 @@
       <%= presenter.attribute_to_html(:files_embargoed, label: "Files Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:abstract_embargoed, label: "Abstract Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:toc_embargoed, label: "Table of Contents Under Embargo", include_empty: true)%>
-      <%= presenter.attribute_to_html(:embargo_length, label: "Length of Embargo")%>
+      <%= presenter.attribute_to_html(:embargo_length, label: "Requested Embargo", include_empty: true)%>
+      <%= presenter.attribute_to_html(:degree_awarded, label: "Degree Awarded")%>
     <% end %>
   </tbody>
 </table>

--- a/spec/system/show_etd_spec.rb
+++ b/spec/system/show_etd_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system 
     expect(find('li.attribute-files_embargoed')).to have_content false
     expect(find('li.attribute-toc_embargoed')).to have_content false
     expect(find('li.attribute-abstract_embargoed')).to have_content false
-    expect(page).to have_content "Length of Embargo"
+    expect(page).to have_css('.attribute-embargo_length', text: '6 months')
     logout
   end
 

--- a/spec/views/hyrax/base/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_metadata.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'hyrax/presents_attributes'
+
+RSpec.describe 'hyrax/base/_metadata.html.erb', type: :view do
+  let(:etd) { FactoryBot.build(:etd, degree_awarded: "Jan 1, 2000") }
+  let(:ability) { Ability.new(FactoryBot.build(:user)) }
+  let(:etd_presenter) { EtdPresenter.new(SolrDocument.new(etd.to_solr), ability) }
+  context "for approvers" do
+    before do
+      allow(etd_presenter).to receive(:current_ability_is_approver?).and_return(true)
+    end
+    it 'shows the graduation date to approvers' do
+      render 'hyrax/base/metadata', presenter: etd_presenter
+      expect(rendered).to have_css('.attribute-degree_awarded', text: '01 January 2000')
+    end
+  end
+
+  context "for non-approvers" do
+    before do
+      allow(etd_presenter).to receive(:current_ability_is_approver?).and_return(false)
+    end
+    it 'shows the graduation date to approvers' do
+      render 'hyrax/base/metadata', presenter: etd_presenter
+      expect(rendered).to have_no_css('.attribute-degree_awarded')
+    end
+  end
+end


### PR DESCRIPTION
This change displays the gradutaion date, or "graduation pending" on
the single ETD view page for administrators.  It does not show the date
to other users.

The commit includes a number of other small refactors to clean up
the display page, simplify views, and clean up tests.