### PR TITLE
Update meta tags to use highwire press naming for Google Scholar

### DIFF
--- a/config/schoolie.yml
+++ b/config/schoolie.yml
@@ -1,8 +1,10 @@
 ---
 static:
-  Institution: Emory University
+  citation_dissertation_institution: Emory University
 attributes:
-  Title: title
-  Author: creator
-  Date: degree_awarded
-  Type: submitting_type
+  citation_title: title
+  citation_author: creator
+  citation_date: degree_awarded
+  citation_dissertation_type: submitting_type
+  citation_keywords: research_field
+  citation_pdf_url: permanent_url


### PR DESCRIPTION
Based on analysis conducted internally and a scan of current tagging
practices across DSpace, BePress, Eprints, and other repositories
it appears that the "highwire press" tag set, though not formally
documented, is the most broadly used system for &lt;meta&gt; tagging
to support inclusion in Google Scholar indexing and searches.

For additional reference we found the following two papers helpful
* https://scholarworks.montana.edu/xmlui/handle/1/3193 - p. 36
* https://www.monperrus.net/martin/accurate+bibliographic+metadata+and+google+scholar