### PR TITLE
Refactor the GraduationService for speed and reliability

### DIFF
--- a/lib/tasks/graduation.rake
+++ b/lib/tasks/graduation.rake
@@ -2,6 +2,7 @@ namespace :emory do
   desc "Check for new graduates."
   task :graduation do
     console_logger = Logger.new(STDOUT)
+    console_logger.level = Logger::WARN
     Rails.logger.extend(ActiveSupport::Logger.broadcast(console_logger))
     GraduationService.run
   end

--- a/spec/factories/etd.rb
+++ b/spec/factories/etd.rb
@@ -116,6 +116,17 @@ FactoryBot.define do
         )
       end
 
+      factory :sample_data_undergrad do
+        title { ["Undergraduate Honors: #{FFaker::Book.title}"] }
+        school { ["Emory College"] }
+        admin_set do
+          AdminSet.where(title: "Emory College").first
+        end
+        department { ["Classics"] }
+        degree { ["B.A."] }
+        submitting_type { ["Honors Thesis"] }
+      end
+
       # this factory returns string values for booleans
       # because the solr_document methods return strings in the feature tests, although not from the application.
       factory :sample_data_with_copyright_questions do

--- a/spec/fixtures/config/emory/admin_sets_registrar_subset.yml
+++ b/spec/fixtures/config/emory/admin_sets_registrar_subset.yml
@@ -1,0 +1,6 @@
+Emory College:
+  approving:
+   - ecadmin
+Candler School of Theology:
+  approving:
+   - candleradmin

--- a/spec/services/graduation_service_method_spec.rb
+++ b/spec/services/graduation_service_method_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+# NOTE: These tests are pulled out of ./spec/service/graduation_service_spec.rb because
+# the test setup for that test group takes more than 20 seconds per example.
+describe GraduationService do
+  let(:grad_service) { described_class.new('./spec/fixtures/registrar_sample.json') }
+
+  describe "#extract_date" do
+    it "returns an ISO date format string" do
+      grad_record = { 'degree status date' => '1938-10-30' }
+      expect(grad_service.extract_date(grad_record)).to eq '1938-10-30'
+    end
+
+    it "returns only the ISO date portion of the data" do
+      grad_record = { 'degree status date' => "Fall '38 (1938-10-30)" }
+      expect(grad_service.extract_date(grad_record)).to eq '1938-10-30'
+    end
+
+    it "returns nil if an ISO date is not present" do
+      grad_record = { 'degree status date' => " " }
+      expect(grad_service.extract_date(grad_record)).to be_nil
+    end
+
+    it "returns nil if no degree status date is present" do
+      grad_record = {}
+      expect(grad_service.extract_date(grad_record)).to be_nil
+    end
+
+    it "handles bad input gracefully" do
+      grad_record = nil
+      expect(grad_service.extract_date(grad_record)).to be_nil
+    end
+  end
+
+  describe "#find_registrar_match" do
+    describe "for exact matches" do
+      let(:etd_solr_doc) { { 'id' => 'MatchingETD', 'depositor_ssim' => ['P0000003'], 'school_tesim' => ['Emory College'], 'degree_tesim' => ['B.S.'] } }
+      it 'returns the matched record' do
+        record_key = grad_service.find_registrar_match(etd_solr_doc)[1]['etd record key']
+        expect(record_key).to eq 'P0000003-UCOL-LIBAS'
+      end
+      it 'returns verified graduation dates' do
+        grad_date = grad_service.find_registrar_match(etd_solr_doc)[0]
+        expect(grad_date).to eq '2017-03-16'
+      end
+      it 'logs match data', :aggregate_failures do
+        allow(Rails.logger).to receive(:warn)
+        _grad_date, _grad_record = grad_service.find_registrar_match(etd_solr_doc)
+        expect(Rails.logger).to have_received(:warn).with(/MatchingETD/)
+        expect(Rails.logger).to have_received(:warn).with(/P0000003-UCOL-LIBAS/)
+        expect(Rails.logger).to have_received(:warn).with(/2017-03-16/)
+      end
+      describe "pending graduation" do
+        let(:etd_solr_doc) { { 'id' => 'MatchingETD', 'depositor_ssim' => ['P0000001'], 'school_tesim' => ['Laney Graduate School'], 'degree_tesim' => ['Ph.D.'] } }
+        it 'returns nil graduation date' do
+          grad_date, _grad_record = grad_service.find_registrar_match(etd_solr_doc)
+          expect(grad_date).to be_nil
+        end
+        it 'logs match data', :aggregate_failures do
+          allow(Rails.logger).to receive(:warn)
+          _grad_date, _grad_record = grad_service.find_registrar_match(etd_solr_doc)
+          expect(Rails.logger).to have_received(:warn).with(/MatchingETD/)
+          expect(Rails.logger).to have_received(:warn).with(/P0000001-GSAS-PHD/)
+          expect(Rails.logger).to have_received(:warn).with(/pending/)
+        end
+      end
+    end
+    describe "for non-matches" do
+      let(:etd_solr_doc) { { 'id' => 'UnmatchedETD', 'depositor_ssim' => ['P0000004'], 'school_tesim' => ['Emory College'], 'degree_tesim' => ['B.S.'] } }
+      it 'logs warnings for near matches with the same PPID', :aggregate_failures do
+        allow(Rails.logger).to receive(:warn)
+        _grad_date, _grad_record = grad_service.find_registrar_match(etd_solr_doc)
+        expect(Rails.logger).to have_received(:warn).with(/UnmatchedETD/)
+        expect(Rails.logger).to have_received(:warn).with(/P0000004-UCOL-LIBAS/)
+        expect(Rails.logger).to have_received(:warn).with(/P0000004-THEO-MDV \(2018-01-12\)/)
+        expect(Rails.logger).to have_received(:warn).with(/P0000004-THEO-THD \(2020-05-23\)/)
+      end
+      it 'logs when no matches exist' do
+        etd_solr_doc['depositor_ssim'] = ['P1234567']
+        allow(Rails.logger).to receive(:warn)
+        _grad_date, _grad_record = grad_service.find_registrar_match(etd_solr_doc)
+        expect(Rails.logger).to have_received(:warn).with(/PPID not found in registrar data/)
+      end
+      it 'returns nil graduation date' do
+        grad_date, _grad_record = grad_service.find_registrar_match(etd_solr_doc)
+        expect(grad_date).to be_nil
+      end
+      it 'returns a dummy registrar record' do
+        _grad_date, grad_record = grad_service.find_registrar_match(etd_solr_doc)
+        expect(grad_record).to eq({ 'degree status descr' => 'Unmatched' })
+      end
+    end
+  end
+end

