### PR TITLE
Refactor approver checks to make them easier to stub in tests

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,11 +7,11 @@ class Ability
   def custom_permissions
     if can_review_submissions?
       can [:manage], String do |id|
-        approver_for?(admin_set: ActiveFedora::Base.find(id)&.admin_set)
+        approver_for?(ActiveFedora::Base.find(id)&.admin_set)
       end
 
       can [:manage], ActiveFedora::Base do |obj|
-        approver_for?(admin_set: obj.admin_set)
+        approver_for?(obj.admin_set)
       end
     end
     return unless admin?
@@ -62,17 +62,15 @@ class Ability
     true
   end
 
-  private
+  # Does the current user have the 'approving' role for a specific workflows?
+  # @return [Boolean]
+  def approver_for?(admin_set)
+    PermissionChecker.user_can_approve_admin_set?(current_user, admin_set)
+  end
 
-    def approver_for?(admin_set:)
-      return false unless admin_set
-
-      workflow = admin_set.active_workflow
-      Hyrax::Workflow::PermissionQuery
-        .scope_processing_workflow_roles_for_user_and_workflow(user:     @user,
-                                                               workflow: workflow)
-        .pluck(:role_id)
-        .map { |id| Sipity::Role.find(id).name }
-        .include?('approving')
-    end
+  # Does the current user have the 'approving' role in any workflows?
+  # @return [Boolean]
+  def can_review_submissions?
+    PermissionChecker.sipity_approver?(current_user)
+  end
 end

--- a/app/services/permission_checker.rb
+++ b/app/services/permission_checker.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class PermissionChecker
+  # Check whether a user has 'approving' role in any workflows
+  # @return [Boolean]
+  def self.sipity_approver?(user)
+    return false unless user.is_a?(User) && user.persisted?
+
+    user.to_sipity_agent.workflow_responsibilities.joins(workflow_role: :role)
+        .where(sipity_roles: { name: Hyrax::RoleRegistry::APPROVING })
+        .present?
+  end
+
+  # Check whether a user has the 'approving' role for an admin_set
+  # @return [Boolean]
+  def self.user_can_approve_admin_set?(user, admin_set)
+    # ensure params are valid
+    return false unless user.is_a?(User) && user.persisted?
+    return false unless admin_set.is_a?(AdminSet) && admin_set.active_workflow.persisted?
+
+    # bypass Sipity checks for Super Admins
+    return true if user.admin?
+
+    # Check Sipity workflows to see the if user is an approver for the admin set
+    #
+    # This long chain allows us to make a single database call for a complex set
+    # of relations:
+    # User --> Sipity::Agent
+    #   --> Sipity::WorkflowResponsibility
+    #     --> Sipity::WorkflowRole
+    #       ?--> Siplity::Role (='approving')
+    #       ?--> Sipity::Workflow (=admin_set.active_workflow)
+    user.to_sipity_agent.workflow_responsibilities.joins(workflow_role: :role)
+        .where(sipity_roles: { name: Hyrax::RoleRegistry::APPROVING },
+               sipity_workflow_roles: { workflow_id: admin_set.active_workflow.id })
+        .present?
+  end
+end

--- a/spec/fixtures/config/emory/admin_sets_school_department.yml
+++ b/spec/fixtures/config/emory/admin_sets_school_department.yml
@@ -1,0 +1,7 @@
+Emory College:
+  approving:
+   - school_approver
+
+Applied Epidemiology:
+  approving:
+    - department_approver

--- a/spec/fixtures/config/emory/superusers_db_only.yml
+++ b/spec/fixtures/config/emory/superusers_db_only.yml
@@ -1,0 +1,3 @@
+superusers:
+  database:
+   - super_admin

