### PR TITLE
Fixes email address for copyright questions

### DIFF
--- a/app/javascript/config/copyrightQuestions.json
+++ b/app/javascript/config/copyrightQuestions.json
@@ -1,7 +1,7 @@
 [
   {
     "label": "Copyright",
-    "text": "Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have questions about your use of copyrighted material, contact the Scholarly Communications Office at scholcom@listserv.cc.emory.edu",
+    "text": "Does your thesis or dissertation contain content, such as a previously published article, for which you no longer own copyright? If you have questions about your use of copyrighted material, contact the Scholarly Communications Office at scholcomm@listserv.cc.emory.edu",
     "chice": "false",
     "name": "etd[other_copyrights]"
   },


### PR DESCRIPTION
For the first time in over four years, someone has had a copyright question.

This is intended to change the email address in the text on the submission form in the copyright questions block, as shown below.
<img width="1197" alt="copyright-email" src="https://user-images.githubusercontent.com/638392/195196869-0a302e29-75a9-4424-9219-ceedae25c0f3.png">
