### PR TITLE
[REFACTOR] Simplify embargo_type strings

### DIFF
--- a/app/actors/hyrax/actors/etd_actor.rb
+++ b/app/actors/hyrax/actors/etd_actor.rb
@@ -18,7 +18,7 @@ module Hyrax
           end
         end
 
-        # We must translate a value like env.attributes[:embargo_type] = "files_restricted, toc_restricted, all_restricted"
+        # We must translate a value like env.attributes[:embargo_type] = "all_restricted"
         # into the ETD's expected etd.files_embargoed = 'true', etd.toc_embargoed = 'true',
         # etd.abstract_embargoed = 'true'
         def translate_embargo_types(env)

--- a/app/javascript/config/embargoContents.json
+++ b/app/javascript/config/embargoContents.json
@@ -3,10 +3,10 @@
   "disabled": false
 },
 { "text": "Files and Table of Contents",
-  "value": "files_restricted, toc_restricted",
+  "value": "toc_restricted",
   "disabled": false
 },
 { "text": "Files and Table of Contents and Abstract",
-  "value": "files_restricted, toc_restricted, all_restricted",
+  "value": "all_restricted",
   "disabled": false
 }]

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -49,12 +49,12 @@ describe('formStore', () => {
     },
     {
       text: 'Files and Table of Contents',
-      value: 'files_restricted, toc_restricted',
+      value: 'toc_restricted',
       disabled: false
     },
     {
       text: 'Files and Table of Contents and Abstract',
-      value: 'files_restricted, toc_restricted, all_restricted',
+      value: 'all_restricted',
       disabled: false
     }
     ])

--- a/app/lib/embargo_type_from_attributes.rb
+++ b/app/lib/embargo_type_from_attributes.rb
@@ -11,9 +11,9 @@ class EmbargoTypeFromAttributes
     when [true, false, false]
       return 'files_restricted'
     when [true, true, false]
-      return 'files_restricted, toc_restricted'
+      return 'toc_restricted'
     when [true, true, true]
-      return 'files_restricted, toc_restricted, all_restricted'
+      return 'all_restricted'
     end
   end
 end

--- a/spec/actors/stack_spec.rb
+++ b/spec/actors/stack_spec.rb
@@ -107,7 +107,7 @@ describe Hyrax::CurationConcern do
               'school' => ['Emory College'],
               'embargo_length' => '6 months',
               'uploaded_files' => [uploaded_file.id],
-              'embargo_type' =>  "files_restricted, toc_restricted, all_restricted" }
+              'embargo_type' =>  "all_restricted" }
           end
 
           it 'sets the file embargo' do

--- a/spec/lib/embargo_type_from_attributes_spec.rb
+++ b/spec/lib/embargo_type_from_attributes_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe EmbargoTypeFromAttributes do
 
   it 'returns the correct resposne for files and toc' do
     type = embargo_type.new(true, true, false)
-    expect(type.s).to eq('files_restricted, toc_restricted')
+    expect(type.s).to eq('toc_restricted')
   end
 
   it 'returns the correct response for files, toc, and abstract' do
     type = embargo_type.new(true, true, true)
-    expect(type.s).to eq('files_restricted, toc_restricted, all_restricted')
+    expect(type.s).to eq('all_restricted')
   end
 end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -369,12 +369,12 @@ describe InProgressEtd do
 
       context 'with existing embargoes and new embargo data' do
         let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_restricted' } }
-        let(:new_data) { { 'embargo_length': '2 Years', 'embargo_type': 'files_restricted, toc_restricted' } }
+        let(:new_data) { { 'embargo_length': '2 Years', 'embargo_type': 'toc_restricted' } }
 
         it 'sets new embargo length and type and does not set no_embargoes' do
           expect(resulting_data).to eq({
             'embargo_length' => '2 Years',
-            'embargo_type' => 'files_restricted, toc_restricted',
+            'embargo_type' => 'toc_restricted',
             "schoolHasChanged" => false
           })
         end
@@ -395,7 +395,7 @@ describe InProgressEtd do
       end
 
       context 'with existing embargoes and no embargo changes' do
-        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'files_restricted, toc_restricted' } }
+        let(:old_data) { { 'embargo_length': '1 Year', 'embargo_type': 'toc_restricted' } }
 
         let(:new_data) { { 'abstract': 'Embargo should be unchanged' } }
 
@@ -403,7 +403,7 @@ describe InProgressEtd do
           expect(resulting_data).to eq({
                                          'abstract' => 'Embargo should be unchanged',
                                          'embargo_length' => '1 Year',
-                                         'embargo_type' => 'files_restricted, toc_restricted',
+                                         'embargo_type' => 'toc_restricted',
                                          "schoolHasChanged" => false
                                        })
         end
@@ -734,7 +734,7 @@ describe InProgressEtd do
         expect(refreshed_data['committee_chair_attributes'].to_s).to match(/Non-Emory/)
         expect(refreshed_data['title']).to eq new_data['title'][0]
         # Test embargo_type is set correctly from *_embargoed booleans
-        expect(refreshed_data['embargo_type']).to eq 'files_restricted, toc_restricted'
+        expect(refreshed_data['embargo_type']).to eq 'toc_restricted'
         expect(refreshed_data['ipe_id']).to eq ipe.id
         expect(refreshed_data['etd_id']).to eq etd.id
       end

--- a/spec/system/edit_file_set_spec.rb
+++ b/spec/system/edit_file_set_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
       'school' => ["Candler School of Theology"],
       'department' => ["Divinity"],
       'embargo_length' => '6 months',
-      'embargo_type' =>  "files_restricted, toc_restricted, all_restricted",
+      'embargo_type' =>  "all_restricted",
       'uploaded_files' => [uploaded_file.id] }
   end
   let(:actor)      { Hyrax::CurationConcern.actor }

--- a/spec/system/embargo_edit_spec.rb
+++ b/spec/system/embargo_edit_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'edit an embargo', :perform_jobs, :js, integration: true, type: :
       'school' => ["Candler School of Theology"],
       'department' => ["Divinity"],
       'embargo_length' => '6 months',
-      'embargo_type' =>  "files_restricted, toc_restricted, all_restricted",
+      'embargo_type' =>  "all_restricted",
       'uploaded_files' => [uploaded_file.id] }
   end
   let(:actor)      { Hyrax::CurationConcern.actor }

--- a/spec/system/embargo_show_spec.rb
+++ b/spec/system/embargo_show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Display an ETD with embargoed content', :perform_jobs, :js, inte
       'school' => ["Candler School of Theology"],
       'department' => ["Divinity"],
       'embargo_length' => '6 months',
-      'embargo_type' =>  "files_restricted, toc_restricted, all_restricted",
+      'embargo_type' =>  "all_restricted",
       'uploaded_files' => [uploaded_file.id] }
   end
   let(:actor)      { Hyrax::CurationConcern.actor }


### PR DESCRIPTION
**RATIONALE**
Rather than mirroring the boolean settings in the embargo_type string passed to and from the ETD forms, we can just pass the highest level restriction - i.e. `all_restricted` also implied `toc_restricted` and `files_restricted`.

Effectively, we only need to pass a unique string for each of the three possible embargo levels:

| `embargo_type` | `files_embargoed` | `toc_embargoed` | `abstract_embargoed` |
|----------------|-------------------|-----------------|----------------------|
|'files_restricted'|true             | false           | false                |
|'toc_restricted'| true              | true            | false                |
|'all_restricted'| true              | true            | true                 |

By using the same strings that are present in the visibility translator, we set ourselves up to replace the strings with the corresponding constants in the Rails codebase.