### PR TITLE
[REFACTOR] Remvove dead code - affiliation_type

### DIFF
--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -156,16 +156,8 @@ class InProgressEtd < ApplicationRecord
     new_data['partnering_agency'] = etd.partnering_agency
     new_data['graduation_date'] = etd.graduation_date
     new_data['embargo_type'] = etd.embargo_type
-
-    members = etd.committee_members.map do |member|
-      member.as_json.merge(affiliation_type: affiliation_type(member.affiliation.first))
-    end
-    new_data['committee_members_attributes'] = members.uniq
-
-    chairs = etd.committee_chair.map do |chair|
-      chair.as_json.merge(affiliation_type: affiliation_type(chair.affiliation.first))
-    end
-    new_data['committee_chair_attributes'] = chairs.uniq
+    new_data['committee_members_attributes'] = etd.committee_members
+    new_data['committee_chair_attributes'] = etd.committee_chair
 
     primary_file = file_for_refresh(etd.primary_file_fs.first)
     new_data['files'] = primary_file.to_json unless primary_file.blank?
@@ -176,11 +168,6 @@ class InProgressEtd < ApplicationRecord
 
     self.data = new_data.to_json
     save!
-  end
-
-  def affiliation_type(affilitation)
-    return 'Non-Emory' if affilitation != 'Emory University'
-    'Emory University'
   end
 
   # Information about the supplemental files that the JavaScript needs for the edit form.

--- a/spec/fixtures/form_submission_params/office_document_bug.rb
+++ b/spec/fixtures/form_submission_params/office_document_bug.rb
@@ -12,23 +12,17 @@
     "submitting_type" => "Master's Thesis",
     "committee_chair_attributes" => {
       "0" => {
-        "affiliation_type" => "Emory Committee Chair",
-        "name" => ["Cook, Captain"],
-        "id" => "#nested_g75972380"
+        "name" => ["Cook, Captain"]
       },
       "1" => {
-        "affiliation_type" => "Emory Committee Chair",
         "name" => [""]
       }
     },
     "committee_members_attributes" => {
       "0" => {
-        "affiliation_type" => "Emory Committee Member",
-        "name" => ["Beard, Black"],
-        "id" => "#nested_g60722120"
+        "name" => ["Beard, Black"]
       },
       "1" => {
-        "affiliation_type" => "Emory Committee Member",
         "name" => [""]
       }
     },

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -100,7 +100,8 @@ describe InProgressEtd do
   describe "My Advisor" do
     context "with valid data" do
       let(:data) do
-        { currentTab: "My Advisor", "committee_chair_attributes": "[0][affiliation_type]Emory" }
+        { currentTab: 'My Advisor',
+          committee_chair_attributes: [{ name: ['Professor McGonagall'], affiliation: ['Emory University'] }] }
       end
       it "is valid" do
         expect(in_progress_etd).to be_valid
@@ -727,13 +728,13 @@ describe InProgressEtd do
         expect(refreshed_data['degree_awarded']).to match(new_data['degree_awarded'])
         expect(refreshed_data['committee_members_attributes'])
           .to include(
-                hash_including('name' => ['Dweck'], "affiliation_type" => 'Non-Emory'),
-                hash_including('name' => ['Hawking'], "affiliation_type" => 'Emory University')
+                hash_including('name' => ['Dweck'], "affiliation" => ['A Famous University']),
+                hash_including('name' => ['Hawking'], "affiliation" => ['Emory University'])
               )
         expect(refreshed_data['committee_chair_attributes'])
           .to include(
-                hash_including('name' => ['Morgan'], "affiliation_type" => 'Non-Emory'),
-                hash_including('name' => ['Merlin'], "affiliation_type" => 'Emory University')
+                hash_including('name' => ['Morgan'], "affiliation" => ['Another University']),
+                hash_including('name' => ['Merlin'], "affiliation" => ['Emory University'])
               )
         expect(refreshed_data['title']).to eq new_data['title'][0]
         # Test embargo_type is set correctly from *_embargoed booleans


### PR DESCRIPTION
**RATIONALE**
The submission form no longer requires `affiliation_type` to be passed in because the form now determines the type based on the `affiliation` value.