### PR TITLE
Improve handling of graduation dates

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -163,7 +163,7 @@ class Etd < ActiveFedora::Base
       super(value.to_time.utc)
     when String
       Rails.logger.warn("Assigning #{__method__} to a string is deprecated. Casting to a Time class value.")
-      super(Date.parse(value).to_time.utc)
+      super(Date.parse(value).at_midnight.utc)
     when NilClass
       super(nil)
     else

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -337,10 +337,12 @@ RSpec.describe Etd do
       Time.zone = tz # reset the timezone for the rest of the test suite
     end
     it "casts Strings from midnight local time to DateTime objects" do
+      tz = Time.zone # save the timezone before changing it
+      Time.zone = "Pacific Time (US & Canada)" # set the ruby local timezone explicitly
       etd.degree_awarded = "July 10, 2017"
-      local_zone = Time.now.zone
-      july2017 = DateTime.new(2017, 7, 10, 0, 0, 0, local_zone)
+      july2017 = Time.zone.local(2017, 0o7, 10, 0, 0, 0)
       expect(etd.degree_awarded).to eq july2017
+      Time.zone = tz # reset the timezone for the rest of the test suite
     end
     it "handles all Date and Time like classes", :aggregate_failures do
       expect { etd.degree_awarded = Time.zone.local(1984) }.not_to raise_error


### PR DESCRIPTION
This change makes setting the graduation time to midnight more explicit.

It also fixes the corresponding test to fix a bug that caused the test to fail when the test was run when daylight savings was in effect by adding better timezone handling in the test.