### PR TITLE
[FIX] Embargo selections reset when editing ETDs

### DIFF
--- a/app/lib/embargo_type_from_attributes.rb
+++ b/app/lib/embargo_type_from_attributes.rb
@@ -8,11 +8,11 @@ class EmbargoTypeFromAttributes
   def s
     embargo_type = [@files, @toc, @abstract]
     case embargo_type
-    when ['true', 'false', 'false']
+    when [true, false, false]
       return 'files_embargoed'
-    when ['true', 'true', 'false']
+    when [true, true, false]
       return 'files_embargoed, toc_embargoed'
-    when ['true', 'true', 'true']
+    when [true, true, true]
       return 'files_embargoed, toc_embargoed, abstract_embargoed'
     end
   end

--- a/spec/lib/embargo_type_from_attributes_spec.rb
+++ b/spec/lib/embargo_type_from_attributes_spec.rb
@@ -3,17 +3,17 @@ RSpec.describe EmbargoTypeFromAttributes do
   let(:embargo_type) { described_class }
 
   it 'returns the correct response for files' do
-    type = embargo_type.new('true', 'false', 'false')
+    type = embargo_type.new(true, false, false)
     expect(type.s).to eq('files_embargoed')
   end
 
   it 'returns the correct resposne for files and toc' do
-    type = embargo_type.new('true', 'true', 'false')
+    type = embargo_type.new(true, true, false)
     expect(type.s).to eq('files_embargoed, toc_embargoed')
   end
 
   it 'returns the correct response for files, toc, and abstract' do
-    type = embargo_type.new('true', 'true', 'true')
+    type = embargo_type.new(true, true, true)
     expect(type.s).to eq('files_embargoed, toc_embargoed, abstract_embargoed')
   end
 end

--- a/spec/system/edit_etd_spec.rb
+++ b/spec/system/edit_etd_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature 'Edit an existing ETD',
               integration: true,
               type: :system do
   let(:depositing_user) { FactoryBot.create(:user) }
-  let(:approving_user) { User.where(uid: "laneyadmin").first }
   let(:file) { FactoryBot.create(:primary_uploaded_file, user_id: depositing_user.id) }
   let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/rollins_subset_admin_sets.yml", "/dev/null") }
   let(:etd) {
@@ -18,7 +17,11 @@ RSpec.feature 'Edit an existing ETD',
                                 department: ["Biostatistics"],
                                 subfield: ["Biostatistics"],
                                 depositor: depositing_user.user_key,
-                                graduation_date: 'Spring 2021')
+                                graduation_date: 'Spring 2021',
+                                embargo_length: '6 months',
+                                files_embargoed: true,
+                                toc_embargoed: true,
+                                abstract_embargoed: false)
   }
   let(:admin_superuser) { User.where(uid: "tezprox").first } # uid from superuser.yml
 
@@ -41,6 +44,8 @@ RSpec.feature 'Edit an existing ETD',
       expect(page).to have_content etd.degree.first
       expect(page).to have_content "Biostatistics - MPH & MSPH"
       expect(page).to have_select('graduation-date', selected: 'Spring 2021')
+      expect(page).to have_select('embargo-length', selected: '6 months')
+      expect(page).to have_select('content-to-embargo', selected: 'Files and Table of Contents')
       click_on "Submit Your Thesis or Dissertation"
       expect(page).to have_content "Biostatistics and Bioinformatics"
       expect(page).to have_content etd.degree.first


### PR DESCRIPTION
**ISSUE**
When a student or admin edits a submitted ETD, the "Content to Embargo" setting is always reset to "Files Embargoed" regardless of what was previously saved.

**DIAGNOSIS**
The library (and corresponding tests) that converts saved embargo settings used a string values instead of boolean values. The source ETD stores `files_embargoed`, `toc_embargoed`, and `abstract_embargoed` as boolean values, bt the translation code was comparing against string values. Examples:
```
true == 'true'
=> false

[true, true, false] == ['true', 'true', 'false']
=> false
```

**RESOLUTION**
Add test cases that demonstrate the bug and update the code to do the comparisions using the correct data types.