### PR TITLE
Merge graduation_date and graduation_year

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,7 +41,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field solr_name("graduation_year", :facetable), label: "Year", limit: 5
+    config.add_facet_field solr_name("graduation_date", :facetable), label: "Year", limit: 5
     config.add_facet_field solr_name("school", :facetable), label: "School", limit: 5
     config.add_facet_field solr_name("department", :facetable), label: "Department", limit: 5
     config.add_facet_field solr_name("degree", :facetable), label: "Degree", limit: 5

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -37,7 +37,7 @@ module Hyrax
     self.terms += [:abstract_embargoed]
     self.terms += [:toc_embargoed]
 
-    self.single_valued_fields = [:title, :creator, :post_graduation_email, :submitting_type, :graduation_date, :degree, :subfield, :department, :school, :language, :abstract, :table_of_contents]
+    self.single_valued_fields = [:title, :creator, :post_graduation_email, :submitting_type, :degree, :subfield, :department, :school, :language, :abstract, :table_of_contents]
 
     # methods for accessing new tab-determined sets of terms on new form tabs in new ui
 

--- a/app/helpers/graduation_helper.rb
+++ b/app/helpers/graduation_helper.rb
@@ -1,5 +1,7 @@
 module GraduationHelper
-  # Given a graduation date and an embargo length, calculate the embargo_release_date.
+  # Calculates the post-graduation embargo release date
+  # @param graduation_date [Date] - the date a degree is awarded
+  # @param requested_embargo [String] - the requested embargo length /\d+ [months|years]/
   def self.embargo_length_to_embargo_release_date(graduation_date, requested_embargo)
     if requested_embargo == InProgressEtd::NO_EMBARGO || requested_embargo.blank?
       # No post-graduation embargo to apply

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -19,7 +19,7 @@ class EtdIndexer < Hyrax::WorkIndexer
       [:abstract, :email, :post_graduation_email, :table_of_contents, :hidden?]
 
     self.stored_and_facetable_fields +=
