### PR TITLE
Add a description to the rake task that updates approvers

### DIFF
--- a/lib/tasks/update_roles.rake
+++ b/lib/tasks/update_roles.rake
@@ -1,6 +1,7 @@
 require 'yaml'
 
 namespace :emory do
+  desc "Update AdminSets and associated approvers"
   task update_roles: :environment do
     # create workflows
     WorkflowSetup.new.setup


### PR DESCRIPTION
The task previously didn't have a description, so it would not appear in task lists generated with `rake -T`.

This change ensures the task appears when listing available tasks.