### PR TITLE
[REFACTOR] Match embargo language between JS & Rails

### DIFF
--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -18,15 +18,15 @@ module Hyrax
           end
         end
 
-        # We must translate a value like env.attributes[:embargo_type] = "files_embargoed, toc_embargoed, abstract_embargoed"
+        # We must translate a value like env.attributes[:embargo_type] = "files_restricted, toc_restricted, all_restricted"
         # into the ETD's expected etd.files_embargoed = 'true', etd.toc_embargoed = 'true',
         # etd.abstract_embargoed = 'true'
         def translate_embargo_types(env)
           return unless env.attributes[:embargo_type]
           embargo_type = env.attributes.delete(:embargo_type)
-          env.attributes[:files_embargoed] = 'true' if embargo_type =~ /files_embargoed/
-          env.attributes[:toc_embargoed] = 'true' if embargo_type =~ /toc_embargoed/
-          env.attributes[:abstract_embargoed] = 'true' if embargo_type =~ /abstract_embargoed/
+          env.attributes[:files_embargoed] = 'true' if embargo_type =~ /files_restricted/
+          env.attributes[:toc_embargoed] = 'true' if embargo_type =~ /toc_restricted/
+          env.attributes[:abstract_embargoed] = 'true' if embargo_type =~ /all_restricted/
         end
     end
   end

--- a/app/javascript/config/embargoContents.json
+++ b/app/javascript/config/embargoContents.json
@@ -1,12 +1,12 @@
 [{ "text": "Files",
-  "value": "files_embargoed",
+  "value": "files_restricted",
   "disabled": false
 },
 { "text": "Files and Table of Contents",
-  "value": "files_embargoed, toc_embargoed",
+  "value": "files_restricted, toc_restricted",
   "disabled": false
 },
 { "text": "Files and Table of Contents and Abstract",
-  "value": "files_embargoed, toc_embargoed, abstract_embargoed",
+  "value": "files_restricted, toc_restricted, all_restricted",
   "disabled": false
 }]

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -343,7 +343,7 @@ export const formStore = {
     } else if (this.savedData['embargo_type']) {
       return this.savedData['embargo_type']
     } else {
-      return 'files_embargoed'
+      return 'files_restricted'
     }
   },
   getSavedSchool () {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -44,17 +44,17 @@ describe('formStore', () => {
   it('returns the correct embargo contents', () => {
     expect(formStore.getEmbargoContents()).toEqual([{
       text: 'Files',
-      value: 'files_embargoed',
+      value: 'files_restricted',
       disabled: false
     },
     {
       text: 'Files and Table of Contents',
-      value: 'files_embargoed, toc_embargoed',
+      value: 'files_restricted, toc_restricted',
       disabled: false
     },
     {
       text: 'Files and Table of Contents and Abstract',
-      value: 'files_embargoed, toc_embargoed, abstract_embargoed',
+      value: 'files_restricted, toc_restricted, all_restricted',
       disabled: false
     }
     ])

--- a/app/lib/embargo_type_from_attributes.rb
+++ b/app/lib/embargo_type_from_attributes.rb
@@ -9,11 +9,11 @@ class EmbargoTypeFromAttributes
     embargo_type = [@files, @toc, @abstract]
     case embargo_type
     when [true, false, false]
-      return 'files_embargoed'
+      return 'files_restricted'
     when [true, true, false]
-      return 'files_embargoed, toc_embargoed'
+      return 'files_restricted, toc_restricted'
     when [true, true, true]
-      return 'files_embargoed, toc_embargoed, abstract_embargoed'
+      return 'files_restricted, toc_restricted, all_restricted'
     end
   end
 end

--- a/spec/actors/stack_spec.rb
+++ b/spec/actors/stack_spec.rb
@@ -107,7 +107,7 @@ describe Hyrax::CurationConcern do
               'school' => ['Emory College'],
               'embargo_length' => '6 months',
               'uploaded_files' => [uploaded_file.id],
-              'embargo_type' =>  "files_embargoed, toc_embargoed, abstract_embargoed" }
+              'embargo_type' =>  "files_restricted, toc_restricted, all_restricted" }
           end
 
           it 'sets the file embargo' do

--- a/spec/lib/embargo_type_from_attributes_spec.rb
+++ b/spec/lib/embargo_type_from_attributes_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe EmbargoTypeFromAttributes do
 
   it 'returns the correct response for files' do
     type = embargo_type.new(true, false, false)
-    expect(type.s).to eq('files_embargoed')
+    expect(type.s).to eq('files_restricted')
   end
 
   it 'returns the correct resposne for files and toc' do
     type = embargo_type.new(true, true, false)
-    expect(type.s).to eq('files_embargoed, toc_embargoed')
+    expect(type.s).to eq('files_restricted, toc_restricted')
   end
 
   it 'returns the correct response for files, toc, and abstract' do
     type = embargo_type.new(true, true, true)
-    expect(type.s).to eq('files_embargoed, toc_embargoed, abstract_embargoed')
+    expect(type.s).to eq('files_restricted, toc_restricted, all_restricted')
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -368,20 +368,20 @@ describe InProgressEtd do
       end
 
       context 'with existing embargoes and new embargo data' do
-        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
-        let(:new_data) { { 'embargo_length': '2 Years', 'embargo_type': 'files_embargoed, toc_embargoed' } }
+        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_restricted' } }
+        let(:new_data) { { 'embargo_length': '2 Years', 'embargo_type': 'files_restricted, toc_restricted' } }
 
         it 'sets new embargo length and type and does not set no_embargoes' do
           expect(resulting_data).to eq({
             'embargo_length' => '2 Years',
-            'embargo_type' => 'files_embargoed, toc_embargoed',
+            'embargo_type' => 'files_restricted, toc_restricted',
             "schoolHasChanged" => false
           })
         end
       end
 
       context 'with existing embargoes and new no embargo data' do
-        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed' } }
+        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_restricted' } }
 
         let(:new_data) { { 'embargo_length': described_class::NO_EMBARGO } }
 
@@ -395,7 +395,7 @@ describe InProgressEtd do
       end
 
       context 'with existing embargoes and no embargo changes' do
-        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_embargoed, toc_embargoed' } }
+        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_restricted, toc_restricted' } }
 
         let(:new_data) { { 'abstract': 'Embargo should be unchanged' } }
 
@@ -403,7 +403,7 @@ describe InProgressEtd do
           expect(resulting_data).to eq({
                                          'abstract' => 'Embargo should be unchanged',
                                          'embargo_length' => '1 Year',
-                                         'embargo_type' => 'files_embargoed, toc_embargoed',
+                                         'embargo_type' => 'files_restricted, toc_restricted',
                                          "schoolHasChanged" => false
                                        })
         end
@@ -734,7 +734,7 @@ describe InProgressEtd do
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Non-Emory/)
         expect(refreshed_data['title']).to eq new_data['title'][0]
         # Test embargo_type is set correctly from *_embargoed booleans
-        expect(refreshed_data['embargo_type']).to eq 'files_embargoed, toc_embargoed'
+        expect(refreshed_data['embargo_type']).to eq 'files_restricted, toc_restricted'
         expect(refreshed_data['ipe_id']).to eq ipe.id
         expect(refreshed_data['etd_id']).to eq etd.id
       end

--- a/spec/system/edit_file_set_spec.rb
+++ b/spec/system/edit_file_set_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
       'school' => ["Candler School of Theology"],
       'department' => ["Divinity"],
       'embargo_length' => '6 months',
-      'embargo_type' =>  "files_embargoed, toc_embargoed, abstract_embargoed",
+      'embargo_type' =>  "files_restricted, toc_restricted, all_restricted",
       'uploaded_files' => [uploaded_file.id] }
   end
   let(:actor)      { Hyrax::CurationConcern.actor }

--- a/spec/system/embargo_edit_spec.rb
+++ b/spec/system/embargo_edit_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'edit an embargo', :perform_jobs, :js, integration: true, type: :
       'school' => ["Candler School of Theology"],
       'department' => ["Divinity"],
       'embargo_length' => '6 months',
-      'embargo_type' =>  "files_embargoed, toc_embargoed, abstract_embargoed",
+      'embargo_type' =>  "files_restricted, toc_restricted, all_restricted",
       'uploaded_files' => [uploaded_file.id] }
   end
   let(:actor)      { Hyrax::CurationConcern.actor }

