### PR TITLE
Fix circleCI build error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,9 @@ jobs:
         working_directory: ~/project
         parallelism: 4
         steps:
+            - checkout
             - browser-tools/install-chrome
             - browser-tools/install-chromedriver
-            - checkout
 
             - samvera/bundle:
                 ruby_version: << parameters.ruby_version >>


### PR DESCRIPTION
The browser-tools install process has begun leaving a license file in the project home directory that prevents circle from successfully cheking out the project.  We see the following error during the build:
> Directory (/home/circleci/project) you are trying to checkout to is not empty and not a git repository

FIX: checkout the code from git before installing browser-tools

see: https://github.com/CircleCI-Public/browser-tools-orb/issues/62