### PR TITLE
[REFACTOR] Remove redundant embargo code

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -70,7 +70,6 @@ module Hyrax
 
     def update
       sanitize_input(params)
-      translate_embargo_string(params)
       merge_selected_files_hashes(params) if params["selected_files"]
       apply_file_metadata(params)
 
@@ -278,29 +277,6 @@ module Hyrax
     end
 
     private
-
-      def translate_embargo_string(params)
-        return unless params['etd']['embargo_type']
-        embargo_booleans = params['etd']['embargo_type'].split(',').map { |type| ActiveModel::Type::Boolean.new.cast(type).to_s }
-        etd = Etd.find(params["id"])
-        case embargo_booleans
-        when ['true']
-          etd.files_embargoed = 'true'
-          etd.toc_embargoed = 'false'
-          etd.abstract_embargoed = 'false'
-          etd.save
-        when ['true', 'true']
-          etd.files_embargoed = 'true'
-          etd.toc_embargoed = 'true'
-          etd.abstract_embargoed = 'false'
-          etd.save
-        when ['true', 'true', 'true']
-          etd.files_embargoed = 'true'
-          etd.toc_embargoed = 'true'
-          etd.abstract_embargoed = 'true'
-          etd.save
-        end
-      end
 
       def must_update_file_visibility?(work)
         work.file_sets.present? &&


### PR DESCRIPTION
**ISSUE**
The controller logic to parse embargo codes is only applied on updates, but not new ETD creation. We didn't notice this because the same functionality is provided in the actor stack, see: https://github.com/curationexperts/laevigata/blob/v12.38.4/app/actors/hyrax/actors/etd_actor.rb#L24-L30

**RESOLUTION**
Since the actor stack logic applies in more contexts (background jobs, etc.) including controller actions, we can safely remove the redundant logic from the controller.