--- a/spec/system/embargo_show_spec.rb
+++ b/spec/system/embargo_show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
       'school' => ["Candler School of Theology"],
       'department' => ["Divinity"],
       'embargo_length' => '6 months',
-      'embargo_type' =>  "files_embargoed, toc_embargoed, abstract_embargoed",
+      'embargo_type' =>  "files_restricted, toc_restricted, all_restricted",
       'uploaded_files' => [uploaded_file.id] }
   end
   let(:actor)      { Hyrax::CurationConcern.actor }


### PR DESCRIPTION
**RATIONALE**
The code that was initially developed to record student embargo requests differed between the Ruby and Javascript code:

RUBY
* files_restricted
* toc_restricted
* all_restricted

JAVASCRIPT
* files_embargoed
* toc_embargoed
* abstract_embargoed

This change modifies all of the Javascript references to align with the definitions in [app/services/visibility_translator](https://github.com/curationexperts/laevigata/blob/v12.38.4/app/services/visibility_translator.rb#L21-L23)
```
class VisibilityTranslator
  RESTRICTED      = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
  ALL_EMBARGOED   = 'all_restricted'.freeze
  FILES_EMBARGOED = 'files_restricted'.freeze
  TOC_EMBARGOED   = 'toc_restricted'.freeze
  OPEN            = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC

...
```

## NOTE
Solr indexes ETDs with a `visibility_ssi` value. This change makes more of the code align with those indexed values. Current stats are
```
"facet_fields":{
      "visibility_ssi":[
        "open",11086,
        "files_restricted",854,
        "all_restricted",624,
        "toc_restricted",85,
        "restricted",2,
        null,0]}
```