### PR TITLE
[REFACTOR] Add testing for SolrDocument

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -108,10 +108,6 @@ class SolrDocument
     self[Solrizer.solr_name('partnering_agency')]
   end
 
-  def pcdm_use
-    self[Solrizer.solr_name('pcdm_use')]
-  end
-
   def submitting_type
     self[Solrizer.solr_name('submitting_type')]
   end

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -26,10 +26,10 @@ class EtdPresenter < Hyrax::WorkShowPresenter
   # and ensure the views get it by setting it as the file_presenter_class in the EtdMemberPresenterFactory, and creating an Etd member factory here.
 
   def subfield
-    return unless solr_document['subfield_tesim']
-    id = solr_document['subfield_tesim'][0]
-    school = Schools::School.new(solr_document['school_tesim'][0])
-    dept = Schools::Department.new(school, solr_document['department_tesim'][0])
+    return unless solr_document.subfield
+    id = solr_document.subfield.first
+    school = Schools::School.new(solr_document.school.first)
+    dept = Schools::Department.new(school, solr_document.department.first)
 
     return unless dept.service
     Schools::Subfield.new(school, dept, id).label
@@ -86,6 +86,11 @@ class EtdPresenter < Hyrax::WorkShowPresenter
   def degree_awarded
     return "graduation pending" unless solr_document.degree_awarded
     solr_document.degree_awarded.to_date.strftime("%d %B %Y")
+  end
+
+  def proquest_submission_date
+    return unless solr_document.proquest_submission_date
+    solr_document.proquest_submission_date.first.to_date.strftime("%d %B %Y")
   end
 
   def submitting_type

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -23,6 +23,7 @@
       <%= presenter.attribute_to_html(:toc_embargoed, label: "Table of Contents Under Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:embargo_length, label: "Requested Embargo", include_empty: true)%>
       <%= presenter.attribute_to_html(:degree_awarded, label: "Degree Awarded")%>
+      <%= presenter.attribute_to_html(:proquest_submission_date, label: "Submitted to Proquest")%>
     <% end %>
   </tbody>
 </table>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -10,12 +10,10 @@
 
     <span>Permanent URL: <%= main_app.hyrax_etd_url(@presenter.id) %></span>
     <% if @presenter.current_ability_is_approver? %>
-    <br />
-    <span id="presenter-email">Email: <%= @presenter.post_graduation_email %></span>
+      <div id="presenter-email">Email: <%= @presenter.post_graduation_email %></div>
     <% end %>
     <% unless @presenter.workflow.state_label == 'Approved' %>
-      <br />
-      <span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
+      <div class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></div>
     <% end %>
   </div>
   <div class="col-sm-8">

--- a/spec/system/show_etd_spec.rb
+++ b/spec/system/show_etd_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe 'Display ETD metadata', integration: true, type: :system do
     @etd = FactoryBot.create(:sample_data_with_copyright_questions,
                         partnering_agency: ["CDC"],
                         school: ["Candler School of Theology"],
+                        department: ["Theological Studies"],
                         embargo_length: "6 months",
-                        files_embargoed: false,
+                        files_embargoed: true,
                         toc_embargoed: nil,
-                        abstract_embargoed: '')
+                        abstract_embargoed: '',
+                        proquest_submission_date: ['2023-06-16T00:00:00Z'])
     primary_pdf_file = "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf"
     supplementary_file_two = "#{::Rails.root}/spec/fixtures/miranda/image.tif"
 
@@ -46,9 +48,13 @@ RSpec.describe 'Display ETD metadata', integration: true, type: :system do
     expect(page).to have_content "Photographer (a portrait of the artist)"
     expect(page).not_to have_content etd.partnering_agency.first # Partnering agency should only display for Rollins
 
+    # Regular users should not see the copyright questions
     expect(page).not_to have_content I18n.t("hyrax.works.requires_permissions_label")
     expect(page).not_to have_content I18n.t("hyrax.works.other_copyrights_label")
     expect(page).not_to have_content I18n.t("hyrax.works.patents_label")
+
+    # Regular users should not see the Proquest submission date
+    expect(page).not_to have_content "Submitted to Proquest"
 
     # User email
     expect(page).not_to have_content("Email: ")
@@ -75,10 +81,13 @@ RSpec.describe 'Display ETD metadata', integration: true, type: :system do
     expect(page).to have_content "Email: "
 
     # Embargo questions
-    expect(find('li.attribute-files_embargoed')).to have_content false
+    expect(find('li.attribute-files_embargoed')).to have_content true
     expect(find('li.attribute-toc_embargoed')).to have_content false
     expect(find('li.attribute-abstract_embargoed')).to have_content false
     expect(page).to have_css('.attribute-embargo_length', text: '6 months')
+
+    # Proquest submission date
+    expect(page).to have_content(/Submitted to Proquest\s*16 June 2023/)
   end
 
   scenario "Etds show permission badges but FileSets don't" do
@@ -101,5 +110,23 @@ RSpec.describe 'Display ETD metadata', integration: true, type: :system do
 
     expect(find("td.attribute.filename a", match: :first)).to have_content etd.title.first.to_s
     expect(page).to have_content "Photographer (a portrait of the artist)"
+  end
+
+  describe 'Rollins submissions' do
+    let(:etd) {
+      FactoryBot.create(:sample_data,
+                                  school: ["Rollins School of Public Health"],
+                                  department: ["Biostatistics"],
+                                  subfield: ["Public Health Informatics"],
+                                  partnering_agency: ["CDC", "Hospital or other health care provider"])
+    }
+    scenario 'display subfield and partnering agencies' do
+      visit("/concern/etds/#{etd.id}")
+      expect(page).to have_content etd.subfield.first
+      expect(page).to have_content etd.partnering_agency[0] # can't guarantee order,
+      expect(page).to have_content etd.partnering_agency[1] # so test each separately
+
+      expect(page).not_to have_content 'Submitted to Proquest'
+    end
   end
 end


### PR DESCRIPTION
**RATIONALE**
The SolrDocument model was not completely covered by the test suite.

I also noticed that the presenter bypassed the model and pulled data directly from the document hash.

This change also displays the Proquest Submission Date to admin users.