### PR TITLE
[REFACTOR] Always explicitly set embargo booleans in actor stack

### DIFF
--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -24,10 +24,25 @@ module Hyrax
         def translate_embargo_types(env)
           return unless env.attributes[:embargo_type]
           embargo_type = env.attributes.delete(:embargo_type)
-          env.attributes[:files_embargoed] = 'true' if embargo_type =~ /files_restricted/
-          env.attributes[:toc_embargoed] = 'true' if embargo_type =~ /toc_restricted/
-          env.attributes[:abstract_embargoed] = 'true' if embargo_type =~ /all_restricted/
+          env.attributes[:files_embargoed]    = files_included?(embargo_type)
+          env.attributes[:toc_embargoed]      = toc_included?(embargo_type)
+          env.attributes[:abstract_embargoed] = abstract_included?(embargo_type)
         end
+
+      def files_included?(embargo_type)
+        embargo_type.match?(VisibilityTranslator::FILES_EMBARGOED) ||
+          embargo_type.match?(VisibilityTranslator::TOC_EMBARGOED) ||
+          embargo_type.match?(VisibilityTranslator::ALL_EMBARGOED)
+      end
+
+      def toc_included?(embargo_type)
+        embargo_type.match?(VisibilityTranslator::TOC_EMBARGOED) ||
+          embargo_type.match?(VisibilityTranslator::ALL_EMBARGOED)
+      end
+
+      def abstract_included?(embargo_type)
+        embargo_type.match?(VisibilityTranslator::ALL_EMBARGOED)
+      end
     end
   end
 end


### PR DESCRIPTION
**RATIONALE**
The previous code did not reset embargo booleans if they were passed into the actor stack along with an embargo type. This could result in invalid embargo settings, e.g.
```
env.attributes[:embargo_type] = 'files_restricted'
env.attributes[:abstract_embargoed] = true
```
After runing the actors, you would have
```
etd.files_embargoed
=> true
etd.toc_embargoed
=> false
etd.abstract_embargoed
=> true
```

To prevent this type of error state, we want to always explicitly set all three embargo booleans to true or false. The updated code will override any individual embargo boolean attributes if the embargo type is present.

This change also ensures that all booleans are set based only on the most restrictive ebargo setting present. This also sets us up to pass only a single embargo value instead of a comma separated list.