### PR TITLE
Migrates SCO's links

### DIFF
--- a/app/assets/stylesheets/emory/_homepage.scss
+++ b/app/assets/stylesheets/emory/_homepage.scss
@@ -22,6 +22,6 @@
   }
 }
 
-.sumbit-my-etd {
+.submit-my-etd {
   margin: 2em;
 }

--- a/app/javascript/Files.vue
+++ b/app/javascript/Files.vue
@@ -113,7 +113,7 @@
         </tbody>
       </table>
     </div>
-    <div class="alert alert-info"><span class="glyphicon glyphicon-info-sign"></span> Please contact <a href="http://sco.library.emory.edu/etds/help-form.html">Emory’s Scholarly Communications Office</a> if you have a supplemental file over 100 MB for assistance with uploading your file(s).</div>
+    <div class="alert alert-info"><span class="glyphicon glyphicon-info-sign"></span> Please contact <a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/help-form">Emory’s Scholarly Communications Office</a> if you have a supplemental file over 100 MB for assistance with uploading your file(s).</div>
     <div v-if="sharedState.preventBoxSupplementalUpload" class="alert alert-warning" id="box-warning"><span class="glyphicon glyphicon-warning-sign"></span> Save and Continue before uploading any (more) files from Box.</div>
     <div class="form-inline">
       <input class="input-file btn-primary" id="add-supplemental-file" name="supplemental_files[]" type="file" ref="fileInput" @change="onSupplementalFileChange"/>

--- a/app/services/hyrax/workflow/seven_day_embargo_notification.rb
+++ b/app/services/hyrax/workflow/seven_day_embargo_notification.rb
@@ -4,6 +4,7 @@ module Hyrax
     # Should notify work depositor only
     class SevenDayEmbargoNotification
       include EmbargoNotificationBehavior
+      CONTACT_LINK = 'https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact'.freeze
 
       def subject
         "Embargo on #{title} will expire in seven days"
@@ -16,7 +17,7 @@ module Hyrax
         Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url}
 
         If you need your record to remain restricted/embargoed, please contact your school administrators
-        located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n
+        located here: #{link_to CONTACT_LINK, CONTACT_LINK} with your request. \n\n
         Please do not reply directly to this email.
 
         FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:

--- a/app/services/hyrax/workflow/sixty_day_embargo_notification.rb
+++ b/app/services/hyrax/workflow/sixty_day_embargo_notification.rb
@@ -4,6 +4,7 @@ module Hyrax
     # Should notify work depositor only
     class SixtyDayEmbargoNotification
       include EmbargoNotificationBehavior
+      CONTACT_LINK = 'https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact'.freeze
 
       def subject
         "Embargo on #{title} will expire in sixty days"
@@ -16,7 +17,7 @@ module Hyrax
         Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url}
 
         If you need your record to remain restricted/embargoed, please contact your school administrators
-        located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request. \n\n
+        located here: #{link_to CONTACT_LINK, CONTACT_LINK} with your request. \n\n
         Please do not reply directly to this email.
 
         FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:

--- a/app/services/hyrax/workflow/today_embargo_notification.rb
+++ b/app/services/hyrax/workflow/today_embargo_notification.rb
@@ -5,6 +5,7 @@ module Hyrax
     # Should notify work depositor only.
     class TodayEmbargoNotification
       include EmbargoNotificationBehavior
+      CONTACT_LINK = 'https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact'.freeze
 
       def subject
         "Embargo on #{title} expires today"
@@ -20,7 +21,7 @@ module Hyrax
         Your dissertation or thesis can be accessed in the Emory University ETD Repository at: #{link_to document_url, document_url}
 
         If you need your record to remain restricted/embargoed, please contact your school administrators
-        located here: #{link_to 'http://sco.library.emory.edu/etds/contact.html', 'http://sco.library.emory.edu/etds/contact.html'} with your request.
+        located here: #{link_to CONTACT_LINK, CONTACT_LINK} with your request. \n\n
         Please do not reply directly to this email.
 
         FOR AUTHORS WHO ALSO SUBMITTED TO PROQUEST:

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -2,35 +2,31 @@
   <h2>Emory Theses and Dissertations</h2>
   <p>The Emory Theses and Dissertations (ETD) Repository holds theses and dissertations from the Laney Graduate School, the Rollins School of Public Health, and the Candler School of Theology, as well as undergraduate honors papers from Emory College of Arts and Sciences.</p>
   <p>Emory University theses and dissertations submitted before the launch of the ETD repository can be found by searching the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>. The theses and dissertations of the Wallace H. Coulter Department of Biomedical Engineering, a joint degree program by Emory University and Georgia Tech, are available in <a href="https://smartech.gatech.edu/">SMARTech</a>, Georgia Tech’s repository, and in the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>.</p>
