### PR TITLE
Add fallback to old Solr index style for degree_awarded

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,7 +81,7 @@ class SolrDocument
   end
 
   def degree_awarded
-    self['degree_awarded_dtsi']
+    self['degree_awarded_dtsi'] || self['degree_awarded_dtsim']&.first || self['degree_awarded_tesim']&.first
   end
 
   def department


### PR DESCRIPTION
Going forward, we want to index degree_awarded as a singular date
(degree_awarded_dtsim), but our current index has it indexed as a
multi-valued field (degree_awarded_dtsim).

This patch allows the application to fall back to looking for the
older indexing styles when we're running on environments that have
not had the full repo reindexed yet.