### PR TITLE
[MAINTENANCE] Disable BrowseEverything functionality

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -188,15 +188,15 @@ Hyrax.config do |config|
   # config.binaries_directory = "tmp/binaries"
 
   # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
-  begin
-    if defined? BrowseEverything
-      config.browse_everything = BrowseEverything.config
-    else
-      Rails.logger.warn "BrowseEverything is not installed"
-    end
-  rescue Errno::ENOENT
-    config.browse_everything = nil
-  end
+  # begin
+  #   if defined? BrowseEverything
+  #     config.browse_everything = BrowseEverything.config
+  #   else
+  #     Rails.logger.warn "BrowseEverything is not installed"
+  #   end
+  # rescue Errno::ENOENT
+  #   config.browse_everything = nil
+  # end
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     end
   end
 
-  mount BrowseEverything::Engine => '/browse'
+  # mount BrowseEverything::Engine => '/browse'
   mount Hydra::RoleManagement::Engine => '/'
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'


### PR DESCRIPTION
**RATIONALE**
Emory no longer uses Box for large file uploads and has moved to Microsoft OneDrive for cloud file management instead.

BrowseEverthing does not provide OneDrive support, so we're currently disabling BrowseEverything in the application.