### PR TITLE
[MAINTENANCE] Remove dead (boilerplate) code

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,6 @@ class User < ApplicationRecord
   include Hyrax::User
   include Hyrax::UserUsageStats
 
-  if Blacklight::Utils.needs_attr_accessible?
-    attr_accessible :ppid, :email, :password, :password_confirmation
-  end
-
   # this is fixing a strange bug, we never store anyone's shibboleth password
   if Hyrax::Actors::CreateWithRemoteFilesActor.needs_attr_accessible?
     attr_reader :password


### PR DESCRIPTION
**RATIONALE**
Blacklight adds redundant boilerplate code to the user model.

The attributes in question, `ppid`, `email`, and password fields, are already part of the model:
```
u.attributes.keys.sort
=> ["address", "admin_area", "affiliation", "arkivo_subscription", "arkivo_token", "avatar_content_type", "avatar_file_name", 
"avatar_file_size", "avatar_updated_at", "chat_id", "created_at", "current_sign_in_at", "current_sign_in_ip", "deactivated",
"department", "display_name", "email", "encrypted_password", "facebook_handle", "googleplus_handle", "guest", "id",
"last_sign_in_at", "last_sign_in_ip", "linkedin_handle", "office", "orcid", "ppid", "preferred_locale", "provider",
"remember_created_at", "reset_password_sent_at", "reset_password_token", "sign_in_count", "telephone", "title",
"twitter_handle", "uid", "updated_at", "website", "zotero_token", "zotero_userid"]
```