### PR TITLE
Add another date indexing variant

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,7 +81,7 @@ class SolrDocument
   end
 
   def degree_awarded
-    self['degree_awarded_dtsi'] || self['degree_awarded_dtsim']&.first || self['degree_awarded_tesim']&.first
+    self['degree_awarded_dtsi'] || self['degree_awarded_ssi'] || self['degree_awarded_dtsim']&.first || self['degree_awarded_tesim']&.first
   end
 
   def department


### PR DESCRIPTION
The possible variants supported for indexing `degree_awarded` are now:
* `degree_awarded_dtsi` - the goal going forward: index the degree awarded
as a single `Date` value
* `degree_awarded_ssi` - the fallback when the degree awarded is still stored
in Fedora as a `String` instead of a `Date`
* `degree_awarded_dtsim` - the older date format that assumes that degree_awarded
dates could be multi-valued (which they should never  be) - got invoked when the
data class stored to Fedora was a `Date`
* `degree_awarded_tesim` - another older format that got invode when the data
class stored to Fedora was a `String` - also wrongly assumes the date can be
multivalued