### PR TITLE
Show consistent user information

### DIFF
--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -136,3 +136,16 @@ input.update_child_embargoes {
   margin-top: 1rem;
   margin-right: 1rem;
 }
+
+table.user-info {
+  // break long system names like "executive_masters_public_health_admin"
+  overflow-wrap: anywhere;
+
+  .display-name { width: 15%; }
+  .net-id { width: 10%; }
+  .ppid { width: 10%; }
+  .roles { }
+  .access { width: 10%; }
+  .user-status { width: 8%; }
+  .actions { width: 8%; }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,18 @@ class User < ApplicationRecord
   # doesn't pass us all the info we need to make a User object, do not make
   # blank one. Usually if the user just tries to log in again it will work.
   # @param [OmniAuth::AuthHash] auth
+  # @example auth = #<OmniAuth::AuthHash /
+  #                   credentials=#<OmniAuth::AuthHash> /
+  #                   extra=#<OmniAuth::AuthHash /
+  #                   raw_info=#<OmniAuth::AuthHash>> /
+  #                   info=#<OmniAuth::AuthHash::InfoHash /
+  #                          display_name="Test User" /
+  #                          name="User, Test" /
+  #                          uid="tuser"> /
+  #                   provider="shibboleth" /
+  #                   uid="P8675309">
+  # @note auth.uid contains the Emory PPID auth.info.uid contains the login name (i.e. NetID)
+  # @note laevigata uses the PPID for the devise user_key (instead of the NetID)
   def self.from_omniauth(auth)
     Rails.logger.debug "auth = #{auth.inspect}"
     raise User::NilShibbolethUserError.new("No uid", auth) if auth.uid.empty? || auth.info.uid.empty?

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -15,32 +15,29 @@
             </div>
             <div class="panel-body">
               <div class="table-responsive">
-                <table class="table table-striped datatable" id="usersTable">
+                <table class="table table-striped datatable user-info" id="usersTable">
                   <thead>
                   <tr>
-                    <th><%= t('.id_label') %></th>
-                    <th><%= t('.displayname_label') %></th>
-                    <th><%= t('.status') %></th>
+                    <th class='display-name'><%= t('.displayname_label') %></th>
+                    <th class='net-id'><%= t('.id_label') %></th>
+                    <th class='ppid'><%= t('.ppid_label') %></th>
                     <th data-orderable="false"><%= t('.role_label') %></th>
                     <% if @presenter.show_last_access? %>
-                      <th><%= t('.access_label') %></th>
+                      <th  class='access'><%= t('.access_label') %></th>
                     <% end %>
-                    <th data-orderable="false"><%= t('.actions_label') %></th>
+                    <th class='user-status'><%= t('.status') %></th>
+                    <th class='actions' data-orderable="false"><%= t('.actions_label') %></th>
                   </tr>
                   </thead>
                   <tbody>
                   <% @presenter.users.each do |user| %>
                     <tr>
-                      <td><%= link_to user.uid || "", hyrax.dashboard_profile_path(user) %></td>
                       <td><%= link_to user.display_name || "", hyrax.dashboard_profile_path(user) %></td>
-                      <td>
-                        <% if user.deactivated %>
-                          <span class='label label-danger'>deactivated</span>
-                        <% end %>
-                      </td>
+                      <td><%= link_to user.uid || "", hyrax.dashboard_profile_path(user) %></td>
+                      <td><%= link_to user.ppid || "", hyrax.dashboard_profile_path(user) %></td>
                       <td>
                         <% roles = @presenter.user_roles(user) %>
-                        <ul>
+                        <ul class="workflow-roles">
                           <% roles.each do |role| %>
                             <li><%= role %></li>
                           <% end %>
@@ -52,6 +49,11 @@
                           <%= @presenter.last_accessed(user).to_formatted_s(:long_ordinal) %>
                         </td>
                       <% end %>
+                      <td>
+                        <% if user.deactivated %>
+                          <span class='label label-danger'>deactivated</span>
+                        <% end %>
+                      </td>
                       <td>
                         <% if user.deactivated %>
                           <%= link_to "Reactivate",  main_app.activate_path(:id=>user.id, :deactivated=>false), :method=>:put, :data => {:confirm => 'Are you sure you want to reactivate the user?'}%>

--- a/app/views/hyrax/admin/workflow_roles/index.html.erb
+++ b/app/views/hyrax/admin/workflow_roles/index.html.erb
@@ -1,0 +1,67 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-users" aria-hidden="true"></span>  <%= t("hyrax.admin.workflow_roles.header") %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title h2"><%= t('.new_role') %></h2>
+      </div>
+      <div class="panel-body">
+        <%= simple_form_for Hyrax::Forms::WorkflowResponsibilityForm.new, url: hyrax.admin_workflow_roles_path do |f| %>
+          <%= f.input :user_id, as: :select, collection: f.object.user_options %>
+          <%= f.input :workflow_role_id, as: :select, collection: f.object.workflow_role_options %>
+          <%= f.submit class: 'btn btn-sm btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title h2"><%= t('.current_roles') %></h3>
+      </div>
+      <div class="panel-body">
+        <table class="table table-striped datatable user-info">
+          <thead>
+          <th class='display-name'><%= t('.header.name') %></th>
+          <th class='net-id'><%= t('.header.netid') %></th>
+          <th class='ppid'><%= t('.header.user') %></th>
+          <th class='roles'><%= t('.header.roles') %></th>
+          </thead>
+          <tbody>
+          <% @presenter.users.each do |user| %>
+            <tr>
+              <td data-sort="<%= user.display_name %>"><%= user.display_name %></td>
+              <td data-sort="<%= user.uid %>"><%= user.uid %></td>
+              <td data-sort="<%= user.user_key %>"><%= user.user_key %></td>
+              <% agent_presenter = @presenter.presenter_for(user) %>
+              <% if agent_presenter && agent_presenter.responsibilities_present? %>
+                <td>
+                  <ul class="workflow-roles">
+                    <% agent_presenter.responsibilities do |responsibility_presenter| %>
+                      <li><%= responsibility_presenter.label %>
+                        <%= link_to hyrax.admin_workflow_role_path(responsibility_presenter.responsibility),
+                                    method: :delete,
+                                    data: { confirm: t('.delete.confirm') } do %>
+                          <span class="fa fa-remove"></span>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </td>
+              <% else %>
+                <td><%= t('.no_roles') %></td>
+              <% end %>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -82,7 +82,15 @@ en:
     contact_form:
       header: Help
     admin:
+      workflow_roles:
+        index:
+          header:
+            name: Display Name
+            netid: NetID
+            user: PPID
       users:
         index:
-          actions_label: "Actions"
-          displayname_label: "Display Name"
+          actions_label: Actions
+          displayname_label: Display Name
+          id_label: NetID
+          ppid_label: PPID


### PR DESCRIPTION
We've had trouble resolving approver issues because the user information
displayed in the dashboard users list doesn't match the information
provided in the workflow magement view.

This change implements consistent column naming and layout for both views
to make matching users across views easier.

**UPDATED VIEWS**
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/3064318/170085033-e83c9b80-72e3-456c-a55e-9334272a6dd1.png">

<img width="1920" alt="image" src="https://user-images.githubusercontent.com/3064318/170084833-7667a6fd-28ff-41d9-9713-a3fb2b23e9ef.png">
