### PR TITLE
[MAINTENANCE] Remove dead code (boilerplate from generator)

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -201,10 +201,6 @@ end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
 
-Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
-Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
-Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
-
 Hyrax::EmbargoPresenter.class_eval do
   def sortable_release_date
     return solr_document.embargo_release_date&.iso8601 unless


### PR DESCRIPTION
**RATIONALE**
The Hyrax generator configures a number of local authorities in the hyrax initializer that are not used in this application.