### PR TITLE
Update CircleCI Samvera Orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    samvera: samvera/circleci-orb@dev:8975953
+    samvera: samvera/circleci-orb@1.0.3
     browser-tools: circleci/browser-tools@1.2.4
     coveralls: coveralls/coveralls@1.0.6
 


### PR DESCRIPTION
We're getting a build error because the development orb we've been using has expired:
```
#!/bin/sh -eo pipefail
# The dev version of samvera/circleci-orb@dev:8975953 has expired. Dev versions of orbs are only valid for 90 days after publishing.
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false
```