### PR TITLE
[REFACTOR] Add test coverage for ProquestNotification

### DIFF
--- a/spec/services/hyrax/workflow/proquest_notification_spec.rb
+++ b/spec/services/hyrax/workflow/proquest_notification_spec.rb
@@ -1,18 +1,41 @@
-libdir = File.expand_path('../../../../', __FILE__)
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 require 'rails_helper'
 
-RSpec.describe Hyrax::Workflow::ProquestNotification, :clean do
+RSpec.describe Hyrax::Workflow::ProquestNotification do
+  let(:admins) { FactoryBot.build_list(:admin, 1) }
+  let(:notification_owner) { spy(User) }
+  let(:logger) { spy(Rails.logger) }
+
   before do
-    w = WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/candler_admin_sets.yml", "/dev/null")
-    w.setup
+    # Stub Role :admin
+    role = double(Role)
+    allow(Role).to receive(:find_by).with(name: 'admin').and_return(role)
+    allow(role).to receive(:users).and_return(admins)
+
+    # Stub WorkflowSetup::NOTIFICATION_OWNER
+    allow(User).to receive(:find_or_create_by).with(uid: WorkflowSetup::NOTIFICATION_OWNER).and_return(notification_owner)
+
+    # Stub logging
+    allow(Rails).to receive(:logger).and_return(logger)
   end
-  let(:notification) { described_class.new("subject", "message") }
-  let(:admin) { FactoryBot.create(:admin) }
-  context "invoke with a message and a subject" do
-    it "sends notifications to the super users and proquest" do
-      admin
-      expect(notification.recipients.pluck(:email)).to include(admin.email)
+
+  describe '.send_notification' do
+    it 'is a class method that notifies super admins' do
+      described_class.send_notification('subject', 'message')
+      expect(notification_owner).to have_received(:send_message).with(admins.first, 'message', 'subject')
+    end
+
+    it 'logs the notifications' do
+      described_class.send_notification('subject', 'message')
+      expect(logger).to have_received(:warn)
+    end
+  end
+
+  describe 'with multiple super users' do
+    let(:notification) { described_class.new("subject", "message") }
+    let(:admins) { FactoryBot.build_list(:admin, 3) }
+
+    it 'sends to each super user' do
+      expect(notification.recipients.pluck(:uid)).to match_array(admins.map(&:uid))
     end
   end
 end


### PR DESCRIPTION
This change speeds up the test by eliminating the workflow setup and stubbing the requried workflow components - i.e. we're testing the notification, not the workflow setup.

I've also added tests for the class-level calling methods to improve test coverage.