### PR TITLE
Fix timestamp bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,6 @@
 
 module ApplicationHelper
   def formatted_date(time:)
-    I18n.l(time.in_time_zone('Eastern Time (US & Canada)'), format: '%D %I.%m %p')
+    I18n.l(time.in_time_zone('Eastern Time (US & Canada)'), format: '%D %I:%M %p')
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
   let(:time) { '2019-07-17 17:08:08 -0400' }
-  let(:est_time) { '07/17/19 05.07 PM' }
+  let(:est_time) { '07/17/19 05:08 PM' }
   describe '#formatted_date' do
     it 'returns an EST date/time with AM and PM' do
       expect(helper.formatted_date(time: time)). to eq(est_time)


### PR DESCRIPTION
There was a bug in the timestamp helper that displayed the month number (%m) instead of the minutes (%M) in certain views.