### PR TITLE
Update circleci/browser-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ jobs:
         parallelism: 4
         steps:
             - checkout
-            - browser-tools/install-chrome
+            - browser-tools/install-chrome:
+                chrome-version: 114.0.5735.198
             - browser-tools/install-chromedriver
 
             - samvera/bundle:


### PR DESCRIPTION
ISSUE
The chromedriver install is failing on current CI runs. This is due to a change in the download path for newer versions of ChromeDriver.

TEMPORARY FIX
Pin chrome to a version before the download path change.

BACKGROUND
Google Announcement: https://groups.google.com/g/chromedriver-users/c/clpipqvOGjE/m/5NxzS_SRAgAJ CircleCI Issue: CircleCI-Public/browser-tools-orb#75