### PR TITLE
[MAINT] Make test profiling optional

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
The current spec helper had a default for profiling. Removing this line stops RSpec from profiling tests by default. If you want to profile all or part of the test suite, you can use the command line option:
```
bundle exec rspec --profile
```