### PR TITLE
[FIX] Flaky presenter test

### DIFF
--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -222,7 +222,7 @@ describe EtdPresenter do
     let(:department) { ['Religion'] }
     let(:school) { ['Laney Graduate School'] }
     let(:partnering_agency) { ["Does not apply (no collaborating organization)"] }
-    let(:post_graduation_email) { ['someone@example.org', 'other junk ignored'] }
+    let(:post_graduation_email) { ['someone@example.org'] }
     let(:submitting_type) { ["Honors Thesis"] }
     let(:research_field) { ['Toxicology'] }
     let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }


### PR DESCRIPTION
**ISSUE**
ActiveTriples does not guarantee that multivalued attributes will be returned in the order they were assigned. So in the context of the current text, we can have two different values returned for the email:
```
etd.post_graduation_email = ['first.address@example.org', 'other address']
# sometimes
etd.post_graduation_email
=> ['first.address@example.org', 'other address']
# other times...
etd.post_graduation_email
=> ['other address', 'first.address@example.org']
```

Becsause of the non-deterministic nature of return values, we should only assign a single value array to fields that should be single-valued - i.e. we can't rely on ordering to consistently return the same value, even when calling `.first`

**FIX**
Update the assinged value to guarantee the return is deterministic. I.E. a single valued array always has the same ordering.