### PR TITLE
Allow school and department approvers to edit InProgressEtds

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -74,6 +74,7 @@ class InProgressEtdsController < ApplicationController
     # Or :advanced form for super_admins - e.g. also show inactive fields values
     def form_level
       return :advanced if current_user.admin?
+      return :advanced if current_ability.can_review_submissions?
       :basic
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,6 +38,11 @@ class Ability
     can :create, InProgressEtd if registered_user?
     can :update, InProgressEtd, user_ppid: current_user.ppid
     can :manage, InProgressEtd if admin?
+    if can_review_submissions?
+      can :manage, InProgressEtd do |ipe|
+        approver_for?(ipe.admin_set)
+      end
+    end
 
     # A user who has permission to edit the corresponding Etd should be able to edit the InProgressEtd. (e.g. admin users, proxy permissions, etc)
     can :update, InProgressEtd do |ipe|

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -170,6 +170,16 @@ class InProgressEtd < ApplicationRecord
     save!
   end
 
+  # Find and return the admin set associated with the School or Department
+  # @return [AdminSet]
+  def admin_set
+    return @admin_set if @admin_set
+    etd_data = JSON.parse(data)
+    school = etd_data['school']
+    department = etd_data['department']
+    @admin_set ||= AdminSet.where(title: school).first || AdminSet.where(title: department).first
+  end
+
   # Information about the supplemental files that the JavaScript needs for the edit form.
   # @returns {Array} that contains 2 things: 'supplemental_files' (an array converted to JSON), and 'supplemental_file_metadata' (an array).
   # The 2 arrays are expected to keep the same order between them.

--- a/spec/controllers/in_progress_etds_controller_spec.rb
+++ b/spec/controllers/in_progress_etds_controller_spec.rb
@@ -67,18 +67,6 @@ RSpec.describe InProgressEtdsController, type: :controller, aggregate_failures: 
           expect(response).to have_http_status(:unauthorized)
         end
       end
-
-      context 'for super_admins' do
-        let(:admin) { FactoryBot.create(:admin) }
-        before { sign_in admin }
-
-        it 'sends the advanced view flag' do
-          expect(ipe.user_ppid).not_to eq admin.ppid
-          get :edit, params: { id: ipe.id }
-          expect(response).to have_http_status(:success)
-          expect(assigns(:form_level)).to eq :advanced
-        end
-      end
     end
 
     describe 'DELETE DESTROY' do
@@ -158,6 +146,70 @@ RSpec.describe InProgressEtdsController, type: :controller, aggregate_failures: 
       it 'redirects to login' do
         delete :destroy, params: { id: ipe.id }
         expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  context 'as a super_admin' do
+    let(:super_admin) { FactoryBot.create(:admin) }
+
+    before do
+      sign_in super_admin
+    end
+
+    describe 'GET EDIT' do
+      it 'sets the advanced view flag' do
+        expect(ipe.user_ppid).not_to eq super_admin.ppid
+        get :edit, params: { id: ipe.id }
+        expect(response).to have_http_status(:success)
+        expect(assigns(:form_level)).to eq :advanced
+      end
+    end
+
+    describe 'PATCH UPDATE' do
+      let(:ipe) { InProgressEtd.create(user_ppid: student.ppid, data: ipe_data.to_json) }
+      let(:ipe_data) { { post_graduation_email: 'student@emory.edu' } }
+
+      context 'with permission to edit' do
+        it 'updates the record' do
+          patch :update, params: { id: ipe.id, etd: { post_graduation_email: 'graduate@gmail.com' } }
+          expect(response).to have_http_status(:success)
+          expect(JSON.parse(ipe.reload.data)['post_graduation_email']).to eq 'graduate@gmail.com'
+        end
+      end
+    end
+  end
+
+  context 'as a school approver' do
+    let(:school_approver) { FactoryBot.create(:user) }
+
+    before do
+      sign_in school_approver
+
+      # Stub workflow checks
+      allow(PermissionChecker).to receive(:sipity_approver?).and_return(true)
+      allow(PermissionChecker).to receive(:user_can_approve_admin_set?).and_return(true)
+    end
+
+    describe 'GET EDIT' do
+      it 'sets the advanced view flag' do
+        expect(ipe.user_ppid).not_to eq school_approver.ppid
+        get :edit, params: { id: ipe.id }
+        expect(response).to have_http_status(:success)
+        expect(assigns(:form_level)).to eq :advanced
+      end
+    end
+
+    describe 'PATCH UPDATE' do
+      let(:ipe) { InProgressEtd.create(user_ppid: student.ppid, data: ipe_data.to_json) }
+      let(:ipe_data) { { school: 'Emory College', department: 'Muppet Studies' } }
+
+      context 'with permission to edit' do
+        it 'updates the record' do
+          patch :update, params: { id: ipe.id, etd: { department: 'Muppet Sciences' } }
+          expect(response).to have_http_status(:success)
+          expect(JSON.parse(ipe.reload.data)['department']).to eq 'Muppet Sciences'
+        end
       end
     end
   end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe InProgressEtd do
+RSpec.describe InProgressEtd do
   let(:in_progress_etd) { described_class.new(data: data.to_json) }
 
   describe "About Me" do
@@ -742,6 +742,41 @@ describe InProgressEtd do
         expect(refreshed_data['ipe_id']).to eq ipe.id
         expect(refreshed_data['etd_id']).to eq etd.id
       end
+    end
+  end
+
+  describe '#admin_set' do
+    # ActiveFedora (AdminSet) is slow, so we're stubbing out the persistence layer in these
+    # tests, so we can focus on the matching logic.
+    # This does require our test to be slightly aware of the implementation,
+    # but it cuts the test speed from 3.5 seconds to under 0.25 seconds
+    let(:school_admin_set) { AdminSet.new(title: ['Henson College']) }
+    let(:department_admin_set) { AdminSet.new(title: ['Design and Fabrication']) }
+
+    before do
+      allow(AdminSet).to receive(:where).and_return([])
+      allow(AdminSet).to receive(:where).with(title: 'Henson College').and_return([school_admin_set])
+      allow(AdminSet).to receive(:where).with(title: 'Design and Fabrication').and_return([department_admin_set])
+    end
+
+    it 'is nil when no school or department are set' do
+      ipe = described_class.new(data: {}.to_json)
+      expect(ipe.admin_set).to be_nil
+    end
+
+    it 'returns the school admin set if it exists' do
+      ipe = described_class.new(data: { school: 'Henson College' }.to_json)
+      expect(ipe.admin_set).to eq school_admin_set
+    end
+
+    it 'returns the department admin set if it exists' do
+      ipe = described_class.new(data: { department: 'Design and Fabrication' }.to_json)
+      expect(ipe.admin_set).to eq department_admin_set
+    end
+
+    it 'prioritzes school matches' do
+      ipe = described_class.new(data: { school: 'Henson College', department: 'Design and Fabrication' }.to_json)
+      expect(ipe.admin_set).to eq school_admin_set
     end
   end
 end


### PR DESCRIPTION
1. Add logic to allow approvers to edit InProgressEtds
2. Show approvers advanced form features

NOTE: We've added an #admin_set method to InProgressEtds that allows us to check Sipity workflow permissions.