### PR TITLE
Display e-mail on Manage Users view in admin dashboard

### DIFF
--- a/app/assets/stylesheets/etd.scss
+++ b/app/assets/stylesheets/etd.scss
@@ -144,6 +144,7 @@ table.user-info {
   .display-name { width: 15%; }
   .net-id { width: 10%; }
   .ppid { width: 10%; }
+  .email { width: 15%; }
   .roles { }
   .access { width: 10%; }
   .user-status { width: 8%; }

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -21,6 +21,7 @@
                     <th class='display-name'><%= t('.displayname_label') %></th>
                     <th class='net-id'><%= t('.id_label') %></th>
                     <th class='ppid'><%= t('.ppid_label') %></th>
+                    <th class='email'><%= t('.email_label') %></th>
                     <th data-orderable="false"><%= t('.role_label') %></th>
                     <% if @presenter.show_last_access? %>
                       <th  class='access'><%= t('.access_label') %></th>
@@ -35,6 +36,7 @@
                       <td><%= link_to user.display_name || "", hyrax.dashboard_profile_path(user) %></td>
                       <td><%= link_to user.uid || "", hyrax.dashboard_profile_path(user) %></td>
                       <td><%= link_to user.ppid || "", hyrax.dashboard_profile_path(user) %></td>
+                      <td><%= link_to user.email || "", hyrax.dashboard_profile_path(user) %></td>
                       <td>
                         <% roles = @presenter.user_roles(user) %>
                         <ul class="workflow-roles">

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -94,3 +94,4 @@ en:
           displayname_label: Display Name
           id_label: NetID
           ppid_label: PPID
+          email_label: E-Mail


### PR DESCRIPTION
When we get bounce notifications from AWS, the only user data we
have available is the e-mail address.  Since this is typically the
post-graduation e-mail supplied by the student, we have no easy way
to match it against a NetID or PPID.

This change displays the e-mail associated with the user so that we
can search and sort on e-mail addresses - and therefore match
bouncing addresses to the corresponding student or approver.

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/3064318/171513159-32f0eaee-956b-4013-8a36-bfd51d8719f4.png">
