### PR TITLE
Remove "dissertation" from tag name

### DIFF
--- a/config/schoolie.yml
+++ b/config/schoolie.yml
@@ -1,6 +1,6 @@
 ---
 static:
-  citation_dissertation_institution: Emory University
+  citation_institution: Emory University
 attributes:
   citation_title: title
   citation_author: creator


### PR DESCRIPTION
**ISSUE**
We're seeing all of the citations in ETDs that Google has indexed flagged as Dissertations - even when they're undergraduate theses.

**HYPOTHESIS**
We think google might be scanning for the word "dissertation" anywhere in the meta tags and values and flagging the ETD as a "PhD Dissertation" rather than just a paper or thesis.