### PR TITLE
Updates links to catalog

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,8 +1,7 @@
 <div class="col-xs-12 col-sm-6">
   <h2>Emory Theses and Dissertations</h2>
-<p>The Emory Theses and Dissertations (ETD) Repository holds theses and dissertations from the Laney Graduate School, the Rollins School of Public Health, and the Candler School of Theology, as well as undergraduate honors papers from Emory College of Arts and Sciences.</p><p> Emory University theses and dissertations submitted before the launch of the ETD repository can be found by using Emory University’s <a href="http://discovere.emory.edu/primo_library/libweb/action/search.do">discoverE catalog</a>.
-The theses and dissertations of the Wallace H. Coulter Department of Biomedical Engineering, a joint degree program by Emory University and Georgia Tech, are available in <a href="https://smartech.gatech.edu/">SMARTech</a> , Georgia Tech’s repository, and Emory University’s <a href="http://discovere.emory.edu/primo_library/libweb/action/search.do">discoverE catalog</a>.</p>
-
+  <p>The Emory Theses and Dissertations (ETD) Repository holds theses and dissertations from the Laney Graduate School, the Rollins School of Public Health, and the Candler School of Theology, as well as undergraduate honors papers from Emory College of Arts and Sciences.</p>
+  <p>Emory University theses and dissertations submitted before the launch of the ETD repository can be found by searching the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>. The theses and dissertations of the Wallace H. Coulter Department of Biomedical Engineering, a joint degree program by Emory University and Georgia Tech, are available in <a href="https://smartech.gatech.edu/">SMARTech</a>, Georgia Tech’s repository, and in the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>.</p>
   <div class="sumbit-my-etd">
     <%= render 'submit_my_etd' %>
   </div>


### PR DESCRIPTION
The new catalog is now in production, and discoverE is no longer available. Therefore, ETDs should link to the new catalog.

c.f. emory-libraries/blacklight-catalog#1244