### PR TITLE
Remove dead code (references to `choose_proquest_submission`)

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -209,11 +209,6 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  # If this user can choose whether to submit to ProQuest or not, what was their choice?
-  property :choose_proquest_submission, predicate: "http://example.com/choose_proquest_submission" do |index|
-    index.as :stored_searchable
-  end
-
   # What date (if any) was this ETD submitted to ProQuest?
   property :proquest_submission_date, predicate: "http://example.com/proquest_submission_date" do |index|
     index.as :stored_searchable

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -148,10 +148,6 @@ class SolrDocument
     self[Solrizer.solr_name('patents')]
   end
 
-  def choose_proquest_submission
-    self[Solrizer.solr_name('choose_proquest_submission')]
-  end
-
   def proquest_submission_date
     self[Solrizer.solr_name('proquest_submission_date')]
   end

--- a/spec/models/proquest_behaviors_etd_spec.rb
+++ b/spec/models/proquest_behaviors_etd_spec.rb
@@ -143,14 +143,8 @@ RSpec.describe Etd do
   end
 
   context "proquest submission" do
-    it "allows the student to choose whether to submit" do
-      expect(etd.choose_proquest_submission).to be_empty
-      etd.choose_proquest_submission = [true]
-      expect(etd.choose_proquest_submission.first).to eq(true)
-    end
     it "records the date the etd was submitted to proquest", :aggregate_failures do
       expect(etd.proquest_submission_date).to be_empty
-      expect(etd.proquest_submission_date.first.instance_of?(Date)).to eq(false)
       etd.proquest_submission_date = [Time.zone.today]
       expect(etd.proquest_submission_date.first).to eq(Time.zone.today)
       expect(etd.proquest_submission_date.first.instance_of?(Date)).to eq(true)


### PR DESCRIPTION
At one point there was a feature request to allow students to
select whether they wished to submit their dissertations to Proquest.

Emory decided to send all Laney dissertations to Proquest, eliminating
the need for user input.  This code never got removed when the
requirements changed.