### PR TITLE
Update deployment files to support SSM

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,4 +1,0 @@
-# deploys to Emory production machine
-set :stage, :prod
-set :rails_env, 'production'
-server '13.59.122.177', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,4 +1,0 @@
-# deploys to Emory qa machine
-set :stage, :qa
-set :rails_env, 'production'
-server 'qa-etd.library.emory.edu', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/ssm.rb
+++ b/config/deploy/ssm.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# deploys to Emory servers via ssm
+# defaults to Staging environment
+# To set a target environment, the instance must be tagged in Gov Cloud:
+#   Project=ETD Service
+#   Environment=Production | Staging | QA | etc.
+# Invoke the deploy command with the HOST_ENV variable specifying the desired environment, e.g.
+#   HOST_ENV=Production bundle exec cap ssm deploy
+# Alternatively, invoke the command with the HOST_ID variable set to a valid  EC2 instance ID, e.g.
+#   HOST_ID=i-0abcdef1234567890 bundle exec cap ssm deploy
+
+require 'net/ssh/proxy/command'
+set :rails_env, 'production'
+set :host_env, -> { ENV['HOST_ENV'] || 'stage' }
+set :instance_id, lambda {
+                    ENV['HOST_ID'] ||
+                      `aws ec2 describe-instances --region us-east-2  --profile emory-etd \
+                                           --filters Name=tag-key,Values=Environment Name=tag-value,Values=#{fetch(:host_env)} Name=instance-state-name,Values=running \
+                                           Name=tag-key,Values=Project Name=tag-value,Values="ETD Service" \
+                                           --query "Reservations[*].Instances[*].InstanceId" --output text`.chomp
+}
+server fetch(:instance_id), user: 'deploy', roles: [:web, :app, :db, :worker]
+set :command, %(aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p' --profile emory-etd)
+set :ssh_options,
+  auth_methods: %w[publickey],
+  forward_agent: true,
+  proxy: Net::SSH::Proxy::Command.new(fetch(:command))

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,4 +1,0 @@
-# deploys to Emory Staging machine
-set :stage, :staging
-set :rails_env, 'production'
-server 'staging-etd.library.emory.edu', user: 'deploy', roles: [:web, :app, :db]


### PR DESCRIPTION
We have updated the ETD environments to run on private networks that now require AWS SSM for connections.

This update allows us to connect to an server by its InstanceID or Environment tag value.