### PR TITLE
[FIX] Department label incorrect when editing Nursing

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,27 +1,7 @@
 <template>
-  <div v-if="sharedState.allowTabSave()">
+  <div>
     <!-- TODO: adding v-model='selected' enables the selected value to appear in the case of an ipe_etd, but it will not without it, with a hyrax etd. But we should refactor for a better solution. -->
     <label for="department"> {{ sharedState.getDepartmentHeading() }} </label>
-    <select
-      name="etd[department]"
-      class="form-control"
-      id="department"
-      aria-required="true"
-      v-model="selected"
-      v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)"
-    >
-      <option
-        v-for="(department, i) in sharedState.departments"
-        v-bind:value="department.id"
-        v-bind:key="`${i}-${department.label}`"
-        :disabled="department.disabled"
-      >
-        {{ department.label }}
-      </option>
-    </select>
-  </div>
-  <div v-else>
-    <label for="department">Department</label>
     <select
       name="etd[department]"
       class="form-control"


### PR DESCRIPTION
**ISSUE**
The label for the department/specialty field is displaying "Department" instead of "Specialty" when editing an InProgressEtd (i.e. and ETD that has been submitted and is being edited in single form view instead via the tabbed wizard).

**RESOLUTION**
The VUE Department component has duplicated code that did not inlcude the dynamic field label call. There were no other differences between the two sections of code, so we removed the v-if conditional and removed the duplicated code.