### PR TITLE
[FIX] Graduation dates are reset when editing ETDs

### DIFF
--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -172,6 +172,7 @@ class InProgressEtd < ApplicationRecord
     new_data['patents'] = etd.patents
     new_data['requires_permissions'] = etd.requires_permissions
     new_data['partnering_agency'] = etd.partnering_agency
+    new_data['graduation_date'] = etd.graduation_date
 
     em_type = EmbargoTypeFromAttributes.new(etd.files_embargoed, etd.toc_embargoed, etd.abstract_embargoed)
     new_data['embargo_type'] = em_type.s

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -688,6 +688,7 @@ describe InProgressEtd do
 
       let(:new_data) do
         { 'title' => ['New ETD Title'],
+          'graduation_date' => 'Spring 2021', # Value should be present and not active in config/authorities/graduation_dates.yml
           'degree_awarded' => '2018-08-23',
           'embargo_length' => '1000 years',
           'keyword' => ['new keyword'],
@@ -714,6 +715,7 @@ describe InProgressEtd do
         # Test for affiliation_type, which we need for the form
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Non-Emory/)
         expect(refreshed_data['title']).to eq new_data['title'][0]
+        expect(refreshed_data['graduation_date']).to eq 'Spring 2021'
         expect(refreshed_data['ipe_id']).to eq ipe.id
         expect(refreshed_data['etd_id']).to eq etd.id
       end

--- a/spec/system/edit_etd_spec.rb
+++ b/spec/system/edit_etd_spec.rb
@@ -12,7 +12,14 @@ RSpec.feature 'Edit an existing ETD',
   let(:approving_user) { User.where(uid: "laneyadmin").first }
   let(:file) { FactoryBot.create(:primary_uploaded_file, user_id: depositing_user.id) }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/rollins_subset_admin_sets.yml", "/dev/null") }
-  let(:etd) { FactoryBot.create(:sample_data, school: ["Rollins School of Public Health"], department: ["Biostatistics"], subfield: ["Biostatistics"], depositor: depositing_user.user_key) }
+  let(:etd) {
+    FactoryBot.create(:sample_data,
+                                school: ["Rollins School of Public Health"],
+                                department: ["Biostatistics"],
+                                subfield: ["Biostatistics"],
+                                depositor: depositing_user.user_key,
+                                graduation_date: 'Spring 2021')
+  }
   let(:admin_superuser) { User.where(uid: "tezprox").first } # uid from superuser.yml
 
   context 'an admin user' do
@@ -33,6 +40,7 @@ RSpec.feature 'Edit an existing ETD',
       expect(page).to have_content "Biostatistics and Bioinformatics"
       expect(page).to have_content etd.degree.first
       expect(page).to have_content "Biostatistics - MPH & MSPH"
+      expect(page).to have_select('graduation-date', selected: 'Spring 2021')
       click_on "Submit Your Thesis or Dissertation"
       expect(page).to have_content "Biostatistics and Bioinformatics"
       expect(page).to have_content etd.degree.first


### PR DESCRIPTION
**ISSUE**
When a previously saved ETD is edited, the system would reset the graduation date to the current semester, regardless of the originally submitted value.

**DIAGNOSIS**
A bug in the code that reloaded the ETD data only loaded the first letter of the field. Because this value didn't match any of the values in the graduation date config file, the form replaced the unknown value with the current default.

**RESOLUTION**
Fix the bug in the code that reloads saved ETD data into the form, so that the existing value is preserved and displayed in the edit form.