### PR TITLE
[REFACTOR] Make EtdFileSetPresenter agnostic about underlying hash

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -108,6 +108,10 @@ class SolrDocument
     self[Solrizer.solr_name('partnering_agency')]
   end
 
+  def pcdm_use
+    self[Solrizer.solr_name('pcdm_use')]&.first
+  end
+
   def submitting_type
     self[Solrizer.solr_name('submitting_type')]
   end

--- a/app/presenters/etd_file_set_presenter.rb
+++ b/app/presenters/etd_file_set_presenter.rb
@@ -4,11 +4,7 @@ class EtdFileSetPresenter < Hyrax::FileSetPresenter
            to: :solr_document
 
   def primary?
-    solr_document.fetch("pcdm_use_tesim", []).include?("primary")
-  end
-
-  def supplementary?
-    !primary?
+    pcdm_use == "primary"
   end
 
   def permission_badge


### PR DESCRIPTION
**RATIONALE**
We don't want the presenter to have to know details about the uderlying SolrDocument implementation like attribute suffixes.