### PR TITLE
[FIX] Admin Dashboard test is failing intermittently

### DIFF
--- a/spec/system/admin_dashboard_spec.rb
+++ b/spec/system/admin_dashboard_spec.rb
@@ -77,6 +77,9 @@ RSpec.describe 'Admin dashboard',
       fill_in 'etd_embargo_release_date', with: '2199-01-01'
       click_button 'Update Embargo'
 
+      # Ensure tubolinks has submitted the form data and refreshed the page
+      expect(page).to have_content(/Work "#{etd.title.first}" successfully updated./, wait: 10)
+
       etd.reload
       expect(etd.embargo_release_date).to eq Date.parse('2199-01-01')
       expect(etd.visibility).to eq VisibilityTranslator::FILES_EMBARGOED


### PR DESCRIPTION
**ISSUE**
The Admin Dashboard test is failing intermittently, but not consistently in local test and CI environments.

**DIAGNOSIS**
The test suite is sometimes proceeding to reload the ETD in the spec before turbolinks had submitted the form data.

**RESOLUTION**
Waiting for content that appears after the page refresh ensures that the JavaScript on the page has had time to finish executing and the application has recieved the form submission before proceeding with additional test steps.