-  <div class="sumbit-my-etd">
+  <div class="submit-my-etd">
     <%= render 'submit_my_etd' %>
   </div>
   <hr>
   <div class="news-and-announcements">
   <h2>News & Announcements</h2>
   <h3>ETD Copyright Workshops</h3>
-Visit the Woodruff Library's <a href="http://sco.library.emory.edu/about/workshops.html">class calendar</a> for upcoming ETD copyright workshops for your thesis/dissertation.
-
-<h3>Submission Forms For All Participants</h3>
-All students depositing their thesis or dissertation must complete the ETD Submission form:
-<ul class="submission-forms">
-  <li>
-    <a href="http://sco.library.emory.edu/etd-static/docs/Laney_ETD_Submission_Form.pdf">Laney Graduate School submission form</a>
-  </li>
-  <li>
-    <a href="http://sco.library.emory.edu/etd-static/docs/Honors_ETD_Submission_Form.pdf">College Honors Program submission form</a>
-  </li>
-  <li>
-    <a href="http://sco.library.emory.edu/etd-static/docs/Candler_ETD_Submission_Form.pdf">Candler School of Theology submission form</a>
-  </li>
-  <li>
-    <a href="http://sco.library.emory.edu/etd-static/docs/Rollins_ETD_Submission_Form.pdf">Rollins School of Public Health submission form</a>
-  </li>
-  <li>
-    <a href="http://sco.library.emory.edu/etd-static/docs/Nursing_ETD_Submission_Form.pdf">Nell Hodgson Woodruff School of Nursing submission form</a>
-  </li>
-</ul>
-This form WHICH REQUIRES THE SIGNATURE OF YOUR ADVISOR gives the library permission to publish your thesis or dissertation on the web; confirms access restrictions -- if any; and certifies that you have secured rights to all content that you will be publishing.
+  <p>Visit the Emory Libraries' Scholarly Communications <a href="https://libraries.emory.edu/services/scholarly-communications/workshops">workshop page</a> for upcoming and recorded ETD copyright workshops for your thesis or dissertation.</p>
+  <h3>Submission Forms For All Participants</h3>
+  <p>All students depositing their thesis or dissertation must complete the ETD Submission form:</p>
+  <ul class="submission-forms">
+    <li>
+      <a target:"_blank" href="https://libraries.emory.edu/media/11036">College Honors Program submission form</a>
+    </li>
+    <li>
+      <a target:"_blank" href="https://libraries.emory.edu/media/11041">Candler School of Theology submission form</a>
+    </li>
+    <li>
+      <a target:"_blank" href="https://libraries.emory.edu/media/11046">Rollins School of Public Health submission form</a>
+    </li>
+    <li>
+      <a target:"_blank" href="https://libraries.emory.edu/media/11051">Nell Hodgson Woodruff School of Nursing submission form</a>
+    </li>
+  </ul>
+  <p>This form WHICH REQUIRES THE SIGNATURE OF YOUR ADVISOR gives the library permission to publish your thesis or dissertation on the web; confirms access restrictions -- if any; and certifies that you have secured rights to all content that you will be publishing.</p>
   </div>
 </div><!-- /.col-xs-6 -->
 

--- a/app/views/hyrax/homepage/_submit_my_etd.html.erb
+++ b/app/views/hyrax/homepage/_submit_my_etd.html.erb
@@ -1,6 +1,6 @@
 <div class="home_share_work row">
   <div class="col-sm-12 text-center">
-    <a href="http://sco.library.emory.edu/etds/faq.html" class="btn btn-primary">
+    <a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/submissions" class="btn btn-primary">
       <i class="glyphicon glyphicon-film"></i> Submission Instructions
     </a>
   </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,17 +3,17 @@
     <div class="navbar">
       <div class="container center">
       <ul class="nav">