--- a/spec/fixtures/config/workflows/minimal_one_step_approval.json
+++ b/spec/fixtures/config/workflows/minimal_one_step_approval.json
@@ -1,0 +1,51 @@
+{
+  "workflows": [
+    {
+      "name": "emory_one_step_approval",
+      "label": "One-step approval tailored for Emory",
+      "description": "A single-step workflow for mediated deposit in which all deposits must be approved by an approver. Approver may also send deposits back to the depositor, comment on the work, and hide or unhide a work.",
+      "allows_access_grant": false,
+      "actions": [
+        {
+          "name": "deposit",
+          "from_states": [],
+          "transition_to": "pending_approval",
+          "notifications": [
+            {
+              "notification_type": "email",
+              "name": "Hyrax::Workflow::PendingApprovalNotification",
+              "to": ["approving", "depositing"]
+            }
+          ],
+          "methods": [
+            "Hyrax::Workflow::DeactivateObject",
+            "Hyrax::Workflow::RevokeEditFromDepositor",
+            "Hyrax::Workflow::GrantReadToDepositor"
+          ]
+        }, {
+          "name": "approve",
+          "from_states": [{"names": ["pending_approval"], "roles": ["approving"]}],
+          "transition_to": "approved",
+          "notifications": [
+            {
+              "notification_type": "email",
+              "name": "Hyrax::Workflow::ApprovedNotification",
+              "to": ["approving", "depositing"]
+            }
+          ],
+          "methods": [
+            "Hyrax::Workflow::GrantReadToDepositor",
+            "Hyrax::Workflow::RevokeEditFromDepositor"
+          ]
+        }, {
+          "name": "publish",
+          "from_states": [{"names": ["approved"], "roles": []}],
+          "transition_to": "published",
+          "methods": [
+            "Hyrax::Workflow::ActivateObject"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/services/permission_checker_spec.rb
+++ b/spec/services/permission_checker_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe PermissionChecker, use_transactional_tests: false do
+  before(:all) do
+    # Workflow setup is extremely expensive (i.e. makes many, many slow database calls).
+    # The tests we want to run are essentially read-only access checks.
+    # So, the state of our workflows does not change between tests
+    # Therefore, we're explicitly setting up workflows once before all tests and
+    # then rolling back changes after all tests have executed.
+
+    # Wrap the entire context in a transaction
+    ActiveRecord::Base.connection.begin_transaction
+
+    # Set Up Workflows
+    Hyrax::Workflow::WorkflowImporter.path_to_workflow_files = "#{fixture_path}/config/workflows/minimal_one_step_approval.json"
+    WorkflowSetup.new("#{fixture_path}/config/emory/superusers_db_only.yml", "#{fixture_path}/config/emory/admin_sets_school_department.yml", "/dev/null").setup
+  end
+
+  after(:all) do
+    # Roll back the transaction started in before(:all)
+    ActiveRecord::Base.connection.rollback_transaction if ActiveRecord::Base.connection.transaction_open?
+    Hyrax::Workflow::WorkflowImporter.path_to_workflow_files = Rails.root.join('config', 'workflows', '*.json')
+  end
+
+  describe '.has_approver_role?' do
+    let(:permission_check) { ->(user) { described_class.sipity_approver?(user) } }
+
+    example 'for super_admins' do
+      super_admin = User.find_by(uid: 'super_admin')
+      expect(described_class.sipity_approver?(super_admin)).to be true
+    end
+
+    example 'for workflow-level approvers' do
+      department_admin = User.find_by(uid: 'department_approver')
+      expect(described_class.sipity_approver?(department_admin)).to be true
+    end
+
+    example 'for regular users' do
+      student_user = FactoryBot.create(:user)
+      expect(described_class.sipity_approver?(student_user)).to be false
+    end
+
+    example 'for unsaved users' do
+      new_user = FactoryBot.build(:user)
+      expect(described_class.sipity_approver?(new_user)).to be false
+    end
+  end
+
+  describe '.user_can_approve_admin_set?' do
+    let(:permission_check) { ->(user, admin_set) { described_class.user_can_approve_admin_set?(user, admin_set) } }
+
+    context 'for super_admins' do
+      let(:super_admin) { User.find_by(uid: 'super_admin') }
+      let(:admin_set) { AdminSet.where(title: 'Applied Epidemiology').first }
+      it 'can approve any admin set' do
+        expect(permission_check.call(super_admin, admin_set)).to be true
+      end
+    end
+
+    context 'for admin set approvers' do
+      let(:school_admin) { User.find_by(uid: 'school_approver') }
+      let(:admin_set) { AdminSet.where(title: 'Emory College').first }
+      it 'can approve associated admin set' do
+        expect(permission_check.call(school_admin, admin_set)).to be true
+      end
+    end
+
+    context 'for other approvers' do
+      let(:department_admin) { User.find_by(uid: 'department_approver') }
+      let(:admin_set) { AdminSet.where(title: 'Emory College').first }
+      it 'can NOT approve other admin sets' do
+        expect(permission_check.call(department_admin, admin_set)).to be false
+      end
+    end
+
+    context 'for regular users' do
+      let(:student_user) { FactoryBot.create(:user) }
+      let(:admin_set) { AdminSet.where(title: 'Emory College').first }
+      it 'can NOT approve other admin sets' do
+        expect(permission_check.call(student_user, admin_set)).to be false
+      end
+    end
+
+    context 'for tranient users' do
+      let(:admin_set) { AdminSet.where(title: 'Emory College').first }
+      it 'can NOT approve admin sets' do
+        expect(permission_check.call(User.new, admin_set)).to be false
+      end
+    end
+
+    context 'when user is invalid' do
+      let(:user) { Hyrax::Group.new('Not a User') } # i.e. anything that is no a User
+      let(:admin_set) { AdminSet.where(title: 'Emory College').first }
+      it 'returns false' do
+        expect(permission_check.call(user, admin_set)).to be false
+      end
+    end
+
+    context 'when admin set is invalid' do
+      let(:super_admin) { FactoryBot.build(:admin) }
+      let(:admin_set) { InProgressEtd.new } # i.e. anything that is not an AdminSet
+      it 'returns false' do
+        expect(permission_check.call(super_admin, admin_set)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
**ISSUE**
1. We would like to leverage existing ability checks when implementing new functionality in the InProgressEtd Controller.
2. The current logic relies on long db query chains that are difficult and complex to stub for testing.

**RESOLUTION**
1. Make the ability checks part of the public API.
2. Encapsulate the permission logic in a service class that can be easily stubbed.