### PR TITLE
Allow users to be deactivated and reactivated

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class UsersController < ApplicationController
+  before_action :ensure_admin!
+  before_action :load_user
+  with_themed_layout 'dashboard'
+
+  def activate
+    @user.update(params.permit(:deactivated))
+    flash[:notice] = params[:deactivated] == "true" ? "User deactivated" : "User reactivated"
+    redirect_to hyrax.admin_users_path
+  end
+
+  private
+
+  def load_user
+    @user = User.find(params[:id])
+  end
+
+  def ensure_admin!
+    authorize! :read, :admin_dashboard
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,10 @@ class User < ApplicationRecord
     uid
   end
 
+  def active_for_authentication?
+    super && !deactivated
+  end
+
   def destroy
     update(deactivated: true) unless deactivated
   end

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -1,51 +1,72 @@
-<% content_for :page_header do %>
-  <h1 class="admin-users-page-title"><%= t('hyrax.admin.users.index.title') %></h1>
+<% provide :page_header do %>
+  <h1>
+    <span class="fa fa-user" aria-hidden="true"></span>
+    <%= t('hyrax.admin.users.index.title') %>
+  </h1>
 <% end %>
 
-<div class="panel panel-default users-listing">
-  <div class="panel-heading">
-      <%= t('hyrax.admin.users.index.describe_users_html', count: @presenter.user_count) %>
-  </div>
-
-  <div class="panel-body">
-    <div class="table-responsive">
-      <table class="table table-striped datatable">
-        <thead>
-          <tr>
-            <th><%= t('.display_name') %></th>
-            <th><%= t('.id_label') %></th>
-            <th><%= t('.role_label') %></th>
-            <th><%= t('.access_label') %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @presenter.users.each do |user| %>
-            <tr>
-              <td><%= link_to hyrax.dashboard_profile_path(user) do %>
-                    <%= user.display_name %>
-                  <% end %>
-              </td>
-              <td>
-                <%= link_to hyrax.dashboard_profile_path(user) do %>
-                  <%= user.uid %>
-                <% end %>
-              </td>
-              <td><% roles = @presenter.user_roles(user) %>
-                  <ul><% roles.each do |role| %>
-                    <li><%= role %></li>
+<div class="row">
+  <div class="col-md-12">
+      <div class="tab-content">
+        <div id="users" class="tab-pane active">
+          <div class="panel panel-default labels users-listing">
+            <div class="panel-heading">
+              <%= t('hyrax.admin.users.index.describe_users_html', count: @presenter.user_count) %>
+            </div>
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-striped datatable" id="usersTable">
+                  <thead>
+                  <tr>
+                    <th><%= t('.id_label') %></th>
+                    <th><%= t('.displayname_label') %></th>
+                    <th><%= t('.status') %></th>
+                    <th data-orderable="false"><%= t('.role_label') %></th>
+                    <% if @presenter.show_last_access? %>
+                      <th><%= t('.access_label') %></th>
                     <% end %>
-                  </ul>
-              </td>
-              <td>
-                <%# in the case that a user is created who never signs in, this is necessary %>
-                <relative-time datetime="<%= @presenter.last_accessed(user).getutc.iso8601 %>" title="<%= @presenter.last_accessed(user).to_formatted_s(:standard) %>">
-                  <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
-                </relative-time>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+                    <th data-orderable="false"><%= t('.actions_label') %></th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  <% @presenter.users.each do |user| %>
+                    <tr>
+                      <td><%= link_to user.uid || "", hyrax.dashboard_profile_path(user) %></td>
+                      <td><%= link_to user.display_name || "", hyrax.dashboard_profile_path(user) %></td>
+                      <td>
+                        <% if user.deactivated %>
+                          <span class='label label-danger'>deactivated</span>
+                        <% end %>
+                      </td>
+                      <td>
+                        <% roles = @presenter.user_roles(user) %>
+                        <ul>
+                          <% roles.each do |role| %>
+                            <li><%= role %></li>
+                          <% end %>
+                        </ul>
+
+                      </td>
+                      <% if @presenter.show_last_access? %>
+                        <td data-sort="<%= @presenter.last_accessed(user).getutc.iso8601 %>">
+                          <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
+                        </td>
+                      <% end %>
+                      <td>
+                        <% if user.deactivated %>
+                          <%= link_to "Reactivate",  main_app.activate_path(:id=>user.id, :deactivated=>false), :method=>:put, :data => {:confirm => 'Are you sure you want to reactivate the user?'}%>
+                        <% else %>
+                          <%= link_to "Deactivate",  main_app.activate_path(:id=>user.id, :deactivated=>true), :method=>:put, :data => {:confirm => 'Are you sure you want to deactivate the user?'}%>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -81,3 +81,8 @@ en:
         text: 'Restricted; Files Only'
     contact_form:
       header: Help
+    admin:
+      users:
+        index:
+          actions_label: "Actions"
+          displayname_label: "Display Name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   end
 
   devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }
+  devise_scope :users do
+    put "activate", to: "users#activate"
+  end
 
   # Disable these routes if you are using Devise's
   # database_authenticatable in your development environment.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -126,6 +126,7 @@ RSpec.configure do |config|
   end
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Capybara::RSpecMatchers, type: :input
 
   config.include Warden::Test::Helpers, type: :feature

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "/user", type: :request do
+  context "logged in but not admin" do
+    let(:user) { FactoryBot.create(:user) }
+    before { sign_in user }
+
+    it "redirects" do
+      put activate_path(id: 1)
+      expect(response).to redirect_to blacklight_path
+    end
+  end
+  context "not logged in" do
+    it "redirects" do
+      put activate_path(id: 1)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+  context "logged in as admin" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:admin) { FactoryBot.create(:admin) }
+    before { sign_in admin }
+
+    describe "user index" do
+      it "renders the links" do
+        get '/admin/users'
+        expect(response).to be_successful
+        expect(response).to render_template 'admin/users/index'
+      end
+    end
+
+    describe "deactivate" do
+      it "renders a successful response" do
+        put activate_path(id: user.id, deactivated: true)
+        expect(response).to redirect_to(hyrax.admin_users_path)
+        expect(flash[:notice]).to eq "User deactivated"
+      end
+    end
+    describe "activate" do
+      it "renders a successful response" do
+        put activate_path(id: user.id, deactivated: false)
+        expect(response).to redirect_to(hyrax.admin_users_path)
+        expect(flash[:notice]).to eq "User reactivated"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to be able to prevent administrative users from logging in
if their roles change without nececessarily deleting their activity
history - i.e. files they may have uploaded to student ETDs and/or
approvals or change requests they have issued.

This change adds the user interface and back-end code to allow
users to be deactivated (or soft-deleted) so that they can no
longer access the system, while any records tied to their userID
still point to a valid (but disabled for login) User record.