### PR TITLE
DRY up test helpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,6 +129,7 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Warden::Test::Helpers, type: :system
   config.include Capybara::RSpecMatchers, type: :input
 
   config.include Warden::Test::Helpers, type: :feature

--- a/spec/system/404_spec.rb
+++ b/spec/system/404_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.describe 'Getting a 404 for RecordNotFound', type: :system do
   before do

--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.describe 'Admin dashboard',
                type: :system,

--- a/spec/system/blacklisted_email_spec.rb
+++ b/spec/system/blacklisted_email_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe 'Do not send email to blacklisted addresses', :clean, integration: true, type: :system do

--- a/spec/system/candler_workflow_etd_spec.rb
+++ b/spec/system/candler_workflow_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Candler approval workflow', :perform_jobs, :clean, integration: true, type: :system do
   let(:depositing_user) { FactoryBot.create(:user) }

--- a/spec/system/check_school_spec.rb
+++ b/spec/system/check_school_spec.rb
@@ -1,6 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-
-include Warden::Test::Helpers
 
 RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :system do
   let(:user) { create :user }

--- a/spec/system/contact_form_spec.rb
+++ b/spec/system/contact_form_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe 'contact form page', integration: true, smoke_test: true, type: :system do

--- a/spec/system/edit_etd_spec.rb
+++ b/spec/system/edit_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.feature 'Edit an existing ETD',
               :perform_jobs,

--- a/spec/system/edit_file_set_spec.rb
+++ b/spec/system/edit_file_set_spec.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, integration: true, type: :system do
   let(:attributes) do

--- a/spec/system/edit_in_progress_etd_spec.rb
+++ b/spec/system/edit_in_progress_etd_spec.rb
@@ -1,7 +1,5 @@
-# Generated via `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
-
-include Warden::Test::Helpers
 
 RSpec.describe 'Edit an existing ETD', :clean, integration: true, type: :system do
   context "no unauthorized users can see a student's in progress ETD" do

--- a/spec/system/edit_migrated_etd_spec.rb
+++ b/spec/system/edit_migrated_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.feature 'Edit a migrated ETD, whose department doesn\'t exist anymore',
               :perform_jobs,

--- a/spec/system/embargo_edit_spec.rb
+++ b/spec/system/embargo_edit_spec.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'edit an embargo', :perform_jobs, :js, integration: true, type: :system do
   before(:all) do

--- a/spec/system/embargo_show_spec.rb
+++ b/spec/system/embargo_show_spec.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, integration: true, type: :system do
   let(:attributes) do

--- a/spec/system/feature_set_spec.rb
+++ b/spec/system/feature_set_spec.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.describe 'Feature configuration', type: :system, integration: true do
   context 'via a config file' do

--- a/spec/system/laney_workflow_etd_spec.rb
+++ b/spec/system/laney_workflow_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.feature 'Laney Graduate School two step approval workflow',
               :perform_jobs,

--- a/spec/system/password_protect_spec.rb
+++ b/spec/system/password_protect_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.describe 'Password protect non production instances', type: :system do
   let(:login) { 'admin' }

--- a/spec/system/read_only_mode_spec.rb
+++ b/spec/system/read_only_mode_spec.rb
@@ -1,7 +1,5 @@
-# Generated via `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
-
-include Warden::Test::Helpers
 
 RSpec.describe 'Read Only Mode', type: :system, integration: true do
   before(:all) do

--- a/spec/system/rollins_workflow_etd_spec.rb
+++ b/spec/system/rollins_workflow_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Create a Rollins ETD', :perform_jobs, :clean, :js, integration: true, type: :system do
   let(:depositing_user) { FactoryBot.create(:user) }

--- a/spec/system/search_etd_spec.rb
+++ b/spec/system/search_etd_spec.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.feature 'Search for an ETD', type: :system, integration: true do
   let(:etd) do

--- a/spec/system/show_admin_set_spec.rb
+++ b/spec/system/show_admin_set_spec.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.describe 'show admin set', type: :system, integration: true do
   let(:admin_set) { FactoryBot.create(:admin_set) }

--- a/spec/system/show_etd_spec.rb
+++ b/spec/system/show_etd_spec.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system do
   let(:etd) do

--- a/spec/system/show_user_spec.rb
+++ b/spec/system/show_user_spec.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.describe 'show user profile', type: :system, integration: true do
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/skip_dashboard_spec.rb
+++ b/spec/system/skip_dashboard_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe 'Skip the dashboard', type: :system, integration: true do

--- a/spec/system/submit_etd_spec.rb
+++ b/spec/system/submit_etd_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
-
 require "rails_helper"
-
-include Warden::Test::Helpers
 
 RSpec.describe "Logged in student can submit an ETD", :clean, type: :system, js: true do
   let(:student) { create :user }

--- a/spec/system/submit_etd_spec_rollins.rb
+++ b/spec/system/submit_etd_spec_rollins.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
-
 require "rails_helper"
-
-include Warden::Test::Helpers
 
 RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
   let(:student) { create :user }

--- a/spec/system/suppress_collections_spec.rb
+++ b/spec/system/suppress_collections_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe 'Collection objects should not appear in search results', :clean, integration: true, type: :system do

--- a/spec/system/undergrad_honors_workflow_etd_spec.rb
+++ b/spec/system/undergrad_honors_workflow_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Emory College approval workflow', :perform_jobs, :clean, :js, integration: true, type: :system, workflow: { admin_sets_config: 'spec/fixtures/config/emory/ec_admin_sets.yml' } do
   let(:depositing_user) { User.where(ppid: etd.depositor).first }

--- a/spec/system/upload_files_spec.rb
+++ b/spec/system/upload_files_spec.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-include Warden::Test::Helpers
 
 RSpec.feature 'Primary PDF', integration: true, type: :system do
   let(:user) { create :user }

--- a/spec/system/validate_new_etd_about_spec.rb
+++ b/spec/system/validate_new_etd_about_spec.rb
@@ -1,6 +1,5 @@
+# frozen_string_literal: true
 require 'rails_helper'
-
-include Warden::Test::Helpers
 
 RSpec.describe 'Validate an Etd: About Me', type: :system, integration: true do
   let(:user) { create :user }

--- a/spec/system/virus_workflow_etd_spec.rb
+++ b/spec/system/virus_workflow_etd_spec.rb
@@ -1,8 +1,6 @@
-# Generated via
-#  `rails generate hyrax:work Etd`
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Virus checking', :perform_jobs, :clean, :js, integration: true, type: :system do
   let(:depositing_user) { User.where(ppid: etd.depositor).first }

--- a/spec/system/workflow_approval_spec.rb
+++ b/spec/system/workflow_approval_spec.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 require 'rails_helper'
 require 'workflow_setup'
-include Warden::Test::Helpers
 
 RSpec.describe 'Dashboard workflow', :clean, integration: true, type: :system do
   let(:approving_user)  { User.find_by(uid: "candleradmin") }


### PR DESCRIPTION
Move the Warden test helper setup to the rails_helper.rb file since it's used in more system specs than not.

Also add `# frozen_string_literal: true since we're checking all these files.