### PR TITLE
Fix coverage reporting to Coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 orbs:
     samvera: samvera/circleci-orb@dev:8975953
     browser-tools: circleci/browser-tools@1.2.4
+    coveralls: coveralls/coveralls@1.0.6
+
 jobs:
     build:
         parameters:
@@ -70,8 +72,8 @@ jobs:
             - store_artifacts:
                 path: tmp/screenshots
 
-            - deploy:
-                command: curl -k https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN} -d "payload[build_num]=${CIRCLE_BUILD_NUM}&payload[status]=done"
+            - coveralls/upload:
+                  path_to_lcov: ./coverage/lcov/laevigata.lcov
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
                 path: tmp/screenshots
 
             - coveralls/upload:
-                  path_to_lcov: ./coverage/lcov/laevigata.lcov
+                  path_to_lcov: ./coverage/lcov/project.lcov
 
 workflows:
     version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'capybara'
   gem 'capybara-screenshot'
-  gem 'coveralls', require: false
   gem 'database_cleaner'
   gem 'fcrepo_wrapper'
   gem 'hyrax-spec'
@@ -75,6 +74,7 @@ group :development, :test do
   gem 'rspec_junit_formatter'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
+  gem 'simplecov-lcov', require: false
   gem 'solr_wrapper', '>= 0.3'
   gem 'vcr'
   gem 'webdrivers', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,12 +197,6 @@ GEM
     commonjs (0.2.7)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -224,7 +218,7 @@ GEM
     devise-guests (0.7.0)
       devise
     diff-lcs (1.4.4)
-    docile (1.3.5)
+    docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
@@ -523,7 +517,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (2.5.1)
+    json (2.6.1)
     json-canonicalization (0.2.1)
     json-ld (3.1.9)
       htmlentities (~> 4.3)
@@ -931,11 +925,13 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
     slop (4.9.1)
     solr_wrapper (3.1.2)
       http
@@ -979,15 +975,10 @@ GEM
     ssrf_filter (1.0.7)
     sxp (1.1.0)
       rdf (~> 3.1)
-    sync (0.5.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.28.0)
-      sync
     tinymce-rails (4.9.11)
       railties (>= 3.1.1)
     trailblazer-option (0.1.1)
@@ -1067,7 +1058,6 @@ DEPENDENCIES
   capybara-screenshot
   clamby (>= 1.2.5)
   coffee-rails
-  coveralls
   database_cleaner
   devise
   devise-guests (~> 0.5)
@@ -1114,6 +1104,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
+  simplecov-lcov
   solr_wrapper (>= 0.3)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,11 +2,13 @@
 
 unless ENV['NO_COVERAGE'] == 'true'
   require 'simplecov'
-  require 'coveralls'
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
                                                                    SimpleCov::Formatter::HTMLFormatter,
-                                                                   Coveralls::SimpleCov::Formatter
+                                                                   SimpleCov::Formatter::LcovFormatter
                                                                  ])
+
   SimpleCov.start do
     # Can filter out files from coverage reports, example below.
     # add_filter 'app/controllers/metadata_samples_controller.rb'


### PR DESCRIPTION
Remove the `coveralls` gem and related configuration.  The gem appears not
to be maintained any longer.

Update CircleCI config to use the Coveralls orb, roughly following the
process outlined here:
* https://circleci.com/blog/adding-test-coverage-to-your-ci-pipeline/
* https://circleci.com/developer/orbs/orb/coveralls/coveralls#quick-start