### PR TITLE
Refactor tests to isolate test environment timezone

### DIFF
--- a/spec/indexers/etd_indexer_spec.rb
+++ b/spec/indexers/etd_indexer_spec.rb
@@ -30,6 +30,6 @@ RSpec.describe EtdIndexer do
 
   it 'indexes degree_awarded as a sortable date' do
     etd.degree_awarded = 'December 04, 2012'
-    expect(solr_doc['degree_awarded_dtsi']).to eq '2012-12-04T00:00:00Z'
+    expect(solr_doc['degree_awarded_dtsi']).to match('2012-12-04')
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -688,7 +688,7 @@ describe InProgressEtd do
 
       let(:new_data) do
         { 'title' => ['New ETD Title'],
-          'degree_awarded' => "2018-08-23T00:00:00.000+00:00",
+          'degree_awarded' => '2018-08-23',
           'embargo_length' => '1000 years',
           'keyword' => ['new keyword'],
           'department' => ['Some'],
@@ -702,10 +702,11 @@ describe InProgressEtd do
       let(:etd) { Etd.create!(new_data) }
       let(:ipe) { described_class.new(etd_id: etd.id, data: stale_data.to_json) }
 
-      it 'replaces the stale data with updated data' do
+      it 'replaces the stale data with updated data', :aggregate_failures do
         expect(
-          refreshed_data.except('committee_chair_attributes', 'ipe_id', 'etd_id', 'title', 'embargo_type', 'partnering_agency')
-          ).to eq new_data.except('committee_chair_attributes', 'title', 'embargo_type', 'partnering_agency')
+          refreshed_data.except('committee_chair_attributes', 'ipe_id', 'etd_id', 'title', 'embargo_type', 'partnering_agency', 'degree_awarded')
+          ).to eq new_data.except('committee_chair_attributes', 'title', 'embargo_type', 'partnering_agency', 'degree_awarded')
+        expect(refreshed_data['degree_awarded']).to match(new_data['degree_awarded'])
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Another University/)
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Merlin/)
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Emory University/)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ::SolrDocument, type: :model do
 
     it 'returns the degree_awarded in UTC' do
       etd.degree_awarded = 'May 15, 1848'
-      expect(solr_doc.degree_awarded).to eq('1848-05-15T00:00:00Z')
+      expect(solr_doc.degree_awarded).to match('1848-05-15T')
     end
   end
 
@@ -83,7 +83,7 @@ RSpec.describe ::SolrDocument, type: :model do
 
     context 'when under embargo' do
       subject(:etd) do
-        FactoryBot.create(:tomorrow_expiration,
+        FactoryBot.build(:tomorrow_expiration,
                           files_embargoed: false,
                           toc_embargoed:   false)
       end


### PR DESCRIPTION
ISSUE:
Depending on the system for the test suite run, the "local" ruby timezone
can either be something like
* UTC+5:00 "Eastern Time (US & Canada)"
* UTC+6:00 "America/Chicago"
* +0000     UTC

So, tests that check for a literal time may fail due to mismatches in
timezone offsets.  This occurs mostly between runs in local developer
environments (typically set to Eastern or Central time) and runs on
CircleCI (set to UTC).

CHANGE:
Update tests to either match just on the date portion of timestamps
or explicitly set timezones for the specific test.