### PR TITLE
FIX Department not displaying when editing submitted ETD

### DIFF
--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -148,7 +148,6 @@ class InProgressEtd < ApplicationRecord
     new_data['degree_awarded'] = etd.degree_awarded # Needed by javascript
     new_data['embargo_length'] = etd.embargo_length
     new_data['keyword'] = etd.keyword
-    new_data['department'] = etd.department
     new_data['research_field'] = etd.research_field
     new_data['other_copyrights'] = etd.other_copyrights
     new_data['patents'] = etd.patents

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe InProgressEtd do
         title: 'Stale Title from IPE',
         partnering_agency: ['Stale parter agency'],
         embargo_length: '1000 years',
-        department: ['Some'],
+        department: 'Some',
         other_copyrights: 'true',
         requires_permissions: 'true',
         patents: 'true',
@@ -721,11 +721,12 @@ RSpec.describe InProgressEtd do
       let(:ipe) { described_class.new(etd_id: etd.id, data: stale_data.to_json) }
 
       it 'replaces the stale data with updated data', :aggregate_failures do
-        special_comparisons = ['title', 'degree_awarded', 'files_embargoed', 'toc_embargoed',
+        special_comparisons = ['title', 'degree_awarded', 'department', 'files_embargoed', 'toc_embargoed',
                                'abstract_embargoed', 'committee_members_attributes', 'committee_chair_attributes']
         expect(refreshed_data).to include new_data.except(*special_comparisons)
         # Special comparisons for data that's reformatted or otherwise transformed
         expect(refreshed_data['degree_awarded']).to match(new_data['degree_awarded'])
+        expect(refreshed_data['department']).to match(new_data['department'][0])
         expect(refreshed_data['committee_members_attributes'])
           .to include(
                 hash_including('name' => ['Dweck'], "affiliation" => ['A Famous University']),

--- a/spec/system/edit_etd_spec.rb
+++ b/spec/system/edit_etd_spec.rb
@@ -40,9 +40,10 @@ RSpec.feature 'Edit an existing ETD',
       login_as admin_superuser
       visit "/concern/etds/#{etd.id}?locale=en"
       click_on "Edit"
-      expect(page).to have_content "Biostatistics and Bioinformatics"
-      expect(page).to have_content etd.degree.first
-      expect(page).to have_content "Biostatistics - MPH & MSPH"
+      expect(page).to have_select('department', selected: 'Biostatistics and Bioinformatics')
+      expect(page).to have_select('subfield', selected: 'Biostatistics - MPH & MSPH')
+      expect(page).to have_select('degree', selected: 'Th.D.')
+      expect(page).to have_select('submitting-type', selected: 'Dissertation')
       expect(page).to have_select('graduation-date', selected: 'Spring 2021')
       expect(page).to have_select('embargo-length', selected: '6 months')
       expect(page).to have_select('content-to-embargo', selected: 'Files and Table of Contents')


### PR DESCRIPTION
**ISSUE**
PR https://github.com/curationexperts/laevigata/pull/2501 [lines 48-52 deleted](https://github.com/curationexperts/laevigata/pull/2501/changes#diff-3dccc1f5290fac13acf81bc1175d93c1f9bb287034a1ada1dba854a5190bd8daL48-L52) added a bug when editing submitted ETDs because it removed the code that converted the department array to a single value in the form.

**FIX**
Remove the special code that sent department as an array instead of a single value. Department is handled successfully by the 'all_simple_fields' loop.