### PR TITLE
Clean up tests

### DIFF
--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -2,11 +2,15 @@
 #  `rails generate hyrax:work Etd`
 require 'rails_helper'
 
-RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
-  let(:user) { create :user }
+RSpec.describe Hyrax::EtdsController, :perform_jobs do
+  before :all do
+    ActiveFedora::Cleaner.clean!
+    # ensure clean! is called before rather than after WorkflowSetup - i.e. avoid using use :clean tag
+    WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null").setup
+  end
 
+  let(:user) { create :user }
   let(:approver) { User.where(uid: "tezprox").first }
-  let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
 
   let(:file1) { File.open("#{fixture_path}/miranda/miranda_thesis.pdf") }
   let(:file2) { File.open("#{fixture_path}/magic_warrior_cat.jpg") }
@@ -41,7 +45,6 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
     end
 
     before do
-      workflow_setup.setup
       etd.assign_admin_set
 
       # Create the ETD record
@@ -132,10 +135,6 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs, :clean do
   end
 
   describe "POST create" do
-    before do
-      workflow_setup.setup
-    end
-
     it "creates an etd" do
       expect {
         post :create, params: { etd: { title: 'a title', school: 'Emory College', department: 'Art History' } }

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -55,9 +55,7 @@ describe AttachFilesToWorkJob do
     let(:file_path) { "#{::Rails.root}/spec/fixtures/virus_checking/virus_check.txt" }
 
     before do
-      # Comment out these Clamby lines, and the ones in rails_helper.rb to really test virus scanning
-      class_double("Clamby").as_stubbed_const
-      allow(Clamby).to receive(:virus?).and_return(true)
+      allow(TestVirusScanner).to receive(:infected?).and_return(true)
       class_double("Hyrax::Workflow::VirusEncounteredNotification").as_stubbed_const
       allow(Hyrax::Workflow::VirusEncounteredNotification).to receive(:send_notification)
     end

--- a/spec/lib/clamby_scanner_spec.rb
+++ b/spec/lib/clamby_scanner_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'clamby_scanner'
+
+RSpec.describe ClambyScanner do
+  let(:infected_file) { Rails.root.join('spec', 'fixtures', 'virus_checking', 'virus_check.txt').to_s }
+  let(:clean_file)    { Rails.root.join('spec', 'fixtures', 'miranda', 'miranda_thesis.pdf').to_s }
+
+  describe "Clamby" do
+    before do
+      # Stub Clamby to return true if filename includes "virus"
+      # in environments without ClamAV installed - e.g. CircleCI
+      Clamby.configure(error_clamscan_missing: false, output_level: 'off')
+      unless Clamby.scanner_exists?
+        class_double("Clamby").as_stubbed_const
+        allow(Clamby).to receive(:virus?) { |args| args.match?(/virus/i) }
+      end
+    end
+
+    it 'detects viruses' do
+      expect(described_class.infected?(infected_file)).to be true
+    end
+
+    it 'passes clean files' do
+      expect(described_class.infected?(clean_file)).to be false
+    end
+  end
+
+  describe "functionality" do
+    # ClambyScanner can be removed once we're running a more recent version of hydra-works
+    it 'is handled natively in hydra-works >= 2.0.0' do
+      pending 'hydra-works >= v2.0.0'
+      native = Gem::Version.new(Hydra::Works::VERSION) >= Gem::Version.new('2.0.0')
+      expect(native).to be true
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,8 @@ RSpec.configure do |config|
   config.before :suite do
     disable_production_minter!
     ActiveFedora::Cleaner.clean!
+
+    Hydra::Works.default_system_virus_scanner = TestVirusScanner
   end
 
   config.after :suite do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -123,11 +123,6 @@ RSpec.configure do |config|
   #   ActiveFedora::Cleaner.clean!
   # end
 
-  config.before do
-    class_double("Clamby").as_stubbed_const
-    allow(Clamby).to receive(:virus?).and_return(false)
-  end
-
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Warden::Test::Helpers, type: :system

--- a/spec/support/test_virus_scanner.rb
+++ b/spec/support/test_virus_scanner.rb
@@ -1,0 +1,5 @@
+class TestVirusScanner < Hydra::Works::VirusScanner
+  def self.infected?(_file)
+    false
+  end
+end

--- a/spec/support/workflow.rb
+++ b/spec/support/workflow.rb
@@ -1,8 +1,8 @@
 module Workflow
-  def change_workflow_status(etd, action_name, user)
+  def change_workflow_status(etd, action_name, user, comment = nil)
     subject = Hyrax::WorkflowActionInfo.new(etd, user)
     sipity_workflow_action = PowerConverter.convert_to_sipity_action(action_name, scope: subject.entity.workflow) { nil }
-    Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
+    Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: comment)
   end
 end
 

