### PR TITLE
Allow super_admins to edit InProgressEtds

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -22,6 +22,7 @@ class InProgressEtdsController < ApplicationController
       authorize! :update, @in_progress_etd
       @in_progress_etd.refresh_from_etd!
       @data = @in_progress_etd.data
+      @form_level = form_level
     end
   rescue ActiveRecord::RecordNotFound
     redirect_to root_url
@@ -67,5 +68,12 @@ class InProgressEtdsController < ApplicationController
 
       # Add the new data to the existing persisted data
       @in_progress_etd.add_data(new_data)
+    end
+
+    # Show :basic form for regular users - e.g. active field values only
+    # Or :advanced form for super_admins - e.g. also show inactive fields values
+    def form_level
+      return :advanced if current_user.admin?
+      :basic
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,6 +37,7 @@ class Ability
   def ipe_permissions
     can :create, InProgressEtd if registered_user?
     can :update, InProgressEtd, user_ppid: current_user.ppid
+    can :manage, InProgressEtd if admin?
 
     # A user who has permission to edit the corresponding Etd should be able to edit the InProgressEtd. (e.g. admin users, proxy permissions, etc)
     can :update, InProgressEtd do |ipe|

--- a/spec/controllers/in_progress_etds_controller_spec.rb
+++ b/spec/controllers/in_progress_etds_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe InProgressEtdsController, type: :controller do
+RSpec.describe InProgressEtdsController, type: :controller, aggregate_failures: true do
   let(:student) { FactoryBot.create(:user) }
   let(:another_user) { FactoryBot.create(:user) }
 
@@ -51,23 +51,32 @@ RSpec.describe InProgressEtdsController, type: :controller do
     end
 
     describe 'GET EDIT' do
-      let(:ipe) { InProgressEtd.create(user_ppid: another_user.ppid, etd_id: etd.id) }
-
-      context 'with permission to edit Etd' do
-        let(:etd) { FactoryBot.create(:etd, user: another_user, edit_users: [student.user_key]) }
-
+      context 'for the owner of the ipe' do
         it 'displays edit form' do
           get :edit, params: { id: ipe.id }
+          expect(response).to have_http_status(:success)
           expect(response).to render_template(:edit)
+          expect(assigns(:form_level)).to eq :basic
         end
       end
 
-      context 'without permission to edit Etd' do
-        let(:etd) { FactoryBot.create(:etd, user: another_user) }
-
+      context "for someone else's ipe" do
+        let(:ipe) { InProgressEtd.create(user_ppid: another_user.ppid) }
         it 'denies access' do
           get :edit, params: { id: ipe.id }
-          expect(response.status).to eq 401 # Unauthorized
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'for super_admins' do
+        let(:admin) { FactoryBot.create(:admin) }
+        before { sign_in admin }
+
+        it 'sends the advanced view flag' do
+          expect(ipe.user_ppid).not_to eq admin.ppid
+          get :edit, params: { id: ipe.id }
+          expect(response).to have_http_status(:success)
+          expect(assigns(:form_level)).to eq :advanced
         end
       end
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -41,4 +41,13 @@ describe Ability do
       end
     end
   end # a student
+
+  describe 'a super_admin' do
+    let(:current_user) { admin }
+    let(:student_ipe) { InProgressEtd.new(user_ppid: student.ppid) }
+
+    it 'can edit a student ipe' do
+      expect(current_ability.can?(:update, student_ipe)).to eq true
+    end
+  end
 end


### PR DESCRIPTION
**ISSUE**
We want super_admins to be able to access inactive field values (like previous semesters) in the ETD editing form (handled as InProgressEtds).

As initial steps, we need to:
1. Allow super_admins to edit & update any student's IPE
2. Send a flag to the VUE form to indicate whether to render active field values only (for regular users) or both active and inactive field values (for super_admins)