### PR TITLE
Refactor department code to simplify naming and logic

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -2,7 +2,7 @@
     <div>
       <label for="department"> {{ sharedState.getDepartmentHeading() }} </label>
         <select id="department" name="etd[department]" class="form-control" aria-required="true" v-model="selected"
-                v-on:change="this.sharedState.getSubfields(), sharedState.setSelectedDepartment(selected), sharedState.setValid('My Program', false)">
+                v-on:change="this.sharedState.getSubfields(), sharedState.setDepartment(selected), sharedState.setValid('My Program', false)">
             <option v-for="department in departments"
                     v-bind:value="department.id"
                     v-bind:disabled="department.disabled">
@@ -27,7 +27,7 @@ export default {
     }
   },
   created() {
-    this.selected = this.sharedState.getSavedDepartment()
+    this.selected = this.sharedState.getDepartment()
     this.fetchData()
     this.sharedState.getSubfields()
   },

--- a/app/javascript/components/submit/MyProgram.vue
+++ b/app/javascript/components/submit/MyProgram.vue
@@ -2,7 +2,7 @@
   <section>
     <h4>My Program</h4>
     <h5>{{ sharedState.getDepartmentHeading() }}</h5>
-    <div> {{ sharedState.getDepartmentLabelFromId(sharedState.getSavedOrSelectedDepartment()) }} </div>
+    <div> {{ sharedState.getDepartmentLabelFromId(sharedState.getDepartment()) }} </div>
     <div v-if="sharedState.getSavedOrSelectedSubfield() && sharedState.getSavedOrSelectedSubfield().length > 0">
           <h5>Subfield</h5>
       <div> {{ sharedState.getSubfieldLabelFromId(sharedState.getSavedOrSelectedSubfield()) }} </div>

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -353,30 +353,22 @@ export const formStore = {
     this.schools.selected = school
 
   },
-  getSelectedDepartment () {
-    return this.selectedDepartment
-  },
 
-  getSavedOrSelectedDepartment () {
-    if (this.getSelectedDepartment().length > 0) {
-      return this.getSelectedDepartment()
-    }
-
-    if (this.getSelectedDepartment().length <= 0) {
-      return this.getSavedDepartment()
+  getDepartment () {
+    if (this.selectedDepartment.length > 0) {
+      return this.selectedDepartment
+    } else {
+      return this.savedData['department']
     }
   },
 
-  getSavedDepartment () {
-    return this.savedData['department']
-  },
-  setSelectedDepartment (department) {
+  setDepartment (department) {
     this.selectedDepartment = department
   },
 
   getDepartments (selectedSchool) {
     if (!this.allowTabSave()) {
-      var savedValue = { "value": this.getSavedDepartment()[0], "active": true, "label": this.getSavedDepartment()[0], "selected": "selected" }
+      var savedValue = { "value": this.getDepartment(), "active": true, "label": this.getDepartment(), "selected": "selected" }
       axios.get(selectedSchool).then(response => {
         this.departments = response.data
         if (!this.allowTabSave()) {
@@ -404,7 +396,8 @@ export const formStore = {
   },
 
   getDepartmentHeading () {
-    // The nursing school uses "Specialty" instead of "Department"
+    // The nursing school uses "Specialty"
+    // All other schools use "Department"
     if ( this.savedData['school']=='Nell Hodgson Woodruff School of Nursing') {
       return 'Specialty'
     } else {
@@ -429,7 +422,7 @@ export const formStore = {
     this.selectedSubfield = subfield
   },
   getSubfields () {
-    const dept = this.getSavedOrSelectedDepartment()
+    const dept = this.getDepartment()
     const endpoints = this.subfieldEndpoints
     const endpoint = endpoints[dept]
     if (endpoint) {

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -30,7 +30,7 @@ describe('formStore', () => {
   it('loads the saved department as the first choice', () => {
 
     formStore.allowTabSave = jest.fn(() => { return false })
-    formStore.getSavedDepartment = jest.fn(() => { return ['African Studies'] })
+    formStore.getDepartment = jest.fn(() => { return 'African Studies' })
     formStore.getDepartments()
     expect(formStore.getDepartments()).toEqual({'active': true, 'label': 'African Studies', 'selected': 'selected', 'value': 'African Studies'})
   })


### PR DESCRIPTION
**RATIONALE**
The ForStore logic makes a larger distinction between saved or selected values for the department. In reality, we want to initialize the selected value with the stored value when one is present. After that, we only need to manage the selected value.