### PR TITLE
Fix bug for embargos not set to midnight GMT

### DIFF
--- a/lib/tasks/embargo_notifications.rake
+++ b/lib/tasks/embargo_notifications.rake
@@ -1,7 +1,6 @@
 namespace :emory do
   desc "Remove expired embargoes and send notifications. Pass date YYYY-MM-DD. Defaults to today."
   task :embargo_expiration, [:date] => [:environment] do |_t, args|
-    Rails.logger.warn "Running EmbargoExpirationService"
     EmbargoExpirationService.run(args[:date])
   end
 end


### PR DESCRIPTION
**ISSUE**
The EmbargoExpriationService has not been processing some expired embargoes because their expiration time is set to midnight Eastern time instead of mignight UTC.

A regression entered the application when we began including time zone information (Eastern) on graduation dates.  This regression occurred in April 2022, but we did not see it immediately because the impacted embargoes were not set to expire for 6 to 12 months.

**FIX**
Update the EmbargoExpirationService to query for embargoes that expire at any time on the requested date (interpreted in UTC) rather than just at midnight.