### PR TITLE
Rename "report.csv" to "etd_report.csv"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ test-report.xml
 # Ignore redis database saves
 **/dump.rdb
 
+# Ignore dynamically generated reports
+/private/**/*.csv
+
 # Don't check dotenv files into github
 .env
 .env.development

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,6 @@ AllCops:
     - 'tmp/**/*'
     - 'config/initializers/explain_partials.rb'
     - 'node_modules/**/*'
-    - lib/tasks/laney_csv_report.rake
 
 # BEGIN; Disabled in move to 2.3 sytax linter
 Style/FrozenStringLiteralComment:

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <% if current_user.admin? %>
-    <%= menu.nav_link(main_app.private_file_path("report.csv")) do %>
-      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('download_report') %></span>
+    <%= menu.nav_link(main_app.private_file_path("etd_report.csv")) do %>
+      <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('download_etd_report') %></span>
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  download_report: "Download Graduation Report"
+  download_etd_report: "Download Graduation Report"
   hello: "Hello world"
   mailboxer:
     message_mailer:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,7 +23,7 @@
 # notifications if so
 every :day, at: '11:55pm' do
   rake "emory:proquest_notifications"
-  rake "emory:nightly_report"
+  rake "emory:etd_report"
 end
 
 every :day, at: '2:20am' do

--- a/lib/tasks/etd_report.rake
+++ b/lib/tasks/etd_report.rake
@@ -1,6 +1,6 @@
 require 'csv'
 namespace :emory do
-  task nightly_report: [:environment] do
+  task etd_report: [:environment] do
     headers = %w[id uid creator title school department degree submitting_type
                  language subfield research_field keyword committee_chair committee_members
                  post_graduation_email degree_awarded graduation_date partnering_agency

--- a/spec/requests/private_file_controller.rb
+++ b/spec/requests/private_file_controller.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "/private", type: :request do
   before :all do
     FileUtils.mkdir_p Rails.root.join("private")
-    FileUtils.touch Rails.root.join("private", "report.csv")
+    FileUtils.touch Rails.root.join("private", "etd_report.csv")
   end
   context "logged in but not admin" do
     let(:user) { FactoryBot.create(:user) }
@@ -29,7 +29,7 @@ RSpec.describe "/private", type: :request do
 
     describe "user index" do
       it "renders the links" do
-        get '/private/report.csv'
+        get '/private/etd_report.csv'
         expect(response).to be_successful
         expect(response.header['Content-type']).to eq "text/csv"
         expect(response.header['Content-Disposition']).to eq "attachment; filename=\"report_#{Time.zone.now.strftime('%Y%m%d')}.csv\""


### PR DESCRIPTION
We have other reports in the system and might want to add others in
the future - so calling the new ETD Report just `report` might be
too generic.

This change renames references to `report` or `nightly_report` to etd_report
to help make things a little more explicit if we ever have to come
back to this code in the future.