### PR TITLE
Update for compatibility with Google Analytics 4

### DIFF
--- a/app/views/_ga.html.erb
+++ b/app/views/_ga.html.erb
@@ -1,0 +1,14 @@
+<%
+  if Hyrax.config.google_analytics_id?
+    tracking_id = Hyrax.config.google_analytics_id
+%>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= tracking_id %>"></script>
+  <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '<%= tracking_id %>');
+  </script>
+<% end %>


### PR DESCRIPTION
ISSUE
The Google Analytics script in Laevigata is provided via a view partial from Hyrax.  Currently the Hyrax 2.x series only supports Google Analytics 3 which is end-of-life.

FIX
Implement a local copy of the relevant partial with the necessary code to support GA4.

See Hyrax original:
https://github.com/samvera/hyrax/blob/v2.9.6/app/views/_ga.html.erb