-            <li class="navbar-text"><a href="http://sco.library.emory.edu/etds/faq.html">Frequently Asked Questions</a></li>
-      <li class="navbar-text"><a href="http://sco.library.emory.edu/etds/contact.html">Contact Us</a></li>
-      <li class="navbar-text"><%= link_to 'ETD Help', hyrax.contact_form_index_path %></li>
-      <li class="navbar-text"><a href=" http://sco.library.emory.edu/etds/intellectual-property.html">Copyright & Patents</a></li>
-      <li class="navbar-text"><a href="http://sco.library.emory.edu/etds/policies.html">Policies & Procedures</a></li>
-      <li class="navbar-text"><a href="http://sco.library.emory.edu/etds/embargo.html">Access Restrictions</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/faq">Frequently Asked Questions</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact">Contact Us</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/help-form">ETD Help</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/copyright-patents">Copyright & Patents</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/policies-procedures">Policies & Procedures</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/access-restrictions">Access Restrictions</a></li>
       <li class="navbar-text"><a href="http://www.graduateschool.emory.edu/">Laney Graduate School</a></li>
       <li class="navbar-text"><a href="https://www.sph.emory.edu/">Rollins School of Public Health</a></li>
       <li class="navbar-text"><a href="http://candler.emory.edu/index.html">Candler School of Theology</a></li>
       <li class="navbar-text"><a href="http://college.emory.edu/main/index.html">Emory College</a></li>
-      <li class="navbar-text"><a href="http://www.emory.edu/home/academics/libraries/index.html">Emory Libraries</a></li>
+      <li class="navbar-text"><a href="https://libraries.emory.edu/">Emory Libraries</a></li>
       <li class="navbar-text">© <%=Time.now.year%> Emory University. Version <span title="<%= GitShaPresenter.sha %>"><%= GitShaPresenter.branch %> updated <%= GitShaPresenter.last_deployed %></span>.</li>
       </ul>
       </div>

--- a/spec/services/hyrax/workflow/seven_day_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/seven_day_embargo_notification_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Hyrax::Workflow::SevenDayEmbargoNotification, :clean do
   let(:user) { FactoryBot.create(:user) }
   let(:etd) { FactoryBot.create(:etd, depositor: user.user_key, post_graduation_email: ["post@graduation.email"]) }
   let(:notification) { described_class.new(etd.id) }
+  let(:contact) { "https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact" }
   context "notifications" do
     it "sends notifications to the post-graduation email address" do
       expect(notification.recipients.pluck(:email)).to include(etd.post_graduation_email.first)
@@ -22,6 +23,9 @@ RSpec.describe Hyrax::Workflow::SevenDayEmbargoNotification, :clean do
       expect(notification.message).to match(/Dear #{user.display_name}/)
       expect(notification.message).to match(/#{etd.title.first}/)
       expect(notification.message).to match(/proquest.com/)
+    end
+    it "links to the contact page" do
+      expect(notification.message).to match(/#{contact}/)
     end
   end
 end

--- a/spec/services/hyrax/workflow/sixty_day_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/sixty_day_embargo_notification_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Hyrax::Workflow::SixtyDayEmbargoNotification, :clean do
   let(:admin) { FactoryBot.create(:admin) }
   let(:etd) { FactoryBot.create(:etd, depositor: user.user_key, post_graduation_email: ["post@graduation.email"]) }
   let(:notification) { described_class.new(etd.id) }
+  let(:contact) { "https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact" }
   context "notifications" do
     it "sends notifications to the post-graduation email address" do
       expect(notification.recipients.pluck(:email)).to include(etd.post_graduation_email.first)
@@ -27,6 +28,9 @@ RSpec.describe Hyrax::Workflow::SixtyDayEmbargoNotification, :clean do
       expect(notification.message).to match(/Dear #{user.display_name}/)
       expect(notification.message).to match(/#{etd.title.first}/)
       expect(notification.message).to match(/proquest.com/)
+    end
+    it "links to the contact page" do
+      expect(notification.message).to match(/#{contact}/)
     end
   end
 end

--- a/spec/services/hyrax/workflow/today_embargo_notification_spec.rb
+++ b/spec/services/hyrax/workflow/today_embargo_notification_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Hyrax::Workflow::TodayEmbargoNotification, :clean do
   let(:user) { FactoryBot.create(:user) }
   let(:etd) { FactoryBot.create(:etd, depositor: user.user_key, post_graduation_email: ["post@graduation.email"]) }
   let(:notification) { described_class.new(etd.id) }
+  let(:contact) { "https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/contact" }
   context "notifications" do
     it "sends notifications to the post-graduation email address" do
       expect(notification.recipients.pluck(:email)).to include(etd.post_graduation_email.first)
@@ -22,6 +23,9 @@ RSpec.describe Hyrax::Workflow::TodayEmbargoNotification, :clean do
       expect(notification.message).to match(/Dear #{user.display_name}/)
       expect(notification.message).to match(/#{etd.title.first}/)
       expect(notification.message).to match(/proquest.com/)
+    end
+    it "links to the contact page" do
+      expect(notification.message).to match(/#{contact}/)
     end
   end
 end


### PR DESCRIPTION
SCO has recently rebuilt their web presence into the Libraries' new Drupal website. this PR moves their links over to the new site.