### PR TITLE
[FIX] Submission and Edit forms displaying inactive degree values

### DIFF
--- a/app/javascript/Degree.vue
+++ b/app/javascript/Degree.vue
@@ -2,7 +2,12 @@
     <div>
         <label for="degree">Degree</label>
         <select id="degree" name="etd[degree]" class="form-control" aria-required="true" v-on:change="sharedState.setValid('My Program', false)">
-            <option v-for="degree in degrees" v-bind:value="degree.id" v-bind:key='degree.id' :selected='degree.selected' :disabled='degree.disabled'>
+            <option v-for="degree in degrees"
+                    v-bind:value="degree.id"
+                    v-bind:key='degree.id'
+                    v-if="degree.active"
+                    :selected='degree.selected'
+                    :disabled='degree.disabled'>
                 {{ degree.label }}
             </option>
         </select>

--- a/app/javascript/SubmittingType.vue
+++ b/app/javascript/SubmittingType.vue
@@ -2,9 +2,12 @@
     <div>
         <label for="submitting-type">Submission Type</label>
         <select id="submitting-type" name="etd[submitting_type]" aria-required="true" class="form-control" v-on:change="sharedState.setValid('My Program', false)">
-            <option v-for="submittingType in submittingTypes" v-bind:value="submittingType.id"
-            v-bind:key='submittingType.id' v-if="submittingType.active" :disabled="submittingType.disabled"
-            :selected="submittingType.selected">
+            <option v-for="submittingType in submittingTypes"
+                    v-bind:value="submittingType.id"
+                    v-bind:key='submittingType.id'
+                    v-if="submittingType.active"
+                    :disabled="submittingType.disabled"
+                    :selected="submittingType.selected">
                 {{ submittingType.label }}
             </option>
         </select>

--- a/app/javascript/test/Degree.spec.js
+++ b/app/javascript/test/Degree.spec.js
@@ -10,7 +10,7 @@ import axios from 'axios'
 jest.mock('axios')
 
 describe('Degree.vue', () => {
-  const resp = {data: [{'id': 'Th.D.', 'label': 'Th.D.', 'active': true}]}
+  const resp = {data: [{'id': 'Th.D.', 'label': 'Th.D.', 'active': true}, {'id': 'Inactive', 'label': 'legacy option', 'active': false}]}
   axios.get.mockResolvedValue(resp)
 
   it('renders a select element', () => {

--- a/app/javascript/test/SubmittingType.spec.js
+++ b/app/javascript/test/SubmittingType.spec.js
@@ -8,7 +8,7 @@ import axios from 'axios'
 jest.mock('axios')
 
 describe('SubmittingType.vue', () => {
-  const resp = {data: [{'id': 'Honors Thesis', 'label': 'Honors Thesis', 'active': true}]}
+  const resp = {data: [{'id': 'Honors Thesis', 'label': 'Honors Thesis', 'active': true}, {'id': 'Inactive', 'label': 'legacy option', 'active': false}]}
   axios.get.mockResolvedValue(resp)
 
   it('renders a select element', () => {


### PR DESCRIPTION
**ISSUE**
Submission and edit forms were displaying inactive degree options.

**RESOLUTION**
Add filter to degree list to only include active degree options.