### PR TITLE
[FIX] Use correct name for School of Nursing in GraduationService

### DIFF
--- a/app/services/graduation_service.rb
+++ b/app/services/graduation_service.rb
@@ -222,7 +222,7 @@ class GraduationService
     "Candler School of Theology" => "THEO",
     "Goizueta Business School" => "UBUS",
     "Rollins School of Public Health" => "PUBH",
-    "Woodruff School of Nursing" => "GNUR"
+    "Nell Hodgson Woodruff School of Nursing" => "GNUR"
   }.freeze
 end
 


### PR DESCRIPTION
**ISSUE**
Graduate Nursing students who graduated in April were not being recognized by the Graduation Service. Although their ETDs were approved by the school, the system was not processing them for publication.

**DIAGNOSIS**
The string used in the Graduation Service mapping did not match the complete school name used throughout the rest of the application, so the service was not generating the proper lookup key - e.g.
* Current(incorrect) lookup key: `P4658562-unrecognized school-DNP`
* Expected key in registrar file: `P4658562-GNUR-DNP`

**RESOLUTION**
Correct the name used in the GraduationService lookup.