--- a/spec/support/workflow.rb
+++ b/spec/support/workflow.rb
@@ -4,10 +4,6 @@ module Workflow
     sipity_workflow_action = PowerConverter.convert_to_sipity_action(action_name, scope: subject.entity.workflow) { nil }
     Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
   end
-
-  def approve_etd(etd, approving_user)
-    change_workflow_status(etd, 'approve', approving_user)
-  end
 end
 
 RSpec.configure do |config|

--- a/spec/system/check_school_spec.rb
+++ b/spec/system/check_school_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :system do
+RSpec.feature 'Selected school', :clean, integration: true, js: true, type: :system do
   let(:user) { create :user }
 
   let(:approver) { User.where(uid: "tezprox").first }
@@ -10,7 +10,7 @@ RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :sy
     allow_any_instance_of(ActionController::Base).to receive(:protect_against_forgery?).and_return(true)
   end
 
-  describe 'verify school is Emory College' do
+  describe 'does not change' do
     let(:default_attrs) do
       { depositor: user.user_key,
         title: ['This is a thesis'],
@@ -36,12 +36,10 @@ RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :sy
     end
 
     context 'when editing an etd' do
-      scenario 'school does not change when etd is in request_changes status' do
+      scenario 'in request_changes status' do
         # Changes are requested for ETD
         change_workflow_status(ec_etd, "request_changes", approver)
 
-        ec_etd.reload
-
         visit("/concern/etds/#{ec_etd.id}")
 
         expect(find('.attribute-school').text).to eq 'Emory College'
@@ -52,12 +50,10 @@ RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :sy
         expect(find('.no-edit-school-name').text).to eq 'Emory College'
       end
 
-      scenario 'school does not change when etd is in approved status' do
+      scenario 'in approved status' do
         # ETD is approved
         change_workflow_status(ec_etd, "approve", approver)
 
-        ec_etd.reload
-
         visit("/concern/etds/#{ec_etd.id}")
 
         expect(find('.attribute-school').text).to eq 'Emory College'
@@ -68,12 +64,10 @@ RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :sy
         expect(find('.no-edit-school-name').text).to eq 'Emory College'
       end
 
-      scenario 'school does not change when etd is in published status' do
+      scenario 'in published status' do
         # ETD is published
         change_workflow_status(ec_etd, "publish", approver)
 
-        ec_etd.reload
-
         visit("/concern/etds/#{ec_etd.id}")
 
         expect(find('.attribute-school').text).to eq 'Emory College'
@@ -82,158 +76,6 @@ RSpec.feature 'Check for school', :clean, integration: true, js: true, type: :sy
 
         expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Emory College'
         expect(find('.no-edit-school-name').text).to eq 'Emory College'
-      end
-    end
-  end
-
-  describe 'verify school is Candler School of Theology' do
-    let(:default_attrs) do
-      { depositor: user.user_key,
-        title: ['This is another thesis'],
-        school: ['Candler School of Theology'],
-        department: ['Divinity'] }
-    end
-    let(:candler_etd) do
-      FactoryBot.build(:etd, default_attrs)
-    end
-
-    let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null") }
-
-    before do
-      workflow_setup.setup
-      candler_etd.assign_admin_set
-
-      # Create the ETD record
-      env = Hyrax::Actors::Environment.new(candler_etd, ::Ability.new(user), {})
-      middleware = Hyrax::DefaultMiddlewareStack.build_stack.build(Hyrax::Actors::Terminator.new)
-      middleware.create(env)
-
-      login_as approver
-    end
-
-    context 'when editing an etd' do
-      scenario 'school does not change when etd is in request_changes status' do
-        # Changes are requested for ETD
-        change_workflow_status(candler_etd, "request_changes", approver)
-
-        candler_etd.reload
-
-        visit("/concern/etds/#{candler_etd.id}")
-
-        expect(find('.attribute-school').text).to eq 'Candler School of Theology'
-
-        click_on("Edit")
-
-        expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Candler School of Theology'
-        expect(find('.no-edit-school-name').text).to eq 'Candler School of Theology'
-      end
-
-      scenario 'school does not change when etd is in approved status' do
-        # ETD is approved
-        change_workflow_status(candler_etd, "approve", approver)
-
-        candler_etd.reload
-
-        visit("/concern/etds/#{candler_etd.id}")
-
-        expect(find('.attribute-school').text).to eq 'Candler School of Theology'
-
-        click_on("Edit")
-
-        expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Candler School of Theology'
-        expect(find('.no-edit-school-name').text).to eq 'Candler School of Theology'
-      end
-
-      scenario 'school does not change when etd is in published status' do
-        # ETD is published
-        change_workflow_status(candler_etd, "publish", approver)
-
-        candler_etd.reload
-
-        visit("/concern/etds/#{candler_etd.id}")
-
-        expect(find('.attribute-school').text).to eq 'Candler School of Theology'
-
-        click_on("Edit")
-
-        expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Candler School of Theology'
-        expect(find('.no-edit-school-name').text).to eq 'Candler School of Theology'
-      end
-    end
-  end
-
-  describe 'verify school is Laney Graduate School' do
-    let(:default_attrs) do
-      { depositor: user.user_key,
-        title: ['This is one more thesis'],
-        school: ['Laney Graduate School'],
-        department: ['Anthropology'] }
-    end
-    let(:laney_etd) do
-      FactoryBot.build(:etd, default_attrs)
-    end
-
-    let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }
-
-    before do
-      workflow_setup.setup
-      laney_etd.assign_admin_set
-
-      # Create the ETD record
-      env = Hyrax::Actors::Environment.new(laney_etd, ::Ability.new(user), {})
-      middleware = Hyrax::DefaultMiddlewareStack.build_stack.build(Hyrax::Actors::Terminator.new)
-      middleware.create(env)
-
-      login_as approver
-    end
-
-    context 'when editing an etd' do
-      scenario 'school does not change when etd is in request_changes status' do
-        # Changes are requested for ETD
-        change_workflow_status(laney_etd, "request_changes", approver)
-
-        laney_etd.reload
-
-        visit("/concern/etds/#{laney_etd.id}")
-
-        expect(find('.attribute-school').text).to eq 'Laney Graduate School'
-
-        click_on("Edit")
-
-        expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Laney Graduate School'
-        expect(find('.no-edit-school-name').text).to eq 'Laney Graduate School'
-      end
-
-      scenario 'school does not change when etd is in approved status' do
-        # ETD is approved
-        change_workflow_status(laney_etd, "approve", approver)
-
-        laney_etd.reload
-
-        visit("/concern/etds/#{laney_etd.id}")
-
-        expect(find('.attribute-school').text).to eq 'Laney Graduate School'
-
-        click_on("Edit")
-
-        expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Laney Graduate School'
-        expect(find('.no-edit-school-name').text).to eq 'Laney Graduate School'
-      end
-
-      scenario 'school does not change when etd is in published status' do
-        # ETD is published
-        change_workflow_status(laney_etd, "publish", approver)
-
-        laney_etd.reload
-
-        visit("/concern/etds/#{laney_etd.id}")
-
-        expect(find('.attribute-school').text).to eq 'Laney Graduate School'
-
-        click_on("Edit")
-
-        expect(find(:css, 'input[name="etd[school]"]', visible: false, match: :first).value).to eq 'Laney Graduate School'
-        expect(find('.no-edit-school-name').text).to eq 'Laney Graduate School'
       end
     end
   end

