### PR TITLE
[MAINTENANCE] Remove dead code - PROQUEST_NOTIFICATION_EMAIL

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
 export RAILS_HOST=localhost:3000
-export PROQUEST_NOTIFICATION_EMAIL=proquest@example.com
 
 export UPLOAD_PATH=tmp/uploads
 export CACHE_PATH=tmp/uploads/cache

--- a/app/services/hyrax/workflow/proquest_notification.rb
+++ b/app/services/hyrax/workflow/proquest_notification.rb
@@ -14,7 +14,7 @@ module Hyrax
       end
 
       def call
-        Rails.logger.warn "ProquestNotification sent to #{ENV['PROQUEST_NOTIFICATION_EMAIL']}: #{@message}"
+        Rails.logger.warn "ProquestNotification sent to #{recipients.map(&:email).join(', ')}: #{@message}"
         user = ::User.find_or_create_by(uid: WorkflowSetup::NOTIFICATION_OWNER)
         recipients.each do |recipient|
           user.send_message(recipient, @message, @subject)
@@ -24,15 +24,7 @@ module Hyrax
       # Send this to the application admins + proquest submission service
       def recipients
         admin_role = Role.find_by(name: "admin")
-        admin_role.users.to_a << proquest_user
-      end
-
-      def proquest_user
-        pu = ::User.find_or_create_system_user("proquest_user")
-        pu.display_name = "ProQuest ETD Submission Service"
-        pu.email = ENV['PROQUEST_NOTIFICATION_EMAIL']
-        pu.save
-        pu
+        admin_role.users.to_a
       end
     end
   end

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -8,7 +8,6 @@ export ACTION_MAILER_PORT=##YOUR DATA HERE##
 export ACTION_MAILER_USER_NAME=##YOUR DATA HERE##
 export ACTION_MAILER_PASSWORD=##YOUR DATA HERE##
 
-export PROQUEST_NOTIFICATION_EMAIL=PQ-DissertationETD@proquest.com
 export FAKE_DATA=true
 
 # Use local database auth instead of Shibboleth

--- a/spec/services/hyrax/workflow/proquest_notification_spec.rb
+++ b/spec/services/hyrax/workflow/proquest_notification_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hyrax::Workflow::ProquestNotification, :clean do
   context "invoke with a message and a subject" do
     it "sends notifications to the super users and proquest" do
       admin
-      expect(notification.recipients.pluck(:email)).to include(ENV['PROQUEST_NOTIFICATION_EMAIL'].downcase)
+      expect(notification.recipients.pluck(:email)).to include(admin.email)
     end
   end
 end


### PR DESCRIPTION
**RATIONALE**
There has been no PROQUEST_NOTIFICATION_EMAIL configured in the production environment for the duration of the project: it is not currently present in the production environment, and there is no evidence of this variable ever being set in the server build scripts.

Therefore the related production code always returns an empty string for the email address resulting in no message being sent to a proquest owned address such as PQ-DissertationETD@proquest.com.

## CURRENT PRODUCTION ENVIRONMENT
```
deploy@etd:/opt/laevigata/current$ RAILS_ENV=production bundle exec rails c
`Redis.current=` is deprecated and will be removed in 5.0. (called from: /opt/laevigata/releases/20240926180822/config/initializers/redis_config.rb:4:in `<top (required)>')
Loading production environment (Rails 5.2.8.1)
irb(main):001:0> ENV['PROQUEST_NOTIFICATION_EMAIL']
=> nil
```