--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -7,8 +7,8 @@ describe GraduationService, :clean do
   let(:nongraduated_user) { FactoryBot.create(:nongraduated_user) }
   let(:double_degree_user) { FactoryBot.create(:double_degree_user) }
   let(:approving_user) { User.where(uid: "candleradmin").first }
-  let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null") }
-  let(:graduated_etd) { FactoryBot.actor_create(:sample_data, degree: ["B.S."], user: graduated_user) }
+  let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/admin_sets_registrar_subset.yml", "/dev/null") }
+  let(:graduated_etd) { FactoryBot.actor_create(:sample_data_undergrad, user: graduated_user) }
   let(:nongraduated_etd) { FactoryBot.actor_create(:sample_data, user: nongraduated_user) }
   # ETD for user that is graduated with one degree but is pursuing another degree with Emory
   let(:double_degree_etd) { FactoryBot.actor_create(:sample_data, degree: ["M.Div."], user: double_degree_user) }
@@ -50,18 +50,6 @@ describe GraduationService, :clean do
     it "finds approved etds" do
       grad_service = described_class.new('./spec/fixtures/registrar_sample.json')
       expect(grad_service.graduation_eligible_works.map { |doc| doc['id'] }).to contain_exactly(graduated_etd.id, nongraduated_etd.id, double_degree_etd.id)
-    end
-  end
-  describe "#status" do
-    it "provides statistics for a run", :aggregate_failures do
-      grad_service = described_class.new('./spec/fixtures/registrar_sample.json')
-
-      expect(grad_service.status.overall).to eq 'Not run'
-      grad_service.run
-      expect(grad_service.status.overall).to eq 'Completed'
-
-      expect(grad_service.status['degree_eligible_etds']).to eq 3
-      expect(grad_service.status['newly_published_etds']).to eq 2
     end
   end
 end


### PR DESCRIPTION
This change addresses a number of issues in the GraduationService:
* Refactor the registrar lookup for speed
   * Use PPID, school, and department info from the ETD to construct the registrar
      data "etd record key"
   * Use the main key when searching registrar data instead of searching nested data
* Remove the `status` object
   * Logging output to the console provides the necessary information with less code
* Improve logging to provide better auditig and debugging info
   * Show whether an approved ETD was matched and whether a graduation date is present
   * Show any other records with the same PPID for unmatched ETDs
* Add unit testing for date extraction and record matching