### PR TITLE
Dynamically generate the environment banner

### DIFF
--- a/app/assets/stylesheets/emory/_homepage.scss
+++ b/app/assets/stylesheets/emory/_homepage.scss
@@ -31,14 +31,14 @@
   margin-bottom: 0.5rem;
 }
 
-#masthead-banner {
+#environment_badge {
   position: absolute;
   width: 100%;
   z-index: -1;
   text-align: center;
 
   font-family: $font-family-headings;
-  font-size: 8rem;
+  font-size: 7rem;
   margin-bottom: 0;
   margin-top: 2rem;
   text-transform: uppercase;

--- a/app/lib/runtime_info.rb
+++ b/app/lib/runtime_info.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'aws-sdk-core'
+require 'aws-sdk-core/ec2_metadata'
+
+include ActionView::Helpers::TagHelper
+
+class RuntimeInfo
+  TAG_MAPPER = { 'prod' => 'production', 'stage' => 'staging', 'qa' => 'qa testing' }.freeze
+
+  class << self
+    def badge
+      @badge ||= tag.div(environment.titleize, id: 'environment_badge', class: display_class)
+    end
+
+    def environment
+      TAG_MAPPER[environment_tag] || environment_tag || Rails.env
+    end
+
+    private
+
+    def display_class
+      'hidden' if environment_tag == 'prod'
+    end
+
+    def environment_tag
+      return nil unless ec2?
+      begin
+        metadata_client = Aws::EC2Metadata.new
+        metadata_client.get('/latest/meta-data/tags/instance/Environment')
+      rescue Aws::EC2Metadata::MetadataNotFoundError
+        'tag missing'
+      rescue Errno::EHOSTDOWN, Net::OpenTimeout, Errno::EHOSTUNREACH
+        # just return nil without an exception
+      end
+    end
+
+    def ec2?
+      File.exist?('/sys/devices/virtual/dmi/id/bios_vendor') &&
+        File.read('/sys/devices/virtual/dmi/id/bios_vendor').match(/EC2/)
+    end
+  end
+end

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,7 +1,7 @@
 <div id="masthead" class="navbar navbar-inverse navbar-static-top" role="banner">
   <div class="container-fluid">
     <!-- Optional text to identify server environment - e.g. "STAGING" -->
-    <div id="masthead-banner"><%= ENV['BANNER'] -%></div>
+    <%= RuntimeInfo.badge -%>
 
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">

--- a/spec/lib/runtime_info_spec.rb
+++ b/spec/lib/runtime_info_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RuntimeInfo do
+  describe '.environment' do
+    describe 'in AWS environments' do
+      let(:response) { nil }
+
+      before do
+        allow(described_class).to receive(:ec2?).and_return(true)
+
+        # stub an EC2Metadata object
+        metadata_service = instance_double(Aws::EC2Metadata)
+        # stub the metadata service
+        allow(Aws::EC2Metadata).to receive(:new).and_return(metadata_service)
+        # stub metadata responses
+        allow(metadata_service).to receive(:get).and_return(response)
+      end
+
+      context 'with tag:Environment=prod' do
+        let(:response) { 'prod' }
+        it 'returns "Production"' do
+          expect(described_class.environment).to eq('production')
+        end
+      end
+
+      context 'with tag:Environment=stage' do
+        let(:response) { 'stage' }
+        it 'returns "Staging"' do
+          expect(described_class.environment).to eq('staging')
+        end
+      end
+
+      context 'with tag:Environment=qa' do
+        let(:response) { 'qa' }
+        it 'returns "quality assurance"' do
+          expect(described_class.environment).to eq('qa testing')
+        end
+      end
+
+      context 'with tag:Environment=any other string' do
+        let(:response) { 'any_other_string' }
+        it 'returns the tag' do
+          expect(described_class.environment).to eq('any_other_string')
+        end
+      end
+
+      context 'with no Environment tag' do
+        before do
+          # stub an EC2Metadata object
+          metadata_service = instance_double(Aws::EC2Metadata)
+          # stub the metadata service
+          allow(Aws::EC2Metadata).to receive(:new).and_return(metadata_service)
+          # stub metadata responses
+          allow(metadata_service).to receive(:get).and_raise(Aws::EC2Metadata::MetadataNotFoundError)
+        end
+
+        it 'returns the Rails environment' do
+          expect(described_class.environment).to match('missing')
+        end
+      end
+    end
+
+    describe 'in local environments' do
+      before do
+        allow(Rails).to receive(:env).and_return('test')
+
+        # stub an EC2Metadata object
+        metadata_service = instance_double(Aws::EC2Metadata)
+        # stub the metadata service
+        allow(Aws::EC2Metadata).to receive(:new).and_return(metadata_service)
+        # speed up failures
+        allow(metadata_service).to receive(:get).and_raise(Errno::EHOSTDOWN)
+      end
+
+      context 'in test' do
+        it 'returns the Rails environment' do
+          expect(described_class.environment).to eq('test')
+        end
+      end
+
+      context 'in development' do
+        before do
+          allow(Rails).to receive(:env).and_return('development')
+        end
+
+        it 'returns the Rails environment' do
+          expect(described_class.environment).to eq('development')
+        end
+      end
+    end
+
+    describe '.badge' do
+      before do
+        described_class.instance_variable_set(:@badge, nil)
+      end
+
+      context 'in EC2 production environments' do
+        before do
+          allow(described_class).to receive(:ec2?).and_return(true)
+          allow(described_class).to receive(:environment_tag).and_return('prod')
+        end
+
+        it 'returns a hidden div' do
+          expect(described_class.badge).to match(/class="hidden"/)
+        end
+      end
+
+      context 'in non-EC2 environments' do
+        it 'returns the rails environment' do
+          expect(described_class.badge).to match(/>Test</)
+        end
+
+        it 'is not hidden' do
+          expect(described_class.badge).not_to match(/class="hidden"/)
+        end
+      end
+
+      context 'in other environments' do
+        before do
+          allow(described_class).to receive(:environment_tag).and_return('testing qa3')
+          allow(described_class).to receive(:ec2?).and_return(true)
+        end
+
+        it 'returns a div tag with the expected ID' do
+          expect(described_class.badge).to match('<div id="environment_badge"')
+        end
+
+        it 'capitalizes the envioronment name' do
+          expect(described_class.badge).to match('Testing Qa3')
+        end
+      end
+    end
+  end
+end

--- a/spec/views/masthead.html.erb_spec.rb
+++ b/spec/views/masthead.html.erb_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe "_masthead", type: :view do
   end
 
   it "dsiplays the BANNER environment variable" do
-    allow(ENV).to receive(:[]).with('BANNER').and_return('banner_text')
-
     render
-    expect(rendered).to have_content('banner_text')
+    expect(rendered).to have_selector('div', id: 'environment_badge', text: 'Test')
   end
 end


### PR DESCRIPTION
**ISSUE**
We would like to automatically generate the environment header in all environments instead of having to rely on an environment variable.

**RESOLUTION**
Dynamically check for an EC2 tag named "Environment" and display it's value in the page header. If no tag is available, use the Rails environment - e.g. "Development", or "Test".

**EXAMPLE**
<img width="1671" height="128" alt="image" src="https://github.com/user-attachments/assets/ec2978f3-7136-4631-b71a-74cd3002a78c" />
