### PR TITLE
Fix graduation report CSV naming

### DIFF
--- a/lib/tasks/etd_report.rake
+++ b/lib/tasks/etd_report.rake
@@ -6,7 +6,7 @@ namespace :emory do
                  post_graduation_email degree_awarded graduation_date partnering_agency
                  date_created date_uploaded abstract]
 
-    CSV.open(Rails.root.join("private", "report.csv").to_s, "wb", write_headers: true, headers: headers) do |csv|
+    CSV.open(Rails.root.join("private", "etd_report.csv").to_s, "wb", write_headers: true, headers: headers) do |csv|
       Etd.search_in_batches({ workflow_state_name_ssim: 'published' }, batch_size: 10) do |batch|
         batch.map { |x| Etd.find(x['id']) }.each do |etd|
           row = {}


### PR DESCRIPTION
The code is generating a file called `report.csv` but downloading a file called `etd_report.csv` that hasn't been updated since April.

```
deploy@ip-10-1-235-97:/opt/laevigata/current$ ls -la /opt/laevigata/shared/private/
total 52792
drwxrwxr-x 2 deploy deploy     4096 Apr 13 23:55 .
drwxr-xr-x 8 deploy deploy     4096 Apr 13 15:32 ..
-rw-rw-r-- 1 deploy deploy 25976983 Apr 13 00:19 etd_report.csv
-rw-rw-r-- 1 deploy deploy 28064358 Oct  7 00:17 report.csv
```

RESOLUTION:
Update the rake task to save the report to the expected filename: `etd_report.csv`