### PR TITLE
[FIX] Ensure embargo contents are reset when user selects no embargo

### DIFF
--- a/app/javascript/Embargo.vue
+++ b/app/javascript/Embargo.vue
@@ -14,6 +14,9 @@
       </option>
     </select>
   </div>
+  <div v-else>
+    <input type="hidden" name="etd[embargo_type]" id="content-to-embargo" value="open" />
+  </div>
 </div>
 
 <div v-else>

--- a/app/javascript/test/Embargo.spec.js
+++ b/app/javascript/test/Embargo.spec.js
@@ -22,6 +22,13 @@ describe('Embargo.vue', () => {
     expect(wrapper.html()).toContain('This form cannot be used to edit the embargo after graduation.')
   })
 
+  it('defaults to no embargo', () => {
+    const wrapper = shallowMount(Embargo, {})
+    formStore.savedData = { 'degree_awarded': null }
+    expect(wrapper.vm.selectedEmbargo).toBe(`None - open access immediately`)
+    expect(wrapper.html()).toContain('<input type="hidden" name="etd[embargo_type]" id="content-to-embargo" value="open">')
+  })
+
   describe('Embargo saved display', () => {
     beforeEach(() => {
       const wrapper = shallowMount(Embargo, {

--- a/spec/actors/stack_spec.rb
+++ b/spec/actors/stack_spec.rb
@@ -76,6 +76,19 @@ describe Hyrax::CurationConcern do
                               visibility_after_embargo: open
       end
 
+      it 'clears embargo booleans when embargo_type is "open"', :aggregate_failures do
+        etd.files_embargoed = true
+        etd.save!
+        attributes.merge!({ 'embargo_length' => 'None - open access immediately',
+                            'embargo_type' => 'open' })
+
+        actor.create(env)
+
+        expect(etd.embargo_length).to eq 'None - open access immediately'
+        expect(etd.embargo_type).to eq VisibilityTranslator::OPEN
+        expect(etd.files_embargoed).to eq false
+      end
+
       context 'with an uploaded file', :perform_jobs do
         before do
           ActiveJob::Base.queue_adapter.filter = [AttachFilesToWorkJob]


### PR DESCRIPTION
**ISSUE**
When a user had initially selected an embargo option and set the contents to embargo, but then later edited their submission to request 'None - open access immediately', embargo booleans were not reset.

This could result in unclear data being persisted for the ETD such as:
```
embargo_length     => 'None - open access immediately'
files_embargoed    => true
toc_embargoed      => true
abstract_embargoed => flase
```
While the code treats this as an open access ETD, it's confuing to see the files and toc booleans set to true.

**RESOLUTION**
This change adds code and tests to
1) Ensure that the form sets the embargo_type to a value that represents
   no embargo when the open access option is chosen for embargo_length
2) Ensure that the actor stack resets embargo booleans when the embargo_type
   is set to 'open' (VisibilityTranslator::OPEN)