### PR TITLE
[MAINTENANCE] Resolve Blacklight::Document#dig deprecations

### DIFF
--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -57,7 +57,7 @@ class EtdPresenter < Hyrax::WorkShowPresenter
   # Return the post_graduation_email
   # NOTE: The field is defined as multivalued, but the application only stores a single value
   def post_graduation_email
-    solr_document.dig('post_graduation_email_tesim', 0)
+    solr_document.to_h.dig('post_graduation_email_tesim', 0)
   end
 
   # Disabling .ttl, jsonld and nt entirely, because these methods expose embargoed content.


### PR DESCRIPTION
**ISSUE**
DEPRECATION WARNING: Blacklight::Document#dig is deprecated; use obj.to_h.dig instead. (called from post_graduation_email at /Users/mark/_no_backup_/Projects/laevigata/app/presenters/etd_presenter.rb:60)

**RESOLTUION**
Update the code as indicated.