### PR TITLE
Fix embargo bug that is causing graduated ETDs to dispaly as embargoed

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -159,6 +159,6 @@ class SolrDocument
   end
 
   def under_embargo?
-    embargo_release_date.present?
+    embargo_release_date.present? && embargo_release_date > Time.current
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -81,6 +81,27 @@ RSpec.describe ::SolrDocument, type: :model do
       end
     end
 
+    describe '#under_embargo?' do
+      context 'with no embargo' do
+        let(:etd) { FactoryBot.build(:etd, embargo_release_date: nil) }
+        it 'returns false' do
+          expect(solr_doc.under_embargo?).to be false
+        end
+      end
+      context 'with a release date in the past' do
+        let(:etd) { FactoryBot.build(:etd, embargo_release_date: 1.month.ago) }
+        it 'returns false' do
+          expect(solr_doc.under_embargo?).to be false
+        end
+      end
+      context 'with a future release date' do
+        let(:etd) { FactoryBot.build(:etd, embargo_release_date: 1.month.from_now) }
+        it 'returns true' do
+          expect(solr_doc.under_embargo?).to be true
+        end
+      end
+    end
+
     context 'when under embargo' do
       subject(:etd) do
         FactoryBot.build(:tomorrow_expiration,


### PR DESCRIPTION
Scholarly Communication staff have noticed a number of ETDs that have attached PDFs that are appearing as embargoed despite the contributors having graduated and the ETDs having been published.

**ANALYSIS**
We have been able to track this down to a bug in how ETD SolrDocuments compute the #under_embargo method.  The SolrDocument method just looks for any value while the same method name on an actual ETD checks for a date value and compares it against the current date.

At one time, embargos were either deleted rather than being deactivated -OR-
The indexing service behaved differently in relation to the embargo_release_date field (i.e. it was smart enough to not index it on ETDs with deactivated embargos)

In either case, a regression occurred either in Hyrax or Laevigata at some point that changed the behavior to index embargo_release_date on SolrDocuments even when the embargo had expired or been deactivated.

**RESOLUTION**
Update the SolrDocument #under_embargo method to check against the current date to match the behavior for ETD objects.

**BUG EXAMPLE**
```
irb(main):039:0> etd = Etd.find('rr171z58q')
=> #<Etd id: "rr171z58q", head: [#<ActiveTriples::Resource:0x788c0 ID:<http://127.0.0.1:8080/fedora/rest/prod/rr/17/1z/58/rr1...
irb(main):040:0> solr_doc = SolrDocument.find('rr171z58q')
Solr query: get select {:qt=>"document", :id=>"rr171z58q"}
Solr fetch (4.4ms)
=> #<SolrDocument:0x000055cabe2eefd0 @_source={"system_create_dtsi"=>"2022-05-02T15:28:40Z", "system_modified_dtsi"=>"2023-07...
irb(main):041:0> etd.under_embargo?
=> false
irb(main):042:0> solr_doc.under_embargo?
=> true
```

**RELEVANT CODE**
Hydra::AccessControls
https://github.com/samvera/hydra-head/blob/v11.0.7/hydra-access-controls/app/models/concerns/hydra/access_controls/embargoable.rb#L51-L53 https://github.com/samvera/hydra-head/blob/v11.0.7/hydra-access-controls/app/models/hydra/access_controls/embargo.rb#L13C14-L13C14 Laevigata
does not do a current date check
https://github.com/curationexperts/laevigata/blob/v12.23.1/app/models/solr_document.rb#L161-L163