### PR TITLE
Remove deprecated calls to `Redis.current`

### DIFF
--- a/app/patches/local_overrides/lock_manager.rb
+++ b/app/patches/local_overrides/lock_manager.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Override Hyrax::LockManager#initialize
+# to avoid deprecated calls to `Redis.current`
+
+module LocalOverrides
+  module LockManager
+    def self.included(k)
+      k.class_eval do
+        def initialize(time_to_live, retry_count, retry_delay)
+          @ttl = time_to_live
+          @client = Redlock::Client.new([Hyrax::RedisEventStore.instance], retry_count: retry_count, retry_delay: retry_delay)
+        end
+      end
+    end
+  end
+end

--- a/app/patches/local_overrides/redis_event_store.rb
+++ b/app/patches/local_overrides/redis_event_store.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Override Hyrax::RedisEventStore#instance
+# to avoid deprecated calls to `Redis.current`
+
+module LocalOverrides
+  module RedisEventStore
+    def self.included(k)
+      k.class_eval do
+        def self.instance
+          @instance ||= Redis::Namespace.new(namespace, redis: Redis.new(REDIS_CONFIG))
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/patches.rb
+++ b/config/initializers/patches.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ActiveSupport::Reloader.to_prepare do
+  # Patch engine and gem classes here, so this gets called on reload
+  # to re-patch the newly redefined classes
+  Hyrax::RedisEventStore.include(LocalOverrides::RedisEventStore)
+  Hyrax::LockManager.include(LocalOverrides::LockManager)
+end

--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
+
 require 'redis'
-config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
-Redis.silence_deprecations
-Redis.current = Redis.new(config.merge(thread_safe: true))
+
+REDIS_CONFIG = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access


### PR DESCRIPTION
**ISSUE**
Our logs are being swamped with deprecation messages similar to:
```
`Redis.current` is deprecated and will be removed in 5.0.
  (called from: /Users/mark/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems
   /hyrax-2.9.6/lib/hyrax/redis_event_store.rb:26:in `instance')
```

**RESOLUTION**
Refactor the redis initilizer and override Hyrax class methods that call `Redis.current` in favor of a memoized call to `Redis.new`

**REFERENCES**
This commit was heavily influenced by
https://github.com/samvera/hyrax/commit/50cc8f0f