### PR TITLE
Clean up styling on submission forms

### DIFF
--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -356,11 +356,21 @@ ul li button:hover {
 
 .tab-content > * {
   margin-right: 2em;
-  margin-bottom: 1em;
+  /* give all elements INSIDE a tab-content block some bottom margin */
+  margin-bottom: 1rem;
+}
+
+div.tab-content {
+  /* give all tab-content blocks themselves a larger bottom margin */
+  margin-bottom: 4rem;
 }
 .tab-content > h1 {
   padding-left: 0;
   margin-bottom: 0.4em;
+}
+.tab-content > h2 {
+  margin-top: 2.5rem;
+  margin-bottom: 1.75rem;
 }
 .tab-content > button {
   margin-bottom: 1.5em;

--- a/app/javascript/components/submit/UserAgreement.vue
+++ b/app/javascript/components/submit/UserAgreement.vue
@@ -1,6 +1,6 @@
 <template>
-  <section>   
-    <h4 id="submission-agreement">Submission Agreement</h4>
+  <section id="submission-agreement">
+    <h4>Submission Agreement</h4>
     <section aria-labelledby="submission-agreement">
     <p>
       I hereby grant to Emory University and its agents the non-exclusive license to archive, make accessible, and display, subject to any embargo restrictions I have specified above, 
@@ -10,7 +10,7 @@
     </p>
     <div class="well">
       <label class="form-inline">
-        <input type="checkbox" v-model="checked" @change="sharedState.setUserAgreement()" />
+        <input id="submission-checkbox" type="checkbox" v-model="checked" @change="sharedState.setUserAgreement()" />
          I HAVE READ AND AGREE TO THE SUBMISSION AGREEMENT
      </label>
     </div>
@@ -40,11 +40,19 @@ export default {
 }
 </script>
 <style scoped>
-h4 {
-  margin-bottom: 2em;
+#submission-agreement > h4 {
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
 }
+label {
+  font-size: larger;
+}
+
 h5 {
   font-weight: 700;
-  
+}
+
+#submission-checkbox {
+  margin-right: 1rem;
 }
 </style>


### PR DESCRIPTION
**RATIONALE**
This change adjusts whitespace to group tab headings more closely with the association inputs and adds more whitespace between submission groups.

We've also addes a space after the submission agreement checkbox and slightly increased the font size.