--- a/spec/system/check_school_spec.rb
+++ b/spec/system/check_school_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.feature 'Selected school', :clean, integration: true, js: true, type: :system do
+RSpec.feature 'Selected school', integration: true, js: true, type: :system do
+  before :all do
+    ActiveFedora::Cleaner.clean!
+    WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null").setup
+  end
+
   let(:user) { create :user }
 
   let(:approver) { User.where(uid: "tezprox").first }
@@ -21,10 +26,7 @@ RSpec.feature 'Selected school', :clean, integration: true, js: true, type: :sys
       FactoryBot.build(:etd, default_attrs)
     end
 
-    let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
-
     before do
-      workflow_setup.setup
       ec_etd.assign_admin_set
 
       # Create the ETD record

--- a/spec/system/show_etd_spec.rb
+++ b/spec/system/show_etd_spec.rb
@@ -2,79 +2,47 @@
 require 'rails_helper'
 require 'workflow_setup'
 
-RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system do
-  let(:etd) do
-    FactoryBot.create(:sample_data_with_copyright_questions,
-                      partnering_agency: ["CDC"],
-                      school: ["Candler School of Theology"],
-                      embargo_length: "6 months",
-                      files_embargoed: false,
-                      toc_embargoed: nil,
-                      abstract_embargoed: '')
-  end
-
+RSpec.describe 'Display ETD metadata', integration: true, type: :system do
   let(:approving_user) { User.where(uid: "candleradmin").first }
 
