### PR TITLE
Don't commit dynamically generated reports to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ test-report.xml
 # Ignore redis database saves
 **/dump.rdb
 
+# Ignore dynamically generated reports
+/private/**/*.csv
+
 # Don't check dotenv files into github
 .env
 .env.development


### PR DESCRIPTION
If we run the etd_report task in local development environments,
it will create a new report file that we don't want checked into
github.