### PR TITLE
Add editng support for inactive departments and graduation semesters

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,67 +1,59 @@
 <template>
-  <div>
-    <!-- TODO: adding v-model='selected' enables the selected value to appear in the case of an ipe_etd, but it will not without it, with a hyrax etd. But we should refactor for a better solution. -->
-    <label for="department"> {{ sharedState.getDepartmentHeading() }} </label>
-    <select
-      name="etd[department]"
-      class="form-control"
-      id="department"
-      aria-required="true"
-      v-model="selected"
-      v-on:change="sharedState.clearSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)"
-    >
-      <option
-        v-for="(department, i) in sharedState.departments"
-        v-bind:value="department.id"
-        v-bind:key="`${i}-${department.label}`"
-        :disabled="department.disabled"
-      >
-        {{ department.label }}
-      </option>
-    </select>
-  </div>
+    <div>
+      <label for="department"> {{ sharedState.getDepartmentHeading() }} </label>
+        <select id="department" name="etd[department]" class="form-control" aria-required="true" v-model="selected"
+                v-on:change="this.sharedState.getSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
+            <option v-for="department in departments"
+                    v-bind:value="department.id"
+                    v-bind:disabled="department.disabled">
+                    {{ labelFor(department.label, department.active) }}
+            </option>
+        </select>
+    </div>
 </template>
 
 <script>
