### PR TITLE
[FIX] Masthead items should be clickable

### DIFF
--- a/app/assets/stylesheets/emory/_homepage.scss
+++ b/app/assets/stylesheets/emory/_homepage.scss
@@ -29,15 +29,14 @@
 #masthead-banner {
   position: absolute;
   width: 100%;
+  z-index: -1;
   text-align: center;
 
-  h2 {
-    font-family: $font-family-headings;
-    font-size: 8rem;
-    margin-bottom: 0;
-    margin-top: 2rem;
-    text-transform: uppercase;
-    color: $emory-light-gold;
-    font-weight: bold;
-  }
+  font-family: $font-family-headings;
+  font-size: 8rem;
+  margin-bottom: 0;
+  margin-top: 2rem;
+  text-transform: uppercase;
+  color: $emory-light-gold;
+  font-weight: bold;
 }

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,5 +1,8 @@
 <div id="masthead" class="navbar navbar-inverse navbar-static-top" role="banner">
   <div class="container-fluid">
+    <!-- Optional text to identify server environment - e.g. "STAGING" -->
+    <div id="masthead-banner"><%= ENV['BANNER'] -%></div>
+
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false">
@@ -10,8 +13,6 @@
       </button>
       <%= render '/logo' %>
     </div>
-
-    <div id="masthead-banner"><h2><%= ENV['BANNER'] -%></h2></div>
 
     <div class="collapse navbar-collapse" id="top-navbar-collapse">
       <%= render '/user_util_links' %>


### PR DESCRIPTION
**ISSUE**
The div containing the banner text defaulted to a z-index higher than the logo/repo name, so users could no longer click on the logo portion of the masthead to return to the homepage.

**RESOLUTION**
Update the CSS to ensure the text layer always sits behind other clickable elements on the masthead.