### PR TITLE
[MAINTENANCE] Remove dead code - EtdForm#no_committee_members

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -136,13 +136,6 @@ module Hyrax
       model.committee_chair.to_a
     end
 
-    def no_committee_members
-      str_committee_members = model.committee_members.to_a.join(',')
-      value = str_committee_members.count("a-zA-Z").zero?
-      empty_committee_members = value
-      model.persisted? && empty_committee_members
-    end
-
     def self.build_permitted_params
       permitted = super
       permitted << { committee_members_attributes: [:id, { name: [] }, { affiliation: [] }, :affiliation_type, { netid: [] }, :_destroy] }

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -131,33 +131,4 @@ RSpec.describe Hyrax::EtdForm do
       it { is_expected.to eq 'Non-Emory Committee Chair' }
     end
   end
-
-  # Figure out the correct state for the 'no committee members' checkbox on the ETD form.
-  describe "#no_committee_members" do
-    subject { form.no_committee_members }
-
-    context "ETD with no committee members" do
-      context "a new record" do
-        it { is_expected.to eq false }
-      end
-
-      context "an existing record" do
-        before { etd.save! }
-        it { is_expected.to eq true }
-      end
-    end
-
-    context "ETD with committee members" do
-      # let(:no_committee_members) {true}
-      let(:etd) { build(:ateer_etd) }
-      context "a new record" do
-        it { is_expected.to eq false }
-      end
-
-      context "an existing record" do
-        before { etd.save! }
-        it { is_expected.to eq false }
-      end
-    end
-  end
 end


### PR DESCRIPTION
**RATIONALE**
The submission and edit UI no longer uses a checkbox to indicate ETDs with no committe members. The JavaScript wizard just passes an empty array to the controller instead.