### PR TITLE
Improve the sort order for the sitemap

### DIFF
--- a/lib/tasks/schoolie.rake
+++ b/lib/tasks/schoolie.rake
@@ -8,7 +8,7 @@ namespace :schoolie do
     result = ActiveFedora::SolrService.query("has_model_ssim:Etd",
                                              fq: "workflow_state_name_ssim:published",
                                              fl: "id,#{date_field}",
-                                             sort: "degree_awarded_dtsi,system_create_dtsi ASC",
+                                             sort: "degree_awarded_dtsi DESC,system_create_dtsi DESC",
                                              rows: 20_000)
     ids = result.map do |x|
       ["https://etd.library.emory.edu/concern/etds/#{x['id']}", x[date_field].to_s]


### PR DESCRIPTION
This changes the sort order of sitemap links so that they are
ordered by degree_awarded, then by system_create - newest to oldest
(i.e. descending dates)
*This gives us all the ETDs in stable order (creation and degree dates
should rarely, if ever, change) so bots and hmans can do a simple diff
on the file to see changes*

The sitemap last modified date is already set to the system_modified date
*This tells bots when to re-index ETDs if embargoes are lifted
or other metadata or file changes occur*