-  # set up the creation of an approving user
-  let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null") }
+  # alias the etd created in the before :all group
+  let(:etd) { @etd }
 
-  # These are all the fields listed on our show wireframes
-  let(:required_fields) do
-    [
-      "title",
-      "creator",
-      "graduation_date",
-      "abstract",
-      "table_of_contents",
-      "school",
-      "department",
-      "degree",
-      "submitting_type",
-      "language",
-      "keyword",
-      "committee_chair_name",
-      "committee_members_names"
-    ]
-  end
+  # Only run expensive test setup once and use it for all tests since they only read data without making changes
+  before :all do
+    ActiveFedora::Cleaner.clean!
 
-  let(:primary_pdf_file) { "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf" }
-  let(:supplementary_file_one) { "#{::Rails.root}/spec/fixtures/miranda/rural_clinics.zip" }
-  let(:supplementary_file_two) { "#{::Rails.root}/spec/fixtures/miranda/image.tif" }
+    @etd = FactoryBot.create(:sample_data_with_copyright_questions,
+                        partnering_agency: ["CDC"],
+                        school: ["Candler School of Theology"],
+                        embargo_length: "6 months",
+                        files_embargoed: false,
+                        toc_embargoed: nil,
+                        abstract_embargoed: '')
+    primary_pdf_file = "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"
+    supplementary_file_two = "#{::Rails.root}/spec/fixtures/miranda/image.tif"
 
-  let(:uploaded_files) do
-    [Hyrax::UploadedFile.create(file: File.open(primary_pdf_file), pcdm_use: FileSet::PRIMARY)] +
-      secondary_files
-  end
+    uploaded_files = [Hyrax::UploadedFile.create(file: File.open(primary_pdf_file), pcdm_use: FileSet::PRIMARY),
+                      Hyrax::UploadedFile.create(file:        File.open(supplementary_file_two),
+                                  pcdm_use:    FileSet::SUPPLEMENTARY,
+                                  title:       "Photographer",
+                                  description: "a portrait of the artist",
+                                  file_type:   "Image")]
 
-  let(:secondary_files) do
-    [Hyrax::UploadedFile.create(file:        File.open(supplementary_file_one),
-                                pcdm_use:    FileSet::SUPPLEMENTARY,
-                                title:       "Rural Clinics in Georgia",
-                                description: "GIS shapefile showing rural clinics",
-                                file_type:   "Dataset"),
-     Hyrax::UploadedFile.create(file:        File.open(supplementary_file_two),
-                                pcdm_use:    FileSet::SUPPLEMENTARY,
-                                title:       "Photographer",
-                                description: "a portrait of the artist",
-                                file_type:   "Image")]
-  end
-
-  before do
-    # There is no fits installed on travis-ci
-    allow(CharacterizeJob).to receive(:perform_later)
-    # prepare db and create approving_user
-    w.setup
-    AttachFilesToWorkJob.perform_now(etd, uploaded_files)
+    AttachFilesToWorkJob.perform_now(@etd, uploaded_files)
   end
 
   scenario "Show all expected ETD fields" do
+    required_fields = ["title", "creator", "graduation_date", "abstract", "table_of_contents", "school",
+                       "department", "degree", "submitting_type", "language", "keyword",
+                       "committee_chair_name", "committee_members_names"]
+
     visit("/concern/etds/#{etd.id}")
     required_fields.each do |field|
       value = etd.send(field.to_sym).first
       expect(value).not_to eq nil
       expect(page).to have_content value
     end
