### PR TITLE
[REFACTOR] Remove dead code for BrowseEverything uploads from Box

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -16,7 +16,6 @@ module Hyrax
 
     def create
       sanitize_input(params)
-      merge_selected_files_hashes(params) if params["selected_files"]
       update_supplemental_files
       update_committee_members
       if params['etd'].fetch('ipe_id', false)
@@ -68,7 +67,6 @@ module Hyrax
 
     def update
       sanitize_input(params)
-      merge_selected_files_hashes(params) if params["selected_files"]
       apply_file_metadata(params)
 
       if params['request_from_form'] == 'true'
@@ -177,7 +175,7 @@ module Hyrax
       uploaded_file_ids = params["uploaded_files"]
       return if uploaded_file_ids.nil?
       uploaded_file_ids.each do |uploaded_file_id|
-        uploaded_file = find_or_create_uploaded_file(uploaded_file_id)
+        uploaded_file = ::Hyrax::UploadedFile.find(uploaded_file_id)
         next if uploaded_file.pcdm_use == "primary"
         apply_metadata_to_uploaded_file(uploaded_file, params)
       end
@@ -186,14 +184,7 @@ module Hyrax
     end
 
     def apply_metadata_to_uploaded_file(uploaded_file, params)
-      filename = get_filename_for_uploaded_file(uploaded_file, params)
-
-      # params['be_pcdm_use_primary'] only gets sent when student uses browse-everything to upload their primary pdf
-      if filename == params.fetch('be_pcdm_use_primary', false)
-        uploaded_file.pcdm_use = ::FileSet::PRIMARY
-        uploaded_file.save
-        return true
-      end
+      filename = get_filename_for_uploaded_file(uploaded_file)
 
       supplemental_file_metadata = get_supplemental_file_metadata(filename, params)
 
@@ -217,61 +208,8 @@ module Hyrax
       supplemental_file_metadata.find { |a| a["filename"].tr(' ', '_') == filename.tr(' ', '_') } || {}
     end
 
-    def get_filename_for_uploaded_file(uploaded_file, params)
-      return File.basename(uploaded_file.file.file.file) if uploaded_file.file.file
-      get_file_for_url(uploaded_file.browse_everything_url, params)
-    end
-
-    # We create more than one selected_files* hash on the front end, via two instances of the browse-everything uploader
-    # We need to find them and merge them into one hash in the structure the rest of the application expects
-
-    # @params [Hash] params
-    # @return [Hash] selected_files
-    def merge_selected_files_hashes(params)
-      selected_files = {}
-      be_files = params.fetch('selected_files', false)
-
-      count_of_files = 0
-      index = 0
-
-      # Get count of all browse-everything selected_files
-      be_files[0].each_key { |k| count_of_files += be_files[0][k].size }
-
-      # Populate the selected_files hash with all of the browse-everything files, with keys in the structure the rest of the application will expect: their indexes converted to strings
-      be_files[0].each_key do |k|
-        be_files[0][k].each do |ke, va| # rubocop:disable Style/HashEachMethods
-          if index < count_of_files
-            selected_files[index.to_s] = va
-            index += 1
-          end
-        end
-      end # rubocop:enable Style/HashEachMethods
-
-      # Add the full hash under the key the rest of the app expects
-      params[:selected_files] = selected_files
-    end
-
-    # Given a browse everything url, return the file name
-    def get_file_for_url(url, params)
-      selected_files = params["selected_files"].values
-      return unless selected_files.map { |a| a["url"] }.include?(url)
-      selected_files.select { |a| a["url"] == url }.first["file_name"]
-    end
-
-    # Given a filename, return the browse everything url
-    def get_url_for_filename(filename, params)
-      selected_files = params["selected_files"].values
-      selected_files.select { |a| a["file_name"] == filename }.first["url"]
-    end
-
-    # Locally uploaded files should already have a Hyrax::UploadedFile object.
-    # If the uploaded_file_id starts with http, then it must be a
-    # BrowseEverything file. Put the id in the browse_everything_url field.
-    # @param [String] uploaded_file_id
-    # @return [::Hyrax::UploadedFile]
-    def find_or_create_uploaded_file(uploaded_file_id)
-      return ::Hyrax::UploadedFile.find(uploaded_file_id) unless uploaded_file_id.starts_with?("http")
-      ::Hyrax::UploadedFile.create(browse_everything_url: uploaded_file_id)
+    def get_filename_for_uploaded_file(uploaded_file)
+      File.basename(uploaded_file.file.file.file)
     end
 
     private


### PR DESCRIPTION
**RATIONALE**
Emory no longer supports Box for large file uploads. Therefore Box support, and correspondingly BrowseEverything can be removed from the applicaiton.

As a side benefit, some of the code being removed was not covered in the existing test suite, resulting in higher overall test coverage.