-import { formStore } from "./formStore";
-import _ from "lodash";
+import axios from "axios"
+import {formStore} from './formStore'
+import {labelFor, showInactive} from './lib/formHelpers'
 
 export default {
   data() {
     return {
-      selected: "",
-      sharedState: formStore
-    };
-  },
-  watch: {
-    selected() {
-      this.sharedState.getSavedOrSelectedDepartment();
-      this.sharedState.getSubfields();
+      sharedState: formStore,
+      selected: '',
+      departmentsEndpoint: '',
+      departments: {}
     }
   },
-  beforeMount: function() {
-    this.sharedState.loadDepartments();
-    this.selected = this.sharedState.getSavedOrSelectedDepartment();
+  created() {
+    this.selected = this.sharedState.getSavedDepartment()
+    this.fetchData()
+    this.sharedState.getSubfields()
   },
-  mounted: function() {
-    this.$nextTick(function() {
-      //this is to handle the case of a saved department
-      if (_.has(this.sharedState.savedData, "etd_id")) {
-        var selectedArray = this.sharedState.getSavedOrSelectedDepartment();
-        this.selected = selectedArray[0];
-      } else {
-        this.selected = this.sharedState.getSavedOrSelectedDepartment();
-        if (!this.selected) {
-          this.selected = "Select a " + this.sharedState.getDepartmentHeading();
-        }
-      }
-    });
-  }
-};
-</script>
+  methods: {
+    labelFor,
+    fetchData() {
+      // We need to choose a department list based on the selected school
+      this.departmentsEndpoint = this.sharedState.schools[this.sharedState.getSavedOrSelectedSchool()]
+      axios.get(this.departmentsEndpoint).then(response => {
+        this.departments = this.getSelected(response.data)
+      }).catch(e => {
+        console.log(e)
+      })
+    },
+    getSelected(data){
+      // Add a placeholder option at the top of the options list
+      data.unshift({ "label": `Select a ${this.sharedState.getDepartmentHeading()}`, "disabled":"disabled","active": true, "id": "" })
 
-<style>
-select {
-  margin-bottom: 1em;
+      // If a previously saved option exists, ensure it's active
+      // If no match is found, we use the placeholder index
+      const selected_index = Math.max(data.findIndex((option) => option.id === this.selected),0)
+      data[selected_index].active = true
+
+      // Filter out inactive options when appropriate
+      return showInactive() ? data : data.filter((option) => option.active)
+    }
+  }
 }
-</style>
+</script>

--- a/app/javascript/GraduationDate.vue
+++ b/app/javascript/GraduationDate.vue
@@ -3,9 +3,9 @@
         <label for="graduation-date">Graduation Date</label>
         <select id="graduation-date" name="etd[graduation_date]" class="form-control" aria-required="true">
             <template v-for="graduationDate in graduationDates">
-                <option v-if="graduationDate.active || showInactive()"
-                        v-bind:value="graduationDate.id"
-                        :selected="graduationDate.selected">
+                <option v-bind:value="graduationDate.id"
+                        v-bind:disabled="graduationDate.disabled"
+                        v-bind:selected="graduationDate.selected">
                     {{ labelFor(graduationDate.label, graduationDate.active) }}
                 </option>
             </template>
@@ -17,7 +17,7 @@
 import axios from "axios"
 import { formStore } from './formStore'
 import {labelFor, showInactive} from './lib/formHelpers'
-import _ from 'lodash'
+
 export default {
   data() {
     return {
@@ -29,7 +29,6 @@ export default {
   },
   methods: {
     labelFor,
-    showInactive,
     fetchData() {
       axios.get(this.graduationDatesEndpoint).then(response => {
         this.graduationDates = this.getSelected(response.data)
@@ -38,18 +37,18 @@ export default {
       })
     },
     getSelected(data){
-      const selected = this.sharedState.getGraduationDate()
-      if (selected !== undefined) {
-        _.forEach(data, function(o){
-          if (o.id === selected){
-            o.selected = 'selected'
-            o.active = true
-          }
-        })
-      } else {
-        data.unshift({ "value": "", "active": true, "label": "Select a Graduation Date", "disabled":"disabled", "selected":"selected" })
-      }
-      return data
+      // Add a placeholder option at the top of the list
+      data.unshift({ "value": "", "active": true, "label": "Select a Graduation Date", "disabled":"disabled" })
+
+      // If a previously saved option exists, set it as active and selected
+      // even if the saved option was inactive
+      this.selected = this.sharedState.getGraduationDate()
+      const selected_index = Math.max(0, data.findIndex((option) => option.id === this.selected))
+      data[selected_index].active = true
+      data[selected_index].selected = true
+
+      // Filter out inactive options when appropriate
+      return showInactive() ? data : data.filter((option) => option.active)
     }
   },
   created() {

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import _ from 'lodash'
+
 import { formStore } from './formStore'
 import StartOverModal from './components/StartOverModal'
 export default {
@@ -38,14 +38,9 @@ export default {
   },
   methods: {
     fetchData() {
-      var selectedSchool = this.sharedState.schools[this.selected]
+      const selectedSchool = this.sharedState.schools[this.selected]
       this.sharedState.setSelectedSchool(this.selected)
       this.sharedState.getDepartments(selectedSchool)
-    },
-    // this only executes when the change event fires (user selects something)
-    clearDepartmentAndSubfields() {
-      this.sharedState.clearDepartment()
-      this.sharedState.clearSubfields()
     }
   },
   mounted: function() {

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -432,24 +432,13 @@ export const formStore = {
     const dept = this.getSavedOrSelectedDepartment()
     const endpoints = this.subfieldEndpoints
     const endpoint = endpoints[dept]
-    if (endpoints[dept] || formStore.subfieldsEdit) {
-      if (!this.allowTabSave()) {
-        axios.get(endpoint).then((response) => {
-          this.clearSubfields()
-          this.subfields = response.data
-          this.subfields.unshift({ 'id': this.savedData['subfield'], 'active': true, 'label': this.savedData['subfield'], 'selected': 'selected' })
-        })
-        return true
-      } else {
-        axios.get(endpoint).then((response) => {
-          this.clearSubfields()
-          this.subfields = response.data
-        })
-      }
+    if (endpoint) {
+      axios.get(endpoint).then((response) => {
+        this.subfields = response.data
+      })
+    } else {
+      this.subfields = []
     }
-  },
-  clearSubfields () {
-    this.subfields = []
   },
   getSubfieldLabelFromId (id) {
     if (this.subfields.length > 0){

--- a/app/javascript/test/Department.spec.js
+++ b/app/javascript/test/Department.spec.js
@@ -2,35 +2,98 @@
 /* global it */
 /* global expect */
 /* global jest */
-import { mount } from '@vue/test-utils'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 import Department from 'Department'
 import axios from 'axios'
-import { formStore } from 'formStore'
+import * as formHelpers from "../lib/formHelpers";
 jest.mock('axios')
 
-window.localStorage = jest.fn()
-window.localStorage.getItem = jest.fn()
-window.localStorage.setItem = jest.fn()
-
-formStore.departments = [{"id":"Divinity","label":"Divinity","active":true},{"id":"Ministry","label":"Ministry","active":true},{"id":"Pastoral Counseling","label":"Pastoral Counseling","active":true},{"id":"Theological Studies","label":"Theological Studies","active":true}]
-const resp =  [{"id":"Divinity","label":"Divinity","active":true},{"id":"Ministry","label":"Ministry","active":true},{"id":"Pastoral Counseling","label":"Pastoral Counseling","active":true},{"id":"Theological Studies","label":"Theological Studies","active":true}]
-axios.get.mockResolvedValue(resp)
-formStore.getSavedOrSelectedDepartment = () => { return 'Divinity' }
 describe('Department.vue', () => {
-  it('it restores the correct value', () => {
-    const wrapper = mount(Department, {
-    })
-    wrapper.vm.$data.school = "Candler School of Theology"
-    wrapper.vm.$data.selected = formStore.getSavedOrSelectedDepartment()
-    expect(wrapper.html()).toContain('Divinity')
+  beforeEach(() => {
+    // mock an response from the candler_rograms endpoint
+    const mockResponse =  {data:
+        [ {"id":"Divinity",             "label":"Divinity",             "active":true},
+          {"id":"Ministry",             "label":"Ministry",             "active":true},
+          {"id":"Pastoral Counseling",  "label":"Pastoral Counseling",  "active":false},
+          {"id":"Theological Studies",  "label":"Theological Studies",  "active":false}]}
+    axios.get.mockResolvedValue(mockResponse)
   })
-  it('has a disabled default ', () => {
-    const wrapper = mount(Department, {
-    })
-    formStore.departments = [{ "value": 1, "active": true, "label": "Select a Department", "disabled":"disabled" ,"selected": "selected"}]
-    wrapper.vm.$data.school = "Candler School of Theology"
-    formStore.getSavedOrSelectedDepartment = () => { return false }
-    wrapper.vm.$data.selected = 'Select a Department'
-    expect(wrapper.html()).toContain('disabled')
+
+  afterEach(() => {
+    // restore any spies created with spyOn
+    jest.restoreAllMocks()
   })
-})
+
+  it('lists active departments', async () =>  {
+    const wrapper = shallowMount(Department, {
+      data() {
+        // set Candler as the previously saved school
+        return {sharedState: {savedData: {school: 'Candler School of Theology'}}}
+      }
+    })
+
+    await flushPromises
+
+    const enabled_options = wrapper.findAll('option:not([disabled])').wrappers.map((wrapper) => wrapper.text())
+    expect(enabled_options).toEqual(['Divinity', 'Ministry'])
+  })
+
+  it('has a disabled default value', async () =>  {
+    const wrapper = shallowMount(Department, {
+      data() {
+        // set Candler as the previously saved school
+        return {sharedState: {savedData: {school: 'Candler School of Theology'}}}
+      }
+    })
+
+    await flushPromises
+
+    // use findAll instead of find to ensure we only have one disabled option
+    const disabled_option = wrapper.findAll('#department option[disabled]').wrappers.map((wrapper) => wrapper.text())
+    expect(disabled_option).toEqual(['Select a Department'])
+  })
+
+  it('lists inacive departments in advanced mode', async () =>  {
+    // render the form using the admin view option
+    jest.spyOn(formHelpers, "showInactive").mockReturnValue(true);
+
+    const wrapper = shallowMount(Department, {
+      data() {
+        // set Candler as the previously saved school
+        return {sharedState: {savedData: {school: 'Candler School of Theology'}}}
+      }
+    })
+
+    await flushPromises
+
+    const enabled_options = wrapper.findAll('option:not([disabled])').wrappers.map((wrapper) => wrapper.text())
+    expect(enabled_options).toEqual(['Divinity', 'Ministry', '⚠️ Pastoral Counseling', '⚠️ Theological Studies'])
+  })
+
+  it('lists includes inactive departments if they were preiously saved', async () =>  {
+    const wrapper = shallowMount(Department, {
+      data() {
+        // set Candler as the previously saved school
+        return {sharedState: {savedData: {school: 'Candler School of Theology', department: 'Theological Studies'}}}
+      }
+    })
+
+    await flushPromises
+
+    const enabled_options = wrapper.findAll('option:not([disabled])').wrappers.map((wrapper) => wrapper.text())
+    expect(enabled_options).toEqual(['Divinity', 'Ministry', 'Theological Studies'])
+  })
+
+  it('Uses "Specialty" instead of "Department" for School of Nursing ', async () =>  {
+    const wrapper = shallowMount(Department, {
+      data() {
+        // set Candler as the previously saved school
+        return {sharedState: {savedData: {school: 'Nell Hodgson Woodruff School of Nursing'}}}
+      }
+    })
+
+    await flushPromises
+
+    // Check the text of the first option
+    expect(wrapper.find('#department option').text()).toEqual('Select a Specialty')
+  })})

--- a/app/javascript/test/LegacyGraduation.spec.js
+++ b/app/javascript/test/LegacyGraduation.spec.js
@@ -3,33 +3,68 @@
 /* global expect */
 /* global jest */
 
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 import GraduationDate from 'GraduationDate'
 import axios from 'axios'
+import * as formHelpers from '../lib/formHelpers'
 
 jest.mock('axios')
+
 describe('GraduationDate.vue with an inactive legacy term', () => {
-  const respData = {data: [
-        {'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}, {'id': '2013', 'label': '2013', 'active': true}]}
-
-  axios.get.mockResolvedValue(respData)
-
   beforeEach(() => {
-    const wrapper = shallowMount(GraduationDate, {
-    })
-    wrapper.vm.$data.graduationDates = respData
-    wrapper.vm.$data.sharedState.getGraduationDate = jest.fn(() => {
-      return '2013'
-    })
+    // mock an abridged response from the graduation_dates endpoint
+    const mockResponse = {
+      data: [{'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}, {'id': '2013', 'label': '2013', 'active': false}]
+    }
+    axios.get.mockResolvedValue(mockResponse)
   })
 
-  it('will set the legacy option properties active = true and selected = selected', () => {
-    const wrapper = shallowMount(GraduationDate, {
-    })
-    wrapper.vm.$data.graduationDates = respData
+  afterEach(() => {
+    // restore any spies created with spyOn
+    jest.restoreAllMocks();
+  });
 
-    const expected_option_data = {data: [{'id': 'Fall 2017', 'label': 'Fall 2017', 'active': true}, {'id': '2013', 'label': '2013', 'active': true, 'selected': 'selected'}]}
+  it('selects the legacy option when set in the source ETD', async () => {
+    const wrapper = shallowMount(GraduationDate)
+    // set saved academic term
+    wrapper.vm.$data.sharedState.savedData['graduation_date'] = "2013"
+    await flushPromises
 
-    expect(wrapper.vm.getSelected(respData)).toEqual(expected_option_data)
+    expect(wrapper.find('#graduation-date').element.value).toEqual('2013')
+  })
+
+  it('displays expected options', async () => {
+    const wrapper = shallowMount(GraduationDate)
+    // set saved academic term
+    wrapper.vm.$data.sharedState.savedData['graduation_date'] = "2013"
+    await flushPromises
+
+    const option_labels = wrapper.findAll('#graduation-date option').wrappers.map((option) => option.text())
+    expect(option_labels).toEqual(['Select a Graduation Date', 'Fall 2017', '2013'])
+  })
+
+  it('does not display inactive options when they are not selected', async () => {
+    const wrapper = shallowMount(GraduationDate)
+    // clear saved academic term
+    wrapper.vm.$data.sharedState.savedData['graduation_date'] = ""
+    await flushPromises
+
+    const option_labels = wrapper.findAll('#graduation-date option').wrappers.map((option) => option.text())
+    expect(option_labels).toEqual(['Select a Graduation Date', 'Fall 2017'])
+  })
+
+  it('displays inactive options in admin view even when they are not selected', async () => {
+
+    // render the form using the admin view option
+    jest.spyOn(formHelpers, "showInactive").mockReturnValue(true);
+
+    const wrapper = shallowMount(GraduationDate)
+
+    // clear saved academic term
+    wrapper.vm.$data.sharedState.savedData['graduation_date'] = ""
+    await flushPromises
+
+    const option_labels = wrapper.findAll('#graduation-date option').wrappers.map((option) => option.text())
+    expect(option_labels).toEqual(['Select a Graduation Date', 'Fall 2017', '⚠️ 2013'])
   })
 })

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -60,12 +60,6 @@ describe('formStore', () => {
     ])
   })
 
-  it('returns a previously saved subfield the list', () => {
-    formStore.subfieldsEdit = true
-    formStore.allowTabSave = jest.fn(() => { return false })
-    expect(formStore.getSubfields()).toEqual(true)
-  })
-
   it('returns true for user agreement when on the edit form', () => {
     formStore.allowTabSave = jest.fn(() => { return false })
     expect(formStore.getUserAgreement()).toEqual(true)


### PR DESCRIPTION
This change adds two features:
1. Approvers and SuperAdmins to choose inactive departments and graduation semesters. Inactive options are flagged with a special icon.
2. Allow submitters to save and re-submit InProgress ETDs with an inactive department or graduation semester.