### PR TITLE
Add a clearer message when no embargos need to be processed

### DIFF
--- a/app/services/embargo_expiration_service.rb
+++ b/app/services/embargo_expiration_service.rb
@@ -26,7 +26,7 @@ class EmbargoExpirationService
 
   def initialize(date)
     @date = date
-    @summary_report = "Summary embargo report for #{date}\n"
+    @summary_report = "Summary embargo report for #{date} \n"
     @summary_report_subject = "ETD embargos summary: #{date}"
   end
 
@@ -80,8 +80,9 @@ class EmbargoExpirationService
   end
 
   def expire_embargoes
-    @summary_report << "\n\Processing current expirations for\n"
     expirations = find_expirations(0)
+    @summary_report << "\n\nProcessing current expirations\n"
+    @summary_report << "\n\n  - no expirations occuring today\n" if expirations.count == 0
     expirations.each do |expiration|
       Rails.logger.warn(message: "EmbargoExpirationService: expiring embargo for ETD #{expiration.id}:",
                         payload: { etd_id: expiration.id })


### PR DESCRIPTION
**ISSUE**
The EmbargoExpirationService sends a summary message to admins. When we updated the service to stop sending advanced notifications, we added code to report which embargos were being expired.

However, if no embargos needed to be handled, the report language looked incomplete and confusing.

**RESOLTION**
This change adds explicit messaging when there are no embargos to be processed.