### PR TITLE
Update deparment selection to be context-sensitive

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -52,7 +52,7 @@ export default {
       } else {
         this.selected = this.sharedState.getSavedOrSelectedDepartment();
         if (!this.selected) {
-          this.selected = "Select a Department";
+          this.selected = "Select a " + this.sharedState.getDepartmentHeading();
         }
       }
     });


### PR DESCRIPTION
**ISSUE**
The department selection prompt text displayed the static string "Select a Department" desptite the input label being dynamic based on the school. This led to the slightly confusing input "Specialty: Select a Department" for the school of nursing.

**RESOLUTION**
This change updates the prompt text to match the input label, based on the previously selected shcool.

## BEFORE
![image](https://github.com/user-attachments/assets/fe7bf5ed-4cf2-41de-bd2f-7d7777ddf818)

## AFTER
![image](https://github.com/user-attachments/assets/73bfbf73-1091-4774-badb-17d59674dfde)
