### PR TITLE
Handle CSV uploads from Windows systems

### DIFF
--- a/app/services/graduation_service.rb
+++ b/app/services/graduation_service.rb
@@ -50,7 +50,7 @@ class GraduationService
   def parse_registrar_file
     grad_records = @registrar_feed.graduation_records
     case grad_records.content_type
-    when 'text/csv'
+    when 'text/csv', 'application/vnd.ms-excel'
       registrar_csv = CSV.parse(grad_records.download, headers: true, header_converters: DOWNCASE_CONVERTER)
       registrar_csv.map { |row| [row['etd record key'], row.to_hash] }.to_h
     when 'application/json'


### PR DESCRIPTION
Some Microsoft Windows systems may upload CSV files with a mime type of 'application/vnd.ms-excel' instead of 'text/csv'.

This change allows the GraduationService to process files with the microsoft mime-type as a csv.  File upload is still restricted to CSV by the accept filter on the upload form, and other sanity checks in the GraduationService will flag if the uploaded file does not appear to contain valid CSV data.

For more detail on the mime-type issue see
https://christianwood.net/posts/csv-file-upload-validation/