### PR TITLE
Disable embargo expiration notifications

### DIFF
--- a/app/services/embargo_expiration_service.rb
+++ b/app/services/embargo_expiration_service.rb
@@ -32,7 +32,7 @@ class EmbargoExpirationService
 
   # Given a work, format it for inclusion in the summary report
   def format_for_summary_report(work)
-    "\n#{work.creator.first}. #{work.title.first} (#{document_path(work)})"
+    "\n  - #{work.creator.first}. #{work.title.first} (#{document_path(work)})"
   end
 
   def document_path(document)
@@ -41,9 +41,9 @@ class EmbargoExpirationService
   end
 
   def run
-    send_today_notifications
-    send_seven_day_notifications
-    send_sixty_day_notifications
+    # send_today_notifications
+    # send_seven_day_notifications
+    # send_sixty_day_notifications
     expire_embargoes
     send_summary_report
   end
@@ -80,9 +80,11 @@ class EmbargoExpirationService
   end
 
   def expire_embargoes
+    @summary_report << "\n\Processing current expirations for\n"
     expirations = find_expirations(0)
     expirations.each do |expiration|
-      Rails.logger.warn "ETD #{expiration.id}: Expiring embargo"
+      Rails.logger.warn(message: "EmbargoExpirationService: expiring embargo for ETD #{expiration.id}:",
+                        payload: { etd_id: expiration.id })
       expiration.visibility = expiration.visibility_after_embargo if expiration.visibility_after_embargo
       expiration.deactivate_embargo!
       expiration.embargo.save
@@ -92,6 +94,7 @@ class EmbargoExpirationService
         fs.deactivate_embargo!
         fs.save
       end
+      @summary_report << format_for_summary_report(expiration)
     end
   end
 

--- a/spec/services/embargo_expiration_service_spec.rb
+++ b/spec/services/embargo_expiration_service_spec.rb
@@ -204,11 +204,11 @@ describe EmbargoExpirationService, :clean do
     end
     it "creates a summary report" do
       service.run
-      expect(Hyrax::Workflow::SixtyDayEmbargoNotification).to have_received(:send_notification)
-      expect(Hyrax::Workflow::SevenDayEmbargoNotification).to have_received(:send_notification)
-      expect(Hyrax::Workflow::TodayEmbargoNotification).to have_received(:send_notification)
-      expect(service.summary_report).to match(/#{etd1.id}/)
-      expect(service.summary_report).to match(/#{etd2.id}/)
+      expect(Hyrax::Workflow::SixtyDayEmbargoNotification).not_to have_received(:send_notification)
+      expect(Hyrax::Workflow::SevenDayEmbargoNotification).not_to have_received(:send_notification)
+      expect(Hyrax::Workflow::TodayEmbargoNotification).not_to have_received(:send_notification)
+      expect(service.summary_report).not_to match(/#{etd1.id}/)
+      expect(service.summary_report).not_to match(/#{etd2.id}/)
       expect(service.summary_report).to match(/#{etd3.id}/)
     end
     it "sends the summary report" do


### PR DESCRIPTION
Per discussions with SCO, they wish to reduce administrative overhead by eliminating embargo expiration notifications.

We still need to process actual embargo expirations to change the corresponding ETDs from a restricted to open status.

Therefore, this change leaves the schedule and service code in place and simply comments out the calls to notification processing so that we still get nightly expiration processing.