### PR TITLE
Enhance GraduationService reporting

### DIFF
--- a/spec/services/graduation_service_spec.rb
+++ b/spec/services/graduation_service_spec.rb
@@ -82,7 +82,7 @@ describe GraduationService do
         expect(Rails.logger).to have_received(:warn).with(/SameSchoolDifferentProgram/)
         expect(Rails.logger).to have_received(:warn).with(/"registrar_key":"P0000005-GSAS-MA"/)
         expect(Rails.logger).to have_received(:warn).with(/"reconciled_key":"P0000005-GSAS-PHD"/)
-        expect(Rails.logger).to have_received(:warn).with(/"graduation_date":"2020-05-25"/)
+        expect(Rails.logger).to have_received(:warn).with(/"grad_date":"2020-05-25"/)
       end
     end
 


### PR DESCRIPTION
Refactor the graduation reporting code to
* Fix `grad_date` column name
* Sort report results by status, school, and program
* Insert blank lines between status groups in the CSV
* Handle link generation more cleanly
* Open and close the report file closer to the code that generates report data