### PR TITLE
Fix redlock deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
     coffee-script-source (1.12.2)
     commonjs (0.2.7)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
+    connection_pool (2.5.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -802,10 +802,12 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.8.1)
-    redis-namespace (1.8.1)
-      redis (>= 3.0.4)
-    redlock (1.2.1)
-      redis (>= 3.0.0, < 5.0)
+    redis-client (0.25.0)
+      connection_pool
+    redis-namespace (1.11.0)
+      redis (>= 4)
+    redlock (2.0.6)
+      redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.0.3)
     representable (3.1.1)
       declarative (< 0.1.0)

--- a/app/patches/local_overrides/lock_manager.rb
+++ b/app/patches/local_overrides/lock_manager.rb
@@ -9,7 +9,8 @@ module LocalOverrides
       k.class_eval do
         def initialize(time_to_live, retry_count, retry_delay)
           @ttl = time_to_live
-          @client = Redlock::Client.new([Hyrax::RedisEventStore.instance], retry_count: retry_count, retry_delay: retry_delay)
+          redis_uri = Hyrax::RedisEventStore.instance.redis.id
+          @client = Redlock::Client.new([redis_uri], retry_count: retry_count, retry_delay: retry_delay)
         end
       end
     end


### PR DESCRIPTION
**ISSUE**
After the `Redis.current` fix, we are now seeing significant numbers of deprecations warnings like:
```
Passing 'call' command to redis as is; blind passthrough has been
  deprecated and will be removed in redis-namespace 2.0
  (at /Users/mark/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/
   redlock-2.0.6/lib/redlock/client.rb:214:in `block (2 levels) in unlock')
```

**DIAGNOSIS**
We were passing a RedisNamespace object to Redlock instead of a plain Redis connection specifier. RedisNamespace was complaining any time an admin (not-namespace-able) command was received.

**RESOLUTION**
Pass a Redis URI to RedLock instead of a RedisNamespace object.