### PR TITLE
[MAINTENANCE] Remove dead code to clear supplemental files

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -75,10 +75,6 @@ class InProgressEtdsController < ApplicationController
 
     # TODO: Get each of these from the form
 
-    def add_supplemental_file_data(etd)
-      etd["no_supplemental_files"] = "0"
-    end
-
     def add_uploaded_file_data(etd)
       etd["uploaded_files"] = "3"
     end
@@ -94,7 +90,6 @@ class InProgressEtdsController < ApplicationController
       terms << "committee_members_attributes"
       terms << "uploaded_files"
       terms << "agreement"
-      terms << "no_supplemental_files"
       params.permit(terms)
     end
 end

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -75,15 +75,6 @@ module Hyrax
       model.primary_pdf_file_name
     end
 
-    # Initial state for the 'No Supplemental Files' checkbox.
-    # Supplemental files aren't required for an ETD, but the
-    # form validation requires the user to explicitly check the
-    # 'No Supplemental Files' checkbox if they don't intend to
-    # add any additional files.
-    def no_supplemental_files
-      model.persisted? && supplemental_files.blank?
-    end
-
     def supplemental_files
       model.ordered_members.to_a.select(&:supplementary?)
     end

--- a/spec/controllers/hyrax/etds_controller_spec.rb
+++ b/spec/controllers/hyrax/etds_controller_spec.rb
@@ -215,7 +215,6 @@ RSpec.describe Hyrax::EtdsController, :perform_jobs do
       {
         "etd" => {
           "title" => "My Title",
-          "no_supplemental_files" => "0",
           "supplemental_file_metadata" => {
             "0" => {
               "filename" => "magic_warrior_cat.jpg",

--- a/spec/fixtures/form_submission_params/office_document_bug.rb
+++ b/spec/fixtures/form_submission_params/office_document_bug.rb
@@ -47,7 +47,6 @@
     "requires_permissions" => "false",
     "other_copyrights" => "false",
     "patents" => "false",
-    "no_supplemental_files" => "1",
     "toc_embargoed" => "",
     "abstract_embargoed" => "",
     "files_embargoed" => ""

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -84,40 +84,6 @@ RSpec.describe Hyrax::EtdForm do
     end
   end
 
-  # Figure out the correct state for the 'No Supplemental Files' checkbox on the ETD form.
-  describe "#no_supplemental_files" do
-    subject { form.no_supplemental_files }
-
-    context "ETD with no supplemental files attached" do
-      context "a new record" do
-        it { is_expected.to eq false }
-      end
-
-      # If we are rendering the edit form for an existing ETD,
-      # and the ETD doesn't have any supplemental files,
-      # the form should pre-check the 'No Supplemental Files'
-      # checkbox, since that is the current state.
-      context "an existing record" do
-        before { etd.save! }
-        it { is_expected.to eq true }
-      end
-    end
-
-    context "ETD with supplemental files" do
-      let(:etd) { build(:etd, ordered_members: [supp_file]) }
-      let(:supp_file) { build(:supplemental_file_set) }
-
-      context "a new record" do
-        it { is_expected.to eq false }
-      end
-
-      context "an existing record" do
-        before { etd.save! }
-        it { is_expected.to eq false }
-      end
-    end
-  end
-
   describe "#cm_affiliation_type" do
     subject { form.cm_affiliation_type(affiliation) }
 


### PR DESCRIPTION
**RATIONALE**
The previous Rails-based submission form required the user to check a checkbox if they did not intend to attach any supplemental files to their submission:
>**PREVIOUSLY**
>```
>    # Initial state for the 'No Supplemental Files' checkbox.
>    # Supplemental files aren't required for an ETD, but the
>    # form validation requires the user to explicitly check the
>    # 'No Supplemental Files' checkbox if they don't intend to
>    # add any additional files.
>```

**NOW**
The current JavaScript submission form no longer uses this mechanism to manage supplemental files; therefore, no code related to `no_supplemental_files` is called in the current version of the application.