### PR TITLE
[REFACTOR] Remove dead code - do_not_send list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ running as expected.**
 
 ## Suppressing email for bouncing addresses
 
-If an email address is bouncing, or if someone prefers not to receive email notifications,
-add the email address to the list in `config/emory/do_not_send.yml`
+If an email address is bouncing, update the post-graduation e-mail on the relevant ETD, or
+deactivate the assoicated student account (which is generally safe since they have graduated and
+would no longer be able to access their emory account in any case).
 
 ## Copying embargo notification emails to a staff member
 

--- a/app/lib/email_intercept.rb
+++ b/app/lib/email_intercept.rb
@@ -1,15 +1,11 @@
 require 'yaml'
 
 class EmailIntercept
+  # Filter email prior to sending
+  # Currently only filters out messages to dummy accounts to prevent bounces
   def self.delivering_email(message)
-    do_not_send_file = Rails.root.join('config', 'emory', 'do_not_send.yml')
-    unless File.file? do_not_send_file
-      Rails.logger.error "Missing config file: #{do_not_send_file}"
-      return
-    end
-    do_not_send = YAML.load_file(do_not_send_file)
     message.to.each do |recipient|
-      message.perform_deliveries = false if do_not_send.include? recipient
+      message.perform_deliveries = false if recipient == 'tezprox@emory.edu'
     end
   end
 end

--- a/config/emory/do_not_send.yml
+++ b/config/emory/do_not_send.yml
@@ -1,3 +1,0 @@
----
-- bnash3@emory.edu
-- tezprox@emory.edu


### PR DESCRIPTION
**ISSUE**
The EmailIntercept class is not currently fully covered by the test suite. In particular, the config file loading safety check is not tested. However, we are not actively maintaining this list and prefer deactivating accounts instead. The only remaining function of this code is to prevent bounces from the dummy account.

**RESOLUTION**
Eliminate the configuration file since it is no longer in use. Update the documentation appropriately.