### PR TITLE
[REFACTOR] Remove dead code for no_embargoes

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -93,7 +93,6 @@ class InProgressEtdsController < ApplicationController
       terms << "committee_chair_attributes"
       terms << "committee_members_attributes"
       terms << "uploaded_files"
-      terms << "no_embargoes"
       terms << "agreement"
       terms << "no_supplemental_files"
       params.permit(terms)

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -30,7 +30,6 @@ module Hyrax
     self.terms += [:patents]
     # my embargo terms
     self.terms += [:embargo_length]
-    self.terms += [:embargo_release_date]
     self.terms += [:embargo_type]
     self.terms += [:files_embargoed]
     self.terms += [:abstract_embargoed]
@@ -89,38 +88,11 @@ module Hyrax
       model.ordered_members.to_a.select(&:supplementary?)
     end
 
-    # Initial state for the 'No Embargo' checkbox.
-    def no_embargoes
-      model.persisted? && !model.under_embargo?
-    end
-
-    def selected_embargo_type
-      return '[:files_embargoed, :toc_embargoed, :abstract_embargoed]' if true_string?(model.abstract_embargoed)
-      return '[:files_embargoed, :toc_embargoed]' if true_string?(model.toc_embargoed)
-      return '[:files_embargoed]' if true_string?(model.files_embargoed)
-    end
-
-    # Both String and boolean 'true' should count as true.
-    def true_string?(field)
-      field == 'true' || field == true
-    end
-
     # we need to pass a nil to Hyrax in order to remove a subfield
     # from an existing ETD, because the absence of the parameter won't
     def self.sanitize_params(form_params)
       form_params["subfield"] = nil unless form_params.include?("subfield")
-      check_for_no_embargoes(form_params)
       super
-    end
-
-    # If no_embargoes is set, set all embargo fields to false
-    def self.check_for_no_embargoes(params)
-      return unless params["no_embargoes"] == "1"
-      params["files_embargoed"] = "false"
-      params["abstract_embargoed"] = "false"
-      params["toc_embargoed"] = "false"
-      params["toc_embargoed"] = "false"
-      params["embargo_length"] = ""
     end
 
     # Select the correct affiliation type for committee member

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -53,8 +53,6 @@ class InProgressEtd < ApplicationRecord
     existing_data = JSON.parse(json_data)
     return existing_data unless new_data
 
-    new_data = add_no_embargoes(new_data)
-    existing_data = remove_stale_embargo_data(existing_data, new_data)
     new_data = keep_last_completed_step(existing_data, new_data)
     new_data = keep_school_has_changed(existing_data, new_data)
     new_data = strip_blank_fields(new_data)
@@ -100,23 +98,6 @@ class InProgressEtd < ApplicationRecord
       new_data[key] = value.reject { |v| v.blank? }
     end
     new_data
-  end
-
-  # currently the EtdForm uses the boolean param "no_embargoes", so we need to send or remove it (seems a good candidate for refactoring in EtdForm)
-
-  def add_no_embargoes(new_data)
-    resulting_data = new_data[:embargo_length] == NO_EMBARGO ? new_data.merge("no_embargoes" => "1") : nil
-
-    resulting_data.nil? ? new_data : resulting_data
-  end
-
-  # Remove embargo_type, if new_data[:embargo_length] == NO_EMBARGO
-  # Remove no_embargoes if new_data[:embargo_length] != NO_EMBARGO
-
-  def remove_stale_embargo_data(existing_data, new_data)
-    existing_data.delete('no_embargoes') if existing_data.keys.include?('no_embargoes') && new_data[:embargo_length] != NO_EMBARGO
-    existing_data.delete('embargo_type') if new_data[:embargo_length] == NO_EMBARGO && existing_data.keys.include?('embargo_type')
-    existing_data
   end
 
   def keep_last_completed_step(existing_data, new_data)

--- a/spec/fixtures/form_submission_params/office_document_bug.rb
+++ b/spec/fixtures/form_submission_params/office_document_bug.rb
@@ -60,7 +60,6 @@
   },
   "index-chair" => "1",
   "index-member" => "1",
