### PR TITLE
[REFACTOR] Add test coverage for ProquestJob sftp

### DIFF
--- a/spec/jobs/proquest_job_spec.rb
+++ b/spec/jobs/proquest_job_spec.rb
@@ -1,15 +1,11 @@
 require 'rails_helper'
-require 'workflow_setup'
 require 'hydra/file_characterization'
-include Warden::Test::Helpers
 include ActiveJob::TestHelper
 
 describe ProquestJob, :clean do
   context "Laney PhD" do
-    let(:w) { WorkflowSetup.new("#{fixture_path}/config/emory/superusers.yml", "#{fixture_path}/config/emory/laney_admin_sets.yml", "/dev/null") }
-    let(:etd) { FactoryBot.build(:ready_for_proquest_submission_phd) }
+    let(:etd) { FactoryBot.create(:ready_for_proquest_submission_phd, creator: ['Roberts, Bartholomew']) }
     let(:user) { User.find_by(ppid: etd.depositor) }
-    let(:ability) { ::Ability.new(user) }
     let(:file1_path) { "#{::Rails.root}/spec/fixtures/joey/joey_thesis.pdf" }
     let(:file1_fits) { "#{fixture_path}/spec/fixtures/joey/joey_thesis.fits.xml" }
     let(:upload1) do
@@ -31,23 +27,10 @@ describe ProquestJob, :clean do
     #     )
     #   end
     # end
-    # let(:attributes_for_actor) { { uploaded_files: [upload1.id, upload2.id] } }
-    let(:attributes_for_actor) { { uploaded_files: [upload1.id] } }
-    let(:approving_user) { User.where(ppid: 'laneyadmin').first }
-    before do
-      # Stub out Etd persistence calls
-      etd.save
-      allow(Etd).to receive(:find).and_return(etd)
-      allow(etd).to receive(:save!).and_return(etd)
-      allow(etd).to receive(:reload).and_return(etd)
+    let(:sftp_session) { spy(Net::SFTP::Session) }
 
-      env = Hyrax::Actors::Environment.new(etd, ability, attributes_for_actor)
-      stack = Hyrax::DefaultMiddlewareStack.build_stack
-      # Bypass AdminSet and Workflow processing to speed up tests
-      stack.middlewares.delete Hyrax::Actors::DefaultAdminSetActor
-      stack.middlewares.delete Hyrax::Actors::InitializeWorkflowActor
-      middleware = stack.build(Hyrax::Actors::Terminator.new)
-      middleware.create(env)
+    before do
+      # Attach files
       perform_enqueued_jobs(except: CreateDerivativesJob) do
         allow(Hydra::FileCharacterization).to receive(:characterize).with(an_instance_of(File), "joey_thesis.pdf", :fits).and_return(file1_fits)
         # allow(Hydra::FileCharacterization).to receive(:characterize).with(an_instance_of(File), "image.tif", :fits).and_return(file2_fits)
@@ -55,18 +38,33 @@ describe ProquestJob, :clean do
         AttachFilesToWorkJob.perform_now(etd, [upload1])
         # AttachFilesToWorkJob.perform_now(etd, [upload1, upload2])
       end
-      sipity_entity = double(Sipity::Entity)
-      allow(sipity_entity).to receive(:workflow_state_name).and_return('published')
+
+      # Stub workflow calls
+      sipity_entity = instance_double(Sipity::Entity)
+      allow(Etd).to receive(:find).with(etd.id).and_return(etd.reload)
       allow(etd).to receive(:to_sipity_entity).and_return(sipity_entity)
+      allow(sipity_entity).to receive(:workflow_state_name).and_return('published')
+
+      # Bypass workflow indexing - https://github.com/samvera/hyrax/blob/v2.9.6/app/indexers/hyrax/indexes_workflow.rb#L27
+      allow(PowerConverter).to receive(:convert_to_sipity_entity).with(etd).and_return(nil)
+      allow(PowerConverter).to receive(:convert_to_sipity_entity).with(sipity_entity).and_return(nil)
+
+      # Stub SFTP to proquest
+      allow(Net::SFTP).to receive(:start).and_yield(sftp_session)
     end
+
     context "#perform" do
       let(:grad_record) { { "home address 1" => "my place" } }
       it "persists the submission date", :aggregate_failures do
-        allow(etd).to receive(:save).and_return(true)
-
         expect(etd.submit_to_proquest?).to eq true
-        expect(etd.reload.proquest_submission_date).not_to be_present
-        described_class.perform_now(etd.id, grad_record, transmit: false, cleanup: true, retransmit: false)
+        expect(etd.proquest_submission_date).to be_blank
+
+        described_class.perform_now(etd.id, grad_record, transmit: true, cleanup: true, retransmit: false)
+
+        # It uploads to Proquest
+        # - first argument is the file path, wich should match the directory configured in `config/proquest.yml`
+        # - second argument is the file name, which shoud end in .zip
+        expect(sftp_session).to have_received(:upload!).with(/tmp\/proquest_exports\/test/, /upload_roberts_bartholomew_\w+.zip/)
 
         # Includes address from registrar data
         expect(etd.export_proquest_xml(grad_record)).to match(/my place/)


### PR DESCRIPTION
**ISSUE**
The test was set up not to send via SFTP, so we weren't testing all of the submission logic or the signature of the sftp call.

**RESOLUTION**
Add a stubbed SFTP service and test the call signature.

This change also removes unnecessary test setup and configuration.