### PR TITLE
[REFACTOR] Clean up ETD submission tests

### DIFF
--- a/spec/system/submit_etd_spec.rb
+++ b/spec/system/submit_etd_spec.rb
@@ -65,8 +65,7 @@ RSpec.describe "Logged in student can submit an ETD", :clean, type: :system, js:
       # File Upload
       expect(page).to have_content("My Files")
       page.attach_file('primary_files[]', pdf, make_visible: true)
-      expect(page).to have_content 'Save and Continue'
-      sleep(3)
+      expect(page).to have_content 'joey_thesis.pdf'
       click_on 'Save and Continue'
 
       # Embargoes

--- a/spec/system/submit_etd_spec_rollins.rb
+++ b/spec/system/submit_etd_spec_rollins.rb
@@ -4,12 +4,10 @@ require "rails_helper"
 RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
   let(:student) { create :user }
   let(:pdf) { Rails.root.join('spec', 'fixtures', 'joey', 'joey_thesis.pdf') }
-  let(:workflow_setup) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/ec_admin_sets.yml", "/dev/null") }
 
   context 'a logged in user', js: true do
     before do
       login_as student
-      workflow_setup.setup
     end
 
     scenario "submitting a new ETD", js: true do
@@ -19,7 +17,8 @@ RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
       expect(page).to have_content('Post-Graduation Email')
       fill_in 'Student Name', with: FFaker::Name.name
       select 'Rollins School of Public Health', from: 'School'
-      select 'Spring 2018', from: 'Graduation Date'
+      first_active_semester = find('#graduation-date > option:nth-child(2)').text
+      select first_active_semester, from: 'Graduation Date'
       fill_in 'Post-Graduation Email', with: FFaker::Internet.email
       click_on 'Save and Continue'
 
@@ -62,11 +61,10 @@ RSpec.describe "Logged in student can submit an ETD", :clean, type: :system do
 
       # File Upload
       page.attach_file('primary_files[]', pdf, make_visible: true)
-      expect(page).to have_content 'Save and Continue'
+      expect(page).to have_content 'joey_thesis.pdf'
       click_on 'Save and Continue'
 
       # Embargoes
-
       select '6 months', from: 'Requested Embargo Length'
       click_on 'Save and Continue'
 


### PR DESCRIPTION
1. Remove workflow setup since the Rollins test does not submit the form
2. Replace a fixed delay to allow for file processing time with a check for the file's name - this only appears once the attachement is complete.