-  "no_embargoes" => "1",
   "uploaded_files" => ["221"],
   "agreement" => "1",
   "save_with_files" => "Submit My ETD",

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -39,25 +39,6 @@ RSpec.describe Hyrax::EtdForm do
         expect(form_params).to eq(sanitized_params)
       end
     end
-
-    context 'when selecting no embargoes' do
-      let(:params) do
-        {
-          "no_embargoes" => "1",
-          "toc_embargoed" => "",
-          "abstract_embargoed" => "",
-          "files_embargoed" => ""
-        }
-      end
-      it "sets other embargo fields false" do
-        allow(Hyrax::Forms::WorkForm).to receive(:sanitize_params).with(params)
-        described_class.sanitize_params(params)
-        expect(params["files_embargoed"]).to eq "false"
-        expect(params["abstract_embargoed"]).to eq "false"
-        expect(params["toc_embargoed"]).to eq "false"
-        expect(params["embargo_length"]).to eq ""
-      end
-    end
   end
 
   describe "#primary_pdf_name" do
@@ -134,78 +115,6 @@ RSpec.describe Hyrax::EtdForm do
         before { etd.save! }
         it { is_expected.to eq false }
       end
-    end
-  end
-
-  # Figure out the correct state for the 'No Embargo' checkbox on the ETD form.
-  describe "#no_embargoes" do
-    subject { form.no_embargoes }
-
-    context "ETD with no embargo" do
-      context "a new record" do
-        it { is_expected.to eq false }
-      end
-
-      context "an existing record" do
-        before { etd.save! }
-        it { is_expected.to eq true }
-      end
-    end
-
-    context "ETD with embargo" do
-      let(:etd) { build(:sample_data_with_only_files_embargoed) }
-
-      context "a new record" do
-        it { is_expected.to eq false }
-      end
-
-      context "an existing record" do
-        before { etd.save! }
-        it { is_expected.to eq false }
-      end
-    end
-  end
-
-  describe "#selected_embargo_type" do
-    subject { form.selected_embargo_type }
-
-    context "a new record" do
-      it { is_expected.to be_nil }
-    end
-
-    context "existing ETD with no embargo" do
-      before { etd.save! }
-      it { is_expected.to be_nil }
-    end
-
-    context "existing ETD with only files embargoed" do
-      let(:etd) { build(:sample_data_with_only_files_embargoed) }
-      before { etd.save! }
-      it { is_expected.to eq '[:files_embargoed]' }
-    end
-
-    context "existing ETD with TOC embargoed" do
-      let(:etd) { build(:etd, toc_embargoed: true, abstract_embargoed: false) }
-      before { etd.save! }
-      it { is_expected.to eq '[:files_embargoed, :toc_embargoed]' }
-    end
-
-    context "existing ETD with Abstract embargoed" do
-      let(:etd) { build(:etd, abstract_embargoed: true) }
-      before { etd.save! }
-      it { is_expected.to eq '[:files_embargoed, :toc_embargoed, :abstract_embargoed]' }
-    end
-
-    # It looks like the embargo fields get stored as strings
-    # instead of booleans if you create an ETD using the UI.
-    # Since this code is already in production, to avoid having
-    # to do a data migration, I don't want to convert these
-    # fields to strictly boolean, so we need to make sure it
-    # works with either strings or booleans.
-    context "existing ETD with TOC embargoed (string values)" do
-      let(:etd) { build(:etd, toc_embargoed: 'true', abstract_embargoed: 'false') }
-      before { etd.save! }
-      it { is_expected.to eq '[:files_embargoed, :toc_embargoed]' }
     end
   end
 


### PR DESCRIPTION
**RATIONALE**
A previous version of the application used a Rails form object instead of the current VUE.js form for ETD creation and editing. This form used an attribute called `no_embargo` to indicate that no embargo had been requested (i.e. open access immediately).

The current codebase relies on the `embargo_length` value to determine whether to apply an embargo or not, so the legacy form attribute and related code can be removed.