### PR TITLE
[REFACTOR] Add test coverage for EmbargoSummaryReportNotification

### DIFF
--- a/spec/services/hyrax/workflow/embargo_summary_report_notification_spec.rb
+++ b/spec/services/hyrax/workflow/embargo_summary_report_notification_spec.rb
@@ -1,17 +1,41 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
-require 'workflow_setup'
 
-RSpec.describe Hyrax::Workflow::EmbargoSummaryReportNotification, :clean do
+RSpec.describe Hyrax::Workflow::EmbargoSummaryReportNotification do
+  let(:admins) { FactoryBot.build_list(:admin, 1) }
+  let(:notification_owner) { spy(User) }
+  let(:logger) { spy(Rails.logger) }
+
   before do
-    w = WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null")
-    w.setup
+    # Stub Role :admin
+    role = double(Role)
+    allow(Role).to receive(:find_by).with(name: 'admin').and_return(role)
+    allow(role).to receive(:users).and_return(admins)
+
+    # Stub WorkflowSetup::NOTIFICATION_OWNER
+    allow(User).to receive(:find_or_create_by).with(uid: WorkflowSetup::NOTIFICATION_OWNER).and_return(notification_owner)
+
+    # Stub logging
+    allow(Rails).to receive(:logger).and_return(logger)
   end
-  let(:notification) { described_class.new("subject", "message") }
-  context "invoke with a message and a subject" do
-    it "sends notifications to the super users and no one else" do
-      expect(notification.recipients.pluck(:uid)).to contain_exactly("superman001", "wonderwoman001", "tezprox")
+
+  describe '.send_notification' do
+    it 'is a class method that notifies super admins' do
+      described_class.send_notification('subject', 'message')
+      expect(notification_owner).to have_received(:send_message).with(admins.first, 'message', 'subject')
+    end
+
+    it 'logs the notifications' do
+      described_class.send_notification('subject', 'message')
+      expect(logger).to have_received(:warn).twice
+    end
+  end
+
+  describe 'with multiple super users' do
+    let(:notification) { described_class.new("subject", "message") }
+    let(:admins) { FactoryBot.build_list(:admin, 3) }
+
+    it 'sends to each super user' do
+      expect(notification.recipients.pluck(:uid)).to match_array(admins.map(&:uid))
     end
   end
 end


### PR DESCRIPTION
This change speeds up the tests by stubbing out only the necessary workflow components instead of setting up full workflows.

We also add tests for the class-level calling methods and check for the expected logging to improve test coverage.