-    expect(page).to have_content "Rural Clinics in Georgia (GIS shapefile showing rural clinics)"
     expect(page).to have_content "Photographer (a portrait of the artist)"
     expect(page).not_to have_content etd.partnering_agency.first # Partnering agency should only display for Rollins
 
@@ -87,7 +55,15 @@ RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system 
   end
 
   scenario 'logged in approver sees copyright info' do
-    login_as approving_user
+    # Build an EtdPresenter with workflow stubbed out
+    # that behaves as if an approver were logged in
+    # (in order to avoid the high setup cost of a full workflow)
+    doc = SolrDocument.find(etd.id)
+    approver = FactoryBot.create(:user)
+    presenter = EtdPresenter.new(doc, approver.ability)
+    allow(presenter).to receive(:current_ability_is_approver?).and_return true
+    allow(EtdPresenter).to receive(:new).and_return presenter
+
     visit("/concern/etds/#{etd.id}")
 
     # Copyright questions
@@ -103,7 +79,6 @@ RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system 
     expect(find('li.attribute-toc_embargoed')).to have_content false
     expect(find('li.attribute-abstract_embargoed')).to have_content false
     expect(page).to have_css('.attribute-embargo_length', text: '6 months')
-    logout
   end
 
   scenario "Etds show permission badges but FileSets don't" do
@@ -118,22 +93,13 @@ RSpec.describe 'Display ETD metadata', :clean, integration: true, type: :system 
     expect(page).not_to have_content("Open Access")
   end
 
-  scenario "Render PDF file as primary PDF" do
+  scenario "Render attached files" do
     visit("/concern/etds/#{etd.id}")
 
     # The primary pdf gets its name changed to the title of the ETD. This test relies on the html structure that the first link in a td.filename is the pdf's title.
     # The Primary pdf fileset table of links appears above the supplemental files table of linked fileset information.
 
     expect(find("td.attribute.filename a", match: :first)).to have_content etd.title.first.to_s
-  end
-
-  context 'with no primary files' do
-    let(:uploaded_files) { secondary_files }
-
-    scenario 'Render supplementary files' do
-      visit("/concern/etds/#{etd.id}")
-      expect(page).to have_content "Rural Clinics in Georgia (GIS shapefile showing rural clinics)"
-      expect(page).to have_content "Photographer (a portrait of the artist)"
-    end
+    expect(page).to have_content "Photographer (a portrait of the artist)"
   end
 end

--- a/spec/system/virus_workflow_etd_spec.rb
+++ b/spec/system/virus_workflow_etd_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe 'Virus checking', :perform_jobs, :clean, :js, integration: true, 
   context 'a logged in user' do
     before do
       allow(CharacterizeJob).to receive(:perform_later) # There is no fits installed on travis-ci
-      class_double("Clamby").as_stubbed_const
-      allow(Clamby).to receive(:virus?).and_return(true)
+      allow(TestVirusScanner).to receive(:infected?).and_return(true)
       w.setup
 
       attributes_for_actor = { uploaded_files: [upload1.id] }
@@ -27,7 +26,7 @@ RSpec.describe 'Virus checking', :perform_jobs, :clean, :js, integration: true, 
       middleware.create(env)
     end
 
-    scenario "supplemental file with virus" do
+    scenario "primary PDF file with virus" do
       # Check the ETD was assigned the right workflow
       expect(etd.active_workflow.name).to eq "emory_one_step_approval"
       expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_approval"
@@ -45,7 +44,7 @@ RSpec.describe 'Virus checking', :perform_jobs, :clean, :js, integration: true, 
       expect(page).to have_content "Virus encountered"
 
       visit("/concern/etds/#{etd.id}")
-      # expect(page).to have_content "Virus detected. File deleted."
+      expect(page).to have_content "Primary PDF\nEmpty"
     end
   end
 end


### PR DESCRIPTION
* Removes unused test setup
* Removes some redundant tests which don't test alternate code paths
* Refactors workflow tests to setup to run slow setup code once per spec file instead of once per test
* Stubs virus scanner at a higher level for better performance
* Adds a test to exercise virus scanner API for hydra-works