### PR TITLE
Update department labels

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,7 +43,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_facet_field solr_name("graduation_date", :facetable), label: "Year", limit: 5
     config.add_facet_field solr_name("school", :facetable), label: "School", limit: 5
-    config.add_facet_field solr_name("department", :facetable), label: "Department", limit: 5
+    config.add_facet_field solr_name("department", :facetable), label: "Department / Specialty", limit: 5
     config.add_facet_field solr_name("degree", :facetable), label: "Degree", limit: 5
     config.add_facet_field solr_name("submitting_type", :facetable), label: "Submission Type", limit: 5
     config.add_facet_field solr_name("research_field", :facetable), label: "Research Field", limit: 5
@@ -66,7 +66,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("creator", :stored_searchable), label: "Student Name", itemprop: 'creator'
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field solr_name("research_field", :stored_searchable), label: "Research Field"
-    config.add_index_field solr_name("department", :stored_searchable), label: "Department", link_to_search: solr_name("department", :facetable)
+    config.add_index_field solr_name("department", :stored_searchable), label: "Department or Specialty", link_to_search: solr_name("department", :facetable)
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -78,7 +78,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("date_uploaded", :stored_searchable), label: "Date Uploaded"
     config.add_show_field solr_name("date_modified", :stored_searchable), label: "Date Modified"
     config.add_show_field solr_name("degree", :stored_searchable), label: "Degree"
-    config.add_show_field solr_name("department", :stored_searchable), label: "Department"
+    config.add_show_field solr_name("department", :stored_searchable), label: "Department or Specialty"
     config.add_show_field solr_name("school", :stored_searchable), label: "School"
     config.add_show_field solr_name("subfield", :stored_searchable), label: "Sub Field"
     config.add_show_field solr_name("partnering_agency", :stored_searchable), label: "Partnering Agency"

--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="sharedState.allowTabSave()">
     <!-- TODO: adding v-model='selected' enables the selected value to appear in the case of an ipe_etd, but it will not without it, with a hyrax etd. But we should refactor for a better solution. -->
-    <label for="department">Department</label>
+    <label for="department"> {{ sharedState.getDepartmentHeading() }} </label>
     <select
       name="etd[department]"
       class="form-control"
@@ -53,7 +53,6 @@ export default {
       sharedState: formStore
     };
   },
-
   watch: {
     selected() {
       this.sharedState.getSavedOrSelectedDepartment();

--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <h4>My Program</h4>
-    <h5>Department</h5>
+    <h5>{{ sharedState.getDepartmentHeading() }}</h5>
     <div> {{ sharedState.getDepartmentLabelFromId(sharedState.getSavedOrSelectedDepartment()) }} </div>
     <div v-if="sharedState.getSavedOrSelectedSubfield() && sharedState.getSavedOrSelectedSubfield().length > 0">
           <h5>Subfield</h5>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -401,6 +401,16 @@ export const formStore = {
       return this.departments.filter((department) => { return department.id === id })[0].label
     }
   },
+
+  getDepartmentHeading () {
+    // The nursing school uses "Specialty" instead of "Department"
+    if ( this.savedData['school']=='Nell Hodgson Woodruff School of Nursing') {
+      return 'Specialty'
+    } else {
+      return 'Department'
+    }
+  },
+
   getSavedOrSelectedSubfield () {
     if (this.selectedSubfield === undefined) {
       this.selectedSubfield = ''

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -87,6 +87,12 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     solr_document.submitting_type.first
   end
 
+  # School-dependent label for departments
+  # @return 'Department' unless school==nursing, which uses 'Specialty' instead
+  def department_or_specialty
+    school&.first&.match?(/Nursing|Woodruff/i) ? 'Specialty' : 'Department'
+  end
+
   def current_user_roles
     # Note: AdminSets need an exact, non-tokenized solr query. A query like
     # AdminSet.where(title: admin_set) is too broad and might match the wrong AdminSet,

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -3,7 +3,7 @@
   <tbody>
     <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
     <%= presenter.attribute_to_html(:school, render_as: :faceted) %>
-    <%= presenter.attribute_to_html(:department, render_as: :faceted) %>
+    <%= presenter.attribute_to_html(:department, render_as: :faceted, label: presenter.department_or_specialty) %>
     <%= presenter.attribute_to_html(:subfield, label: "Subfield / Discipline", render_as: :faceted) %>
     <%= presenter.attribute_to_html(:degree, render_as: :faceted) %>
     <%= presenter.attribute_to_html(:submitting_type, label: "Submission", render_as: :faceted) %>

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -300,4 +300,16 @@ describe EtdPresenter do
       expect(presenter.abstract_with_embargo_check).not_to include 'under embargo'
     end
   end
+
+  describe '#department_or_specialty' do
+    it 'returns "Specialty" for the nursing school' do
+      etd.school = ['Nell Hodgson Woodruff School of Nursing']
+      expect(presenter.department_or_specialty).to eq 'Specialty'
+    end
+
+    it 'returns "Department" when school is not nursing' do
+      etd.school = ['Any other school']
+      expect(presenter.department_or_specialty).to eq 'Department'
+    end
+  end
 end

--- a/spec/views/hyrax/base/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_metadata.html.erb_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe 'hyrax/base/_metadata.html.erb', type: :view do
       expect(rendered).to have_no_css('.attribute-degree_awarded')
     end
   end
+
+  context "renders department labels" do
+    it 'as "Department" by default' do
+      etd.school = ['Any School']
+      etd.department = ['Some Department']
+      render 'hyrax/base/metadata', presenter: etd_presenter
+      expect(rendered).to have_css('.etd.attributes th', text: 'Department')
+    end
+
+    it 'as "Specialty" for nursing' do
+      etd.school = ['Nell Hodgson Woodruff School of Nursing']
+      etd.department = ['Any Specialty']
+      render 'hyrax/base/metadata', presenter: etd_presenter
+      expect(rendered).to have_css('.etd.attributes th', text: 'Specialty')
+    end
+  end
 end


### PR DESCRIPTION
This change updates labels to display school specific language where possible or generic language where the display label is shared.

When the school value can be accessed,
* "Nell Hodgson Woodruff School of Nursing" displays "Specialty" as the label for the `department` value
* All other schools display "Department" as the label

Otherwise, the application displays a generic label of either:
* "Department or Specialty", or
* "Department / Specialty" in facets