### PR TITLE
[REFACTOR] Remove unnecessary form code

### DIFF
--- a/app/controllers/hyrax/etds_controller.rb
+++ b/app/controllers/hyrax/etds_controller.rb
@@ -68,13 +68,9 @@ module Hyrax
       sanitize_input(params)
       apply_file_metadata(params)
 
-      if params['request_from_form'] == 'true'
-        curation_concern.committee_chair = nil
-        curation_concern.committee_members = nil
-        update_with_response_for_form
-      else
-        super
-      end
+      curation_concern.committee_chair = nil
+      curation_concern.committee_members = nil
+      update_with_response_for_form
     end
 
     def update_with_response_for_form

--- a/app/javascript/App.vue
+++ b/app/javascript/App.vue
@@ -146,7 +146,6 @@
 
           <input name="etd[currentTab]" type="hidden" :value="value.label" />
           <input name="etd[currentStep]" type="hidden" :value="value.step" />
-          <input name="request_from_form" type="hidden" value="true" />
           <button v-if="allowTabSave() && !sharedState.tabs.submit.currentStep" type="submit" class="btn btn-primary" autofocus>Save and Continue</button>
 
         </div>

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -145,11 +145,6 @@ describe('App.vue', () => {
   })
 
   describe('Edit form:', () => {
-    it('contains hidden flag needed on back end', () => {
-      const wrapper = shallowMount(App, { })
-      expect(wrapper.contains('input[name=request_from_form][value=true]')).toBe(true)
-    })
-
     it('with an associated ETD record, renders the form without tabs', () => {
       const wrapper = shallowMount(App, { })
       wrapper.vm.$data.sharedState.setEtdId('123')

--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs do
       let(:new_morgan) { { name: ['Morgan (edited)'], affiliation: ['Emory University'] } }
 
       before do
-        patch :update, params: { id: etd, etd: new_attrs, request_from_form: 'true' }
+        patch :update, params: { id: etd.id, etd: new_attrs }
         etd.reload # Test persisted state
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs do
         allow(Hyrax::CurationConcern).to receive(:actor).and_return(test_actor)
         allow(controller).to receive(:actor_environment)
 
-        patch :update, params: { id: etd, etd: { supplemental_file_metadata: supp_file_meta }, uploaded_files: [uf.id], request_from_form: 'true' }
+        patch :update, params: { id: etd, etd: { supplemental_file_metadata: supp_file_meta }, uploaded_files: [uf.id] }
         uf.reload
       end
 
@@ -123,7 +123,7 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs do
 
     context 'new data submitted from the form' do
       it 'updates the ETD and returns json redirect path' do
-        patch :update, params: { id: etd, etd: { title: 'New Title' }, request_from_form: 'true' }
+        patch :update, params: { id: etd, etd: { title: 'New Title' } }
 
         etd.reload
         expect(etd.title).to eq ['New Title']


### PR DESCRIPTION
**ISSUE**
We previously provided code pathways for native Hyrax conroller updates if we were not using the JavaScript front-end, and separate processing for patches from the JavaScript front-end.

All user input now comes from the JavaScript front-end, so we no longer need to support multiple update pathways.

**RESOLUTION**
Therefore, we can remove the `request_from_form` flag that triggers the JavaScript update pathway - i.e. all updates should now use that single update process.