### PR TITLE
[REFACTOR] Set coverage reporting default to off

### DIFF
--- a/dotenv.sample
+++ b/dotenv.sample
@@ -14,9 +14,6 @@ export FAKE_DATA=true
 # Use local database auth instead of Shibboleth
 export LAEVIGATA_DATABASE_AUTH=true
 
-# Turn off coveralls during specs
-export NO_COVERAGE=true
-
 # For hyrax config
 
 UPLOAD_PATH=tmp/uploads

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-unless ENV['NO_COVERAGE'] == 'true'
+if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   require 'simplecov-lcov'
   SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true


### PR DESCRIPTION
**ISSUE**
Rather than having to always set an environment variable to disable coverage if we don't want it; change the configuration so that coverage reporting is only generated during the test suite when it is explicitly requested, e.g.

```
COVERAGE=true bundle exec rspec
```

Otherwise, run the test suite without generating a coverage report.