### PR TITLE
Refactor GraduationService

### DIFF
--- a/app/services/graduation_service.rb
+++ b/app/services/graduation_service.rb
@@ -15,7 +15,7 @@ class GraduationService
       degree_awarded_date = GraduationService.check_degree_status(work)
       if degree_awarded_date
         Rails.logger.warn "Graduation service: Awarding degree for ETD #{work.id} as of #{degree_awarded_date}"
-        GraduationJob.perform_later(work.id, degree_awarded_date.to_s)
+        GraduationJob.perform_now(work.id, degree_awarded_date.to_s)
       end
     end
     remove_instance_variable(:@registrar_data)

--- a/app/services/graduation_service.rb
+++ b/app/services/graduation_service.rb
@@ -1,5 +1,5 @@
-# An automated service that:
-# 1. Checks the repository for works in the `approved` workflow state but which have no `degree_awarded` value
+# A service that:
+# 1. Checks the repository for works in the `approved` workflow state
 # 2. For each of these works, query the registrar data to see if the student has graduated
 # 3. If so, call GraduationJob for the given work and the graduation_date returned by registrar data
 # @param [String] The path to the data JSON file. Expects location of registrar data to be set in REGISTRAR_DATA_PATH, e.g., in .env.production
@@ -7,34 +7,37 @@
 #  GraduationService.run
 class GraduationService
   def self.run(registrar_data_path = ENV['REGISTRAR_DATA_PATH'])
+    new(registrar_data_path).run
+  end
+
+  # Load the provided file into a JSON object for processing
+  def initialize(registrar_data_path)
+    raise "Cannot find registrar data at: #{registrar_data_path || 'no path provided'}" unless File.file?(registrar_data_path)
     Rails.logger.warn("Graduation service: Running graduation service with file #{registrar_data_path}")
-    raise "Cannot find registrar data" unless registrar_data_path && File.file?(registrar_data_path)
-    Rails.logger.warn("Graduation service: found registrar data")
-    GraduationService.load_data(registrar_data_path)
-    GraduationService.graduation_eligible_works.each do |work|
-      degree_awarded_date = GraduationService.check_degree_status(work)
+    @registrar_data = JSON.parse(File.read(registrar_data_path))
+  end
+
+  # Find all ETDs that have been 'approved' but not yet 'published'
+  # Match them to graduation records and check whether a degree has been awarded yet
+  def run
+    return unless @registrar_data
+    graduation_eligible_works.each do |work|
+      degree_awarded_date = check_degree_status(work)
       if degree_awarded_date
         Rails.logger.warn "Graduation service: Awarding degree for ETD #{work['id']} as of #{degree_awarded_date}"
         GraduationJob.perform_now(work['id'], degree_awarded_date.to_s)
       end
     end
-    remove_instance_variable(:@registrar_data)
-  end
-
-  # Load the Registrar's data from the JSON file.
-  # @param [String] The path to the data JSON file.
-  def self.load_data(path_to_data)
-    @registrar_data = JSON.parse(File.read(path_to_data))
   end
 
   # Find all Etds in the 'approved' workflow state that are eligible for graduation
-  # @return [Array<SolrDocument>] An Array of SolrDocuments indexed for the matching ETDs
-  def self.graduation_eligible_works
+  # @return [Array<Hash>] An Array of Hashes representing the ETDs indexed to Solr
+  def graduation_eligible_works
     eligible_works = []
     # Use #search_in_batches to avoid timeouts in the case where there are a large number of ETDs
     # that have been approved and are pending graduation (i.e. publication)
     Etd.search_in_batches({ workflow_state_name_ssim: 'approved' }, batch_size: 50) do |batch|
-      eligible_works.concat(batch.to_a)
+      eligible_works.concat(batch)
     end
 
     Rails.logger.warn "Graduation service: There were #{eligible_works.count} ETDs eligible for graduation"
@@ -42,9 +45,9 @@ class GraduationService
   end
 
   # Check the degree status for the given work. If the degree has been awarded, return the relevant date.
-  # @param [SolrDocument] work - the SolrDocument indexed for the corresponding ETD
-  # @return [Date] the date the degree was awarded, otherwise false
-  def self.check_degree_status(work)
+  # @param [Hash] work - the Solr document Hash for the corresponding ETD
+  # @return [Date] the date the degree was awarded, otherwise nil
+  def check_degree_status(work)
     return Time.zone.today.strftime('%Y-%m-%d') if Rails.env.development? || ENV['FAKE_DATA'] # Otherwise it will never find registrar data for our fake users
     # Find all records by this PPID
     records = @registrar_data.select { |_k, v| v['public person id'] == work['depositor_ssim'].first }
