### PR TITLE
[MAINTENANCE] Remove dead code - obsolete methods

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -59,18 +59,6 @@ module Hyrax
       [:keyword, :research_field]
     end
 
-    def about_me_fields
-      [:creator, :graduation_date, :post_graduation_email]
-    end
-
-    def about_my_program_fields
-      [:school, :department, :subfield, :partnering_agency, :degree, :submitting_type]
-    end
-
-    def about_my_etd_fields
-      [:language, :abstract, :table_of_contents, :research_field]
-    end
-
     def primary_pdf_name
       model.primary_pdf_file_name
     end


### PR DESCRIPTION
**RATIONALE**
A number of EtdForm instance methods were replaced by class methods but not all of the instance methods were deleted from the codebase:
* about_me_fields *replaced by ==>* EtdForm.about_me_terms
* about_my_program_fields *replaced by ==>* EtdForm.my_program_terms
* about_my_etd_fields *replaced by ==>* EtdForm.my_etd_terms

The instance methods are no longer called and can be removed.