### PR TITLE
[Maintenance] Always stub virus scanner

### DIFF
--- a/spec/lib/clamby_scanner_spec.rb
+++ b/spec/lib/clamby_scanner_spec.rb
@@ -8,12 +8,9 @@ RSpec.describe ClambyScanner do
   describe "Clamby" do
     before do
       # Stub Clamby to return true if filename includes "virus"
-      # in environments without ClamAV installed - e.g. CircleCI
       Clamby.configure(error_clamscan_missing: false, output_level: 'off')
-      unless Clamby.scanner_exists?
-        class_double("Clamby").as_stubbed_const
-        allow(Clamby).to receive(:virus?) { |args| args.match?(/virus/i) }
-      end
+      class_double("Clamby").as_stubbed_const
+      allow(Clamby).to receive(:virus?) { |args| args.match?(/virus/i) }
     end
 
     it 'detects viruses' do


### PR DESCRIPTION
**RATIONALE**
We're testing whether our code behaves correctly when ClamAV (via Clamby) detects a virus, not whether ClamAV is installed and working correctly. We need to have a different process in place to ensure ClamAV is working correctly in production anyway.

Shelling out to ClamAV during the test suite adds significant overhead that tells us about the environment rather than the application behavior.

This change ensures the tests just test whether our code behaves correctly when ClamAV is installed and running as expected.