### PR TITLE
[MAINTENANCE] Update Clamby configuraration

### DIFF
--- a/config/initializers/clamby.rb
+++ b/config/initializers/clamby.rb
@@ -1,12 +1,10 @@
 Hydra::Works.default_system_virus_scanner = ::ClambyScanner
 
-if Rails.env.production?
-  Clamby.configure(
-    check:  false, # only used for development environment
-    daemonize: true,
-    error_clamscan_missing: true,
-    error_file_missing: true,
-    error_file_virus: false, # we trigger a custom virus error, this setting will cause that to never trigger if true in prod
-    fdpass: true
-  )
-end
+Clamby.configure(
+  check:  false, # only used for development environment
+  daemonize: Rails.env.production?,
+  error_clamscan_missing: Rails.env.production?,
+  error_file_missing: true,
+  error_file_virus: false, # we trigger a custom virus error, this setting will cause that to never trigger if true in prod
+  fdpass: true
+)


### PR DESCRIPTION
**RATIONALE**
The coverage report is flagging the Clamby initializer because it's only run in production. Otherwise, we're getting the default settings.

This change always runs the configuration code and modifies individual settings as needed for the production environment.