-      [:creator, :graduation_year, :files_embargoed,
+      [:creator, :graduation_date, :files_embargoed,
        :abstract_embargoed, :toc_embargoed]
   end
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -57,10 +57,6 @@ class Etd < ActiveFedora::Base
     members.select(&:supplementary?)
   end
 
-  property :graduation_year, predicate: "http://purl.org/dc/terms/issued", multiple: false do |index|
-    index.as :stored_searchable, :facetable
-  end
-
   property :keyword, predicate: "http://schema.org/keywords" do |index|
     index.as :stored_searchable, :facetable
   end
@@ -71,10 +67,6 @@ class Etd < ActiveFedora::Base
 
   property :post_graduation_email, predicate: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#privateEmailAddress" do |index|
     index.as :displayable
-  end
-
-  property :graduation_date, predicate: "http://purl.org/dc/terms/issued" do |index|
-    index.as :stored_searchable, :facetable
   end
 
   # Boolean
@@ -151,6 +143,12 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  # [String] representing the semester and year the student graduates; legacy records only have a year value
+  property :graduation_date, predicate: "http://purl.org/dc/terms/issued", multiple: false do |index|
+    index.as :stored_sortable, :facetable
+  end
+
+  # [Time] stores the day recorded by the Registrar on which a degree was awarded - typically truncates or ignores time portion of the value
   property :degree_awarded, predicate: "http://dublincore.org/documents/dcmi-terms/#terms-dateAccepted", multiple: false do |index|
     index.as :stored_sortable
   end
@@ -220,6 +218,11 @@ class Etd < ActiveFedora::Base
   property :proquest_submission_date, predicate: "http://example.com/proquest_submission_date" do |index|
     index.as :stored_searchable
   end
+
+  property :abstract,              predicate: "http://purl.org/dc/terms/abstract"
+  property :table_of_contents,     predicate: "http://purl.org/dc/terms/tableOfContents"
+  property :creator,               predicate: "http://id.loc.gov/vocabulary/relators/aut"
+  property :legacy_id,             predicate: "http://id.loc.gov/vocabulary/identifiers/local"
 
   include ::Hyrax::BasicMetadata
   apply_schema Schemas::EmoryEtdSchema, Schemas::GeneratedResourceSchemaStrategy.new

--- a/app/models/schemas/emory_etd_schema.rb
+++ b/app/models/schemas/emory_etd_schema.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 module Schemas
+  # include these properties in their own schema in order to redefine the mappings
+  # included via Hyrax::BasicMetadata
   class EmoryEtdSchema < ActiveTriples::Schema
-    property :legacy_id,             predicate: "http://id.loc.gov/vocabulary/identifiers/local"
-    property :abstract,              predicate: "http://purl.org/dc/terms/abstract"
-    property :table_of_contents,     predicate: "http://purl.org/dc/terms/tableOfContents"
-    property :creator,               predicate: "http://id.loc.gov/vocabulary/relators/aut"
     property :keyword,               predicate: "http://schema.org/keywords"
-    property :graduation_date,       predicate: "http://purl.org/dc/terms/issued"
+    property :creator,               predicate: "http://id.loc.gov/vocabulary/relators/aut"
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -80,8 +80,16 @@ class SolrDocument
     self[Solrizer.solr_name('degree')]
   end
 
+  # @return [DateTime] - the day recorded by the Registrar that a degree wqs granted - time value it typically truncated
+  # see `graduation_date` for the semester and year value used for faceting
   def degree_awarded
     self['degree_awarded_dtsi'] || self['degree_awarded_ssi'] || self['degree_awarded_dtsim']&.first || self['degree_awarded_tesim']&.first
+  end
+
+  # @return [String] - the semester and year (or just year for legacy records) of graduation - e.g. "2018", "Fall 2021"
+  # see `degree_awarded` for the timestamp representing the day the degree was recorded by the Emory Registrar
+  def graduation_date
+    self[Solrizer.solr_name('graduation_date', :stored_sortable)] || self[Solrizer.solr_name('graduation_date', :stored_searchable)]&.first
   end
 
   def department
@@ -94,10 +102,6 @@ class SolrDocument
 
   def embargo_length
     self['embargo_length_ssi']
-  end
-
-  def graduation_year
-    self[Solrizer.solr_name('graduation_year')]
   end
 
   def hidden?

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -7,7 +7,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
            :department,
            :embargo_length,
            :files_embargoed,
-           :graduation_year,
+           :graduation_date,
            :language,
            :school,
            :partnering_agency,

--- a/app/views/hyrax/base/_work_title.erb
+++ b/app/views/hyrax/base/_work_title.erb
@@ -6,9 +6,7 @@
     <% end %>
 <% end %>
 <% presenter.creator.each_with_index do |creator, index| %>
-  <h2><%= creator %>
-    <% if presenter.respond_to?(:graduation_year) && presenter.graduation_year %>
-    (<%= presenter.graduation_year.first %>)
-    <% end %>
+  <h2>
+    <%= creator %> (<%= presenter.graduation_date %>)
   </h2>
 <% end %>

--- a/lib/tasks/laney_csv_report.rake
+++ b/lib/tasks/laney_csv_report.rake
@@ -17,8 +17,8 @@ namespace :emory do
         members = etd.committee_members_names.to_a
         date =  etd.date_uploaded.to_date
         program = etd.research_field.to_a
-        puts etd.graduation_year
-        if academic_year.include? etd.graduation_year
+        puts etd.graduation_date
+        if academic_year.include? etd.graduation_date
           csv << [creator.first, chair.first, members.first, date, program.first]
         end
       end

--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
       subfield { [] }
       degree { ['MA'] }
       language { ['English'] }
-      graduation_year { "2016" }
+      graduation_date { "Spring 1986" }
       abstract { [] << FFaker::Lorem.paragraph }
       table_of_contents { [] << FFaker::Lorem.paragraph }
       # 2017-08-21 is the actual date of this embargo expiration, but now that it
@@ -77,7 +77,7 @@ FactoryBot.define do
 
     factory :sample_data do
       creator { [] << "#{FFaker::Name.last_name}, #{FFaker::Name.first_name}" }
-      graduation_year { "2017" }
+      graduation_date { "2017" }
       school { ["Candler School of Theology"] }
       post_graduation_email { [] << FFaker::Internet.email }
       admin_set do

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -146,12 +146,12 @@ RSpec.describe Etd do
     end
   end
 
-  context "graduation_year" do
+  context "graduation_date" do
     let(:etd) { FactoryBot.build(:etd) }
-    it "has graduation_year" do
-      etd.graduation_year = "2007"
+    it "has graduation_date" do
+      etd.graduation_date = "Winter 2007"
       expect(etd.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/issued/)
-      expect(etd.graduation_year).to eq "2007"
+      expect(etd.graduation_date).to eq "Winter 2007"
     end
   end
 
@@ -306,15 +306,6 @@ RSpec.describe Etd do
     it "has a post graduation email with the expected predicate" do
       etd.post_graduation_email = ['kandis@robellarkin.info']
       expect(etd.resource.dump(:ttl)).to match(/www.ebu.ch\/metadata\/ontologies\/ebucore\/ebucore\#privateEmailAddress/)
-    end
-  end
-
-  context "graduation_date" do
-    let(:etd) { FactoryBot.build(:etd) }
-    it "has a semester and year" do
-      etd.graduation_date = ["Spring 2019"]
-      expect(etd.resource.dump(:ttl)).to match(/purl.org\/dc\/terms\/issued/)
-      expect(etd.graduation_date).to eq ["Spring 2019"]
     end
   end
 

--- a/spec/system/search_etd_spec.rb
+++ b/spec/system/search_etd_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Search for an ETD', type: :system, integration: true do
     FactoryBot.create(
       :etd,
       creator: ["Janakiramen, Helen"],
-      graduation_year: '2017',
+      graduation_date: 'Fall 2017',
       school: ["Candler School of Theology"],
       department: ["Robotics"],
       subfield: ["Political Robotics"],
@@ -51,7 +51,7 @@ RSpec.feature 'Search for an ETD', type: :system, integration: true do
       expect(page).not_to have_xpath("//h3", text: "Student Name")
       expect(page).not_to have_link(etd.creator.first, class: "facet_select")
       expect(page).to have_xpath("//h3", text: "Year")
-      expect(page).to have_link(etd.graduation_year.first, class: "facet_select")
+      expect(page).to have_link(etd.graduation_date, class: "facet_select")
       expect(page).to have_xpath("//h3", text: "School")
       expect(page).to have_link(etd.school.first, class: "facet_select")
       expect(page).to have_xpath("//h3", text: "Department")

--- a/spec/system/show_etd_spec.rb
+++ b/spec/system/show_etd_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system 
     [
       "title",
       "creator",
-      "graduation_year",
+      "graduation_date",
       "abstract",
       "table_of_contents",
       "school",


### PR DESCRIPTION
Both properties were being saved to the same predicate causing
them to effectively be confusing synonyms for the same value.
This also triggered the following warning in logs repeatedly when
running the application:

```
W, [2021-02-24T20:01:54.006580 #962]  WARN -- : 
Same predicate (http://purl.org/dc/terms/issued)
used for properties graduation_date and graduation_year
```

Since `graduation_date` was used more commonly, this change updates
all references from `graduation_year` to `graduation_date`.