### PR TITLE
Output semantic metadata to logs in JSON format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'omniauth-shibboleth', '~> 1.3'
 gem 'pg', '~> 1.0'
 gem 'rack', '>= 2.1.4'
 gem 'rails', '~> 5.2'
+# Support semantic logs in JSON format [https://logger.rocketjob.io/rails.html]
+gem 'rails_semantic_logger'
 gem 'rsolr', '~> 1.0'
 gem 'rubyzip'
 gem 'sanitize', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,6 +727,10 @@ GEM
       loofah (~> 2.19, >= 2.19.1)
     rails_autolink (1.1.6)
       rails (> 3.1)
+    rails_semantic_logger (4.14.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (5.2.8.1)
       actionpack (= 5.2.8.1)
       activesupport (= 5.2.8.1)
@@ -902,6 +906,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     shex (0.6.3)
       ebnf (~> 2.1, >= 2.2)
       htmlentities (~> 4.3)
@@ -1092,6 +1098,7 @@ DEPENDENCIES
   rack (>= 2.1.4)
   rails (~> 5.2)
   rails-controller-testing
+  rails_semantic_logger
   rsolr (~> 1.0)
   rspec (~> 3.5)
   rspec-activemodel-mocks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,4 +40,11 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError do |exception|
     render plain: '404 Not found', status: 404
   end
+
+  private
+
+  def append_info_to_payload(payload)
+    super
+    payload[:request_id] = request.request_id
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,5 @@
 class ApplicationJob < ActiveJob::Base
+  def perform_now
+    SemanticLogger.tagged(job_class: self.class, job_id: job_id) { super }
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,10 @@ module Laevigata
     config.middleware.use(::ExceptionMiddleware)
     config.autoload_paths += %W[#{config.root}/lib]
 
+    # Output logs in JSON format
+    config.rails_semantic_logger.format = :json
+    config.semantic_logger.application = Rails.version < '6' ? Rails.application.class.parent.name : Rails.application.class.module_parent_name
+
     # Allow psych to serialize additional classes - see https://stackoverflow.com/a/72970171
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
 


### PR DESCRIPTION
In order to easily leaverage search and filtering capabilities in log aggregation and analysis tools like AWS CloudWatch logs, we want to send our logs in an easily parsable format.

We've chosen [Semantic Logger](https://logger.rocketjob.io/index.html) because it provides an easy drop-in replacement for the default Rails logger. Semantic Logger doesn't require us to change any of our existing logging code and makes it simple to output logs in JSON format.