@@ -78,7 +81,7 @@ class GraduationService
 
   # If there is more than one record matching the student, find the one that matches the degree code
   # of the etd. If that record has it's degree awarded, graduate the etd.
-  def self.disambiguate_registrar(work, records)
+  def disambiguate_registrar(work, records)
     degree_code_matches = records.select { |_key, value| value['degree code'] == work_degree(work['degree_tesim'].first) }
     if degree_code_matches.size == 1 && degree_code_matches.first[1]['degree status descr'] == 'Awarded'
       return degree_code_matches.first[1]
@@ -86,7 +89,7 @@ class GraduationService
     nil
   end
 
-  def self.work_degree(work_degree)
+  def work_degree(work_degree)
     # This hash will map degree codes from laevigata to degrees in @registrar_data
     degrees = { "Th.D." => "THD", "Ph.D." => "PHD", "DMin" => "DM", "D.N.P." => "DNP",
                 "M.A." => "MA", "M.S." => "MS", "M.Div." => "MDV", "M.T.S." => "MTS",

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -9,7 +9,7 @@ export ACTION_MAILER_USER_NAME=##YOUR DATA HERE##
 export ACTION_MAILER_PASSWORD=##YOUR DATA HERE##
 
 export PROQUEST_NOTIFICATION_EMAIL=PQ-DissertationETD@proquest.com
-export REGISTRAR_DATA_PATH=/usr/local/projects/hyrax/laevigata/spec/fixtures/registrar_sample.json
+export REGISTRAR_DATA_PATH=./laevigata/spec/fixtures/registrar_sample.json
 export FAKE_DATA=true
 
 # Use local database auth instead of Shibboleth
@@ -17,9 +17,6 @@ export LAEVIGATA_DATABASE_AUTH=true
 
 # Turn off coveralls during specs
 export NO_COVERAGE=true
-
-# Dial back fedora & solr
-export _JAVA_OPTIONS="-Xmx600m"
 
 # For hyrax config
 

--- a/lib/tasks/graduation.rake
+++ b/lib/tasks/graduation.rake
@@ -1,7 +1,9 @@
 namespace :emory do
   desc "Check for new graduates."
   task :graduation do
-    Rails.logger.warn "Running GraduationService with file #{ENV['REGISTRAR_DATA_PATH']}"
+    # Echo logging to the console so we can track progress
+    console_logger = Logger.new(STDOUT)
+    ActiveSupport::Logger.broadcast(console_logger)
     GraduationService.run
   end
 end

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -35,14 +35,14 @@ describe GraduationService, :clean do
   describe "#run" do
     it "finds all works in an approved state that do not yet have a degree_awarded value" do
       described_class.load_data('./spec/fixtures/registrar_sample.json')
-      expect(described_class.graduation_eligible_works.map(&:id)).to contain_exactly(graduated_etd.id, nongraduated_etd.id, double_degree_etd.id)
+      expect(described_class.graduation_eligible_works.map { |doc| doc['id'] }).to contain_exactly(graduated_etd.id, nongraduated_etd.id, double_degree_etd.id)
       described_class.remove_instance_variable(:@registrar_data)
     end
     it "checks the graduation status for a given work" do
       described_class.load_data('./spec/fixtures/registrar_sample.json')
-      expect(described_class.check_degree_status(graduated_etd)).to eq Date.new(2017, 5, 18)
-      expect(described_class.check_degree_status(nongraduated_etd)).to eq false
-      expect(described_class.check_degree_status(double_degree_etd)).to eq Date.new(2018, 1, 12)
+      expect(described_class.check_degree_status(graduated_etd.to_solr)).to eq Date.new(2017, 5, 18)
+      expect(described_class.check_degree_status(nongraduated_etd.to_solr)).to eq nil
+      expect(described_class.check_degree_status(double_degree_etd.to_solr)).to eq Date.new(2018, 1, 12)
       described_class.remove_instance_variable(:@registrar_data)
     end
     it "checks for new graduates" do

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -19,31 +19,29 @@ describe GraduationService, :clean do
     subject = Hyrax::WorkflowActionInfo.new(graduated_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
-    expect(graduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
     # Create and approve the nongraduated ETD
     subject = Hyrax::WorkflowActionInfo.new(nongraduated_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
-    expect(nongraduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
     # Create and approve graduated ETD with a user that is in school for another degree
     subject = Hyrax::WorkflowActionInfo.new(double_degree_etd, approving_user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
-    expect(double_degree_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
   end
 
   describe "#run" do
     it "finds all works in an approved state that do not yet have a degree_awarded value" do
-      described_class.load_data('./spec/fixtures/registrar_sample.json')
-      expect(described_class.graduation_eligible_works.map { |doc| doc['id'] }).to contain_exactly(graduated_etd.id, nongraduated_etd.id, double_degree_etd.id)
-      described_class.remove_instance_variable(:@registrar_data)
+      expect(graduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
+      expect(nongraduated_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
+      expect(double_degree_etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
+      grad_service = described_class.new('./spec/fixtures/registrar_sample.json')
+      expect(grad_service.graduation_eligible_works.map { |doc| doc['id'] }).to contain_exactly(graduated_etd.id, nongraduated_etd.id, double_degree_etd.id)
     end
     it "checks the graduation status for a given work" do
-      described_class.load_data('./spec/fixtures/registrar_sample.json')
-      expect(described_class.check_degree_status(graduated_etd.to_solr)).to eq Date.new(2017, 5, 18)
-      expect(described_class.check_degree_status(nongraduated_etd.to_solr)).to eq nil
-      expect(described_class.check_degree_status(double_degree_etd.to_solr)).to eq Date.new(2018, 1, 12)
-      described_class.remove_instance_variable(:@registrar_data)
+      grad_service = described_class.new('./spec/fixtures/registrar_sample.json')
+      expect(grad_service.check_degree_status(graduated_etd.to_solr)).to eq Date.new(2017, 5, 18)
+      expect(grad_service.check_degree_status(nongraduated_etd.to_solr)).to eq nil
+      expect(grad_service.check_degree_status(double_degree_etd.to_solr)).to eq Date.new(2018, 1, 12)
     end
     it "checks for new graduates" do
       allow(GraduationJob).to receive(:perform_now)

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -46,9 +46,9 @@ describe GraduationService, :clean do
       described_class.remove_instance_variable(:@registrar_data)
     end
     it "checks for new graduates" do
-      allow(GraduationJob).to receive(:perform_later)
+      allow(GraduationJob).to receive(:perform_now)
       described_class.run('./spec/fixtures/registrar_sample.json')
-      expect(GraduationJob).to have_received(:perform_later).twice
+      expect(GraduationJob).to have_received(:perform_now).twice
     end
   end
 end

--- a/spec/system/candler_workflow_etd_spec.rb
+++ b/spec/system/candler_workflow_etd_spec.rb
@@ -92,9 +92,8 @@ RSpec.describe 'Candler approval workflow', :perform_jobs, :clean, integration: 
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
-      # Run the graduation service
-      allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
-      GraduationService.run
+      # Publish the ETD via the GraduationJob
+      GraduationJob.perform_now(etd.id, Time.zone.yesterday)
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")

--- a/spec/system/laney_workflow_etd_spec.rb
+++ b/spec/system/laney_workflow_etd_spec.rb
@@ -128,9 +128,8 @@ RSpec.feature 'Laney Graduate School two step approval workflow',
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
-      # Run the graduation service
-      allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
-      GraduationService.run
+      # Publish the ETD via the GraduationJob
+      GraduationJob.perform_now(etd.id, Time.zone.yesterday)
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")

--- a/spec/system/rollins_workflow_etd_spec.rb
+++ b/spec/system/rollins_workflow_etd_spec.rb
@@ -90,9 +90,8 @@ RSpec.describe 'Create a Rollins ETD', :perform_jobs, :clean, :js, integration: 
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
-      # Run the graduation service
-      allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
-      GraduationService.run
+      # Publish the ETD via the GraduationJob
+      GraduationJob.perform_now(etd.id, Time.zone.yesterday)
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")

--- a/spec/system/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/system/undergrad_honors_workflow_etd_spec.rb
@@ -90,9 +90,8 @@ RSpec.describe 'Emory College approval workflow', :perform_jobs, :clean, :js, in
       visit("/concern/etds/#{etd.id}")
       expect(page).to have_content "The work is not currently available because it has not yet completed the publishing process"
 
-      # Run the graduation service
-      allow(GraduationService).to receive(:check_degree_status).and_return(Time.zone.today)
-      GraduationService.run
+      # Publish the ETD via the GraduationJob
+      GraduationJob.perform_now(etd.id, Time.zone.yesterday)
 
       # Now the work should be publicly visible
       visit("/concern/etds/#{etd.id}")


### PR DESCRIPTION
Refactor the GraduationService and emory:graduation tasks for performance, clarity, and easier reporting:

REPORTING
* Echo logging to console when run as a rake task
* Run GraduationJob in foreground rather than job queue to include output in reporting

PERFORMANCE
* Avoid queuing overhead
* Use Solr query documents instead of ActiveFedora ETD objects wherever possible

CLARITY
* Remove duplicate logging between rake task and service (move all logging to service)
* Use instance methods rather than class methods 
* Date lookup returns `Date` or `nil` instead of `Date` or `false`