### PR TITLE
[FIX] Specialty select box promt text missing

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -387,7 +387,7 @@ export const formStore = {
     } else {
       axios.get(selectedSchool).then(response => {
         const departmentsFromQA = response.data.filter(function(val) { if (val.active != false) { return val } })
-        const prompt = 'Select a ' + this.getDepartmentHeading
+        const prompt = 'Select a ' + this.getDepartmentHeading()
         departmentsFromQA.unshift({ "value": prompt, "active": true, "label": prompt, "id": prompt,  "disabled":"disabled", "selected": "selected"})
         this.departments = departmentsFromQA
       })


### PR DESCRIPTION
**ISSUE**
When we updated the default value to change from "Department" to "Specialty" for nursing, the function call was called with improper syntax resulting in the function code being dispalyed instead of the call result.

**RESOULTION**
Correct the syntax error in the Javascript to set the default string.