### PR TITLE
[REFACTOR] Move post_graduation_email to the presenter

### DIFF
--- a/app/helpers/etd_helper.rb
+++ b/app/helpers/etd_helper.rb
@@ -33,11 +33,6 @@ module EtdHelper
     end
   end
 
-  def post_graduation_email(f)
-    etd = Etd.find(f)
-    etd.post_graduation_email.first
-  end
-
     private
 
       def departments(school)

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -54,6 +54,12 @@ class EtdPresenter < Hyrax::WorkShowPresenter
     "http://pid.emory.edu/#{identifier.first}"
   end
 
+  # Return the post_graduation_email
+  # NOTE: The field is defined as multivalued, but the application only stores a single value
+  def post_graduation_email
+    solr_document.dig('post_graduation_email_tesim', 0)
+  end
+
   # Disabling .ttl, jsonld and nt entirely, because these methods expose embargoed content.
   # If we need it in the future, go back to using the version of this method
   # defined in Hyrax.

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -11,7 +11,7 @@
     <span>Permanent URL: <%= main_app.hyrax_etd_url(@presenter.id) %></span>
     <% if @presenter.current_ability_is_approver? %>
     <br />
-    <span id="presenter-email">Email: <%= post_graduation_email(@presenter.id) %></span>
+    <span id="presenter-email">Email: <%= @presenter.post_graduation_email %></span>
     <% end %>
     <% unless @presenter.workflow.state_label == 'Approved' %>
       <br />

--- a/spec/helpers/etd_helper_spec.rb
+++ b/spec/helpers/etd_helper_spec.rb
@@ -53,10 +53,4 @@ RSpec.describe EtdHelper, type: :helper do
       expect(form).to have_received(:input).with(:partnering_agency, hash_including(selected: 'CDC'))
     end
   end
-
-  example "#post_graduation_email" do
-    allow(Etd).to receive(:find).and_return(etd)
-    expect(etd.post_graduation_email).to be_a_kind_of(ActiveTriples::Relation)
-    expect(helper.post_graduation_email(etd.id)).to be_a_kind_of(String)
-  end
 end

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -222,13 +222,15 @@ describe EtdPresenter do
     let(:department) { ['Religion'] }
     let(:school) { ['Laney Graduate School'] }
     let(:partnering_agency) { ["Does not apply (no collaborating organization)"] }
+    let(:post_graduation_email) { ['someone@example.org', 'other junk ignored'] }
     let(:submitting_type) { ["Honors Thesis"] }
     let(:research_field) { ['Toxicology'] }
     let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
     let :etd do
       Etd.new(title: title, creator: creator, keyword: keyword, degree: degree, department: department,
               school: school, partnering_agency: partnering_agency, submitting_type: submitting_type,
-              research_field: research_field, visibility: visibility, requires_permissions: true, other_copyrights: false, patents: true)
+              research_field: research_field, visibility: visibility, post_graduation_email: post_graduation_email,
+              requires_permissions: true, other_copyrights: false, patents: true)
     end
 
     # If the fields require no addition logic for display, you can simply delegate
@@ -242,6 +244,12 @@ describe EtdPresenter do
     it { is_expected.to delegate_method(:requires_permissions).to(:solr_document) }
     it { is_expected.to delegate_method(:other_copyrights).to(:solr_document) }
     it { is_expected.to delegate_method(:patents).to(:solr_document) }
+
+    describe '#post_graduation_email' do
+      it 'returns a single string' do
+        expect(presenter.post_graduation_email).to eq 'someone@example.org'
+      end
+    end
 
     describe '#permission_badge' do
       it 'shows Open Access' do


### PR DESCRIPTION
**RATIONALE**
We have a helper defined solely to provide a single valued string populated with the post_graduation_email, but we always call it by passing the ETD id from a presenter.

Moving the logic to the presenter allows us to eliminate the helper.