### PR TITLE
Add the link for ETD PDFs for Google Scholar

### DIFF
--- a/config/schoolie.yml
+++ b/config/schoolie.yml
@@ -7,4 +7,4 @@ attributes:
   citation_date: degree_awarded
   citation_dissertation_type: submitting_type
   citation_keywords: research_field
-  citation_pdf_url: permanent_url
+  citation_pdf_url: download_url


### PR DESCRIPTION
Hyrax provides a `:download_url` in the WorkShowPresenter:
https://github.com/samvera/hyrax/blob/v3.1.0/app/presenters/hyrax/work_show_presenter.rb#L57-L61

NOTE: this functionality assumes the primary PDF is set as
the representative media for each ETD.