### PR TITLE
Rename nursing submission type per requirements document

### DIFF
--- a/config/authorities/submitting_type.yml
+++ b/config/authorities/submitting_type.yml
@@ -1,5 +1,5 @@
 terms:
+    - Scholarly Project
     - Honors Thesis
-    - Capstone
     - Master's Thesis
     - Dissertation


### PR DESCRIPTION
**RATIONALE**
An earlier iteration of the requirements referenced a new "Capstone" submission type, but the final decision is to use "Scholarly Project" for nursing school submissions.