### PR TITLE
Refactor IPE to minimize casting JSON to/from String

### DIFF
--- a/app/controllers/in_progress_etds_controller.rb
+++ b/app/controllers/in_progress_etds_controller.rb
@@ -32,11 +32,11 @@ class InProgressEtdsController < ApplicationController
   def update
     @in_progress_etd = InProgressEtd.find(params[:id])
     authorize! :update, @in_progress_etd
-    @in_progress_etd.data = prepare_etd_data.to_json
+    @in_progress_etd.data = prepare_etd_data
 
     if @in_progress_etd.save
       @data = @in_progress_etd.data
-      render json: { in_progress_etd: @data, lastCompletedStep: current_step(@data), tab_name: tab_name }, status: 200
+      render json: { in_progress_etd: @data.to_json, lastCompletedStep: current_step(@data), tab_name: tab_name }, status: 200
     else
       render json: { errors: @in_progress_etd.errors.messages }, status: 422
     end
@@ -53,8 +53,7 @@ class InProgressEtdsController < ApplicationController
   private
 
     def current_step(data)
-      saved_data = JSON.parse(data)
-      saved_data['currentStep']
+      data['currentStep']
     end
 
     def tab_name

--- a/app/javascript/SaveAndSubmit.js
+++ b/app/javascript/SaveAndSubmit.js
@@ -48,7 +48,7 @@ export default class SaveAndSubmit {
         this.formStore.setComplete(response.data.tab_name)
         this.formStore.loadTabs()
       })
-      .catch(error => {
+      .catch((error) => {
         this.formStore.errored = true
         this.formStore.errors = []
         this.formStore.errors.push(error.response.data.errors)

--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -21,6 +21,9 @@
 class InProgressEtd < ApplicationRecord
   NO_EMBARGO = 'None - open access immediately'
 
+  serialize :data, JSON
+
+  after_initialize :initialize_data
   after_create :add_id_to_data_store
 
   # custom validators check for presence of tab-determined set of fields based on presence of tab-identifying data
@@ -31,6 +34,10 @@ class InProgressEtd < ApplicationRecord
   validates_with KeywordValidator
   validates_with EmbargoValidator
   validates_with MyFilesValidator
+
+  def initialize_data
+    self.data ||= {}
+  end
 
   # @param new_data [Hash, HashWithIndifferentAccess] New data to add to the existing data store.
   # @return [Hash] The resulting hash, with new data added to old data.
@@ -49,19 +56,16 @@ class InProgressEtd < ApplicationRecord
   # Blank fields should be first-class data, just like
   # populated fields.
   def add_data(new_data)
-    json_data = data || {}.to_json
-    existing_data = JSON.parse(json_data)
-    return existing_data unless new_data
+    return self.data unless new_data
 
-    new_data = keep_last_completed_step(existing_data, new_data)
-    new_data = keep_school_has_changed(existing_data, new_data)
+    new_data = new_data.with_indifferent_access
+    new_data = keep_last_completed_step(self.data, new_data)
+    new_data = keep_school_has_changed(self.data, new_data)
     new_data = strip_blank_fields(new_data)
     remove_blank_members(new_data)
     remove_blank_supp_files(new_data)
 
-    resulting_data = existing_data.merge(new_data)
-    self.data = resulting_data.to_json
-    resulting_data
+    self.data.merge!(new_data)
   end
 
   # If we see the 'files' key in the new_data, then
@@ -119,9 +123,9 @@ class InProgressEtd < ApplicationRecord
 
   # Store this record's ID for the javascript form to use.
   def add_id_to_data_store
-    return unless id
+    return if data['ipe_id'].present? || id.blank?
     add_data('ipe_id' => id)
-    save
+    save!
   end
 
   # If this record is associated with an Etd record
@@ -159,24 +163,20 @@ class InProgressEtd < ApplicationRecord
     new_data['committee_chair_attributes'] = etd.committee_chair
 
     primary_file = file_for_refresh(etd.primary_file_fs.first)
-    new_data['files'] = primary_file.to_json unless primary_file.blank?
+    new_data['files'] = primary_file unless primary_file.blank?
 
     unless etd.supplemental_files_fs.blank?
       new_data['supplemental_files'], new_data['supplemental_file_metadata'] = supplemental_files_for_refresh(etd)
     end
 
-    self.data = new_data.to_json
+    self.data = new_data
     save!
   end
 
   # Find and return the admin set associated with the School or Department
   # @return [AdminSet]
   def admin_set
-    return @admin_set if @admin_set
-    etd_data = JSON.parse(data)
-    school = etd_data['school']
-    department = etd_data['department']
-    @admin_set ||= AdminSet.where(title: school).first || AdminSet.where(title: department).first
+    @admin_set ||= AdminSet.where(title: data['school']).first || AdminSet.where(title: data['department']).first
   end
 
   # Information about the supplemental files that the JavaScript needs for the edit form.
@@ -192,7 +192,7 @@ class InProgressEtd < ApplicationRecord
       supp_files_metadata << file_metadata_for_refresh(supp_file)
     end
 
-    [supp_files.to_json, supp_files_metadata]
+    [supp_files, supp_files_metadata]
   end
 
   # Information about the file that the JavaScript needs for display and to render the 'Remove' button.
@@ -226,5 +226,9 @@ class InProgressEtd < ApplicationRecord
       ::Hyrax::EtdForm.my_program_terms +
       ::Hyrax::EtdForm.my_etd_terms +
       ::Hyrax::EtdForm.keyword_terms
+  end
+
+  def current_tab
+    data['currentTab']
   end
 end

--- a/app/validators/about_me_validator.rb
+++ b/app/validators/about_me_validator.rb
@@ -1,17 +1,8 @@
 class AboutMeValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
+    return unless record.current_tab == "About Me"
     ::Hyrax::EtdForm.about_me_terms.each do |field|
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
+      record.errors.add(field, "#{field} is required") if record.data[field.to_s].blank?
     end
-  end
-
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "About Me"
   end
 end

--- a/app/validators/embargo_validator.rb
+++ b/app/validators/embargo_validator.rb
@@ -1,20 +1,11 @@
 class EmbargoValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
+    return unless record.current_tab == "Embargo"
     # TODO: the embargo form will send 'no' values by default,
     # but this tab hasn't been built to conform to the wireframes yet.
     # when it is this validator will check for actual values.
     # ::Hyrax::EtdForm.embargo_terms.each do |field|
     #   record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
     # end
-  end
-
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "Embargo"
   end
 end

--- a/app/validators/keyword_validator.rb
+++ b/app/validators/keyword_validator.rb
@@ -1,17 +1,8 @@
 class KeywordValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
+    return unless record.current_tab == "Keywords"
     ::Hyrax::EtdForm.keyword_terms.each do |field|
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank? || parsed_data(record)[field.to_s].first.blank?
+      record.errors.add(field, "#{field} is required") if record.data[field.to_s].blank? || record.data[field.to_s].first.blank?
     end
-  end
-
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "Keywords"
   end
 end

--- a/app/validators/my_advisor_validator.rb
+++ b/app/validators/my_advisor_validator.rb
@@ -1,18 +1,9 @@
 class MyAdvisorValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
+    return unless record.current_tab == "My Advisor"
     ::Hyrax::EtdForm.my_advisor_terms.each do |field|
       next if field == :committee_members_attributes
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
+      record.errors.add(field, "#{field} is required") if record.data[field.to_s].blank?
     end
-  end
-
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Advisor"
   end
 end

--- a/app/validators/my_etd_validator.rb
+++ b/app/validators/my_etd_validator.rb
@@ -1,17 +1,8 @@
 class MyEtdValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
+    return unless record.current_tab == "My Etd"
     ::Hyrax::EtdForm.my_etd_terms.each do |field|
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
+      record.errors.add(field, "#{field} is required") if record.data[field.to_s].blank?
     end
-  end
-
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Etd"
   end
 end

--- a/app/validators/my_files_validator.rb
+++ b/app/validators/my_files_validator.rb
@@ -1,26 +1,17 @@
 class MyFilesValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
-    record.errors.add('files', "A thesis or dissertation file is required") if parsed_data(record)['files'].nil?
+    return unless record.current_tab == "My Files"
+    record.errors.add('files', "A thesis or dissertation file is required") if record.data['files'].nil?
 
     record.errors.add('supplementalFiles', "A title, description and file type are required for each Supplemental File.") if file_without_metadata(record)
   end
 
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Files"
-  end
-
   def file_without_metadata(record)
-    return false if parsed_data(record)['supplemental_files'].nil?
-    return true if parsed_data(record)['supplemental_file_metadata'].nil?
+    return false if record.data['supplemental_files'].nil?
+    return true if record.data['supplemental_file_metadata'].nil?
 
     meta_missing = false
-    parsed_data(record)['supplemental_file_metadata'].each do |sf|
+    record.data['supplemental_file_metadata'].each do |sf|
       meta_missing = sf[1]['title'].blank? || sf[1]['description'].blank? || sf[1]['file_type'].blank? ? true : false
     end
     meta_missing

--- a/app/validators/my_program_validator.rb
+++ b/app/validators/my_program_validator.rb
@@ -1,20 +1,10 @@
 class MyProgramValidator < ActiveModel::Validator
   def validate(record)
-    return unless current_tab?(record)
+    return unless record.current_tab == "My Program"
     fields_to_validate = ::Hyrax::EtdForm.my_program_terms - [:partnering_agency]
     fields_to_validate.each do |field|
-      # TODO: confirm whether subfields are never required by Emory
-      next if field == :subfield
-      record.errors.add(field, "#{field} is required") if parsed_data(record)[field.to_s].blank?
+      next if field == :subfield # Subfields are not currently required
+      record.errors.add(field, "#{field} is required") if record.data[field.to_s].blank?
     end
-  end
-
-  def parsed_data(record)
-    return {} unless record.data
-    JSON.parse(record.data)
-  end
-
-  def current_tab?(record)
-    parsed_data(record)['currentTab'] == "My Program"
   end
 end

--- a/spec/controllers/in_progress_etds_controller_spec.rb
+++ b/spec/controllers/in_progress_etds_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe InProgressEtdsController, type: :controller, aggregate_failures: 
         end
 
         it 'updates the record' do
-          expect(JSON.parse(ipe.data)['title']).to eq new_title
+          expect(ipe.data['title']).to eq new_title
         end
       end
 
@@ -167,14 +167,14 @@ RSpec.describe InProgressEtdsController, type: :controller, aggregate_failures: 
     end
 
     describe 'PATCH UPDATE' do
-      let(:ipe) { InProgressEtd.create(user_ppid: student.ppid, data: ipe_data.to_json) }
+      let(:ipe) { InProgressEtd.create(user_ppid: student.ppid, data: ipe_data) }
       let(:ipe_data) { { post_graduation_email: 'student@emory.edu' } }
 
       context 'with permission to edit' do
         it 'updates the record' do
           patch :update, params: { id: ipe.id, etd: { post_graduation_email: 'graduate@gmail.com' } }
           expect(response).to have_http_status(:success)
-          expect(JSON.parse(ipe.reload.data)['post_graduation_email']).to eq 'graduate@gmail.com'
+          expect(ipe.reload.data['post_graduation_email']).to eq 'graduate@gmail.com'
         end
       end
     end
@@ -201,14 +201,14 @@ RSpec.describe InProgressEtdsController, type: :controller, aggregate_failures: 
     end
 
     describe 'PATCH UPDATE' do
-      let(:ipe) { InProgressEtd.create(user_ppid: student.ppid, data: ipe_data.to_json) }
+      let(:ipe) { InProgressEtd.create(user_ppid: student.ppid, data: ipe_data) }
       let(:ipe_data) { { school: 'Emory College', department: 'Muppet Studies' } }
 
       context 'with permission to edit' do
         it 'updates the record' do
           patch :update, params: { id: ipe.id, etd: { department: 'Muppet Sciences' } }
           expect(response).to have_http_status(:success)
-          expect(JSON.parse(ipe.reload.data)['department']).to eq 'Muppet Sciences'
+          expect(ipe.reload.data['department']).to eq 'Muppet Sciences'
         end
       end
     end

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe InProgressEtd do
-  let(:in_progress_etd) { described_class.new(data: data.to_json) }
+  let(:in_progress_etd) { described_class.new(data: data) }
 
   describe "About Me" do
     context "with valid data" do
@@ -15,14 +15,14 @@ RSpec.describe InProgressEtd do
     end
 
     context "with invalid data" do
-      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", graduation_date: "tomorrow", post_graduation_email: "", school: "" }.to_json) }
+      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", graduation_date: "tomorrow", post_graduation_email: "", school: "" }) }
 
       it "is not valid" do
         expect(in_progress_etd).not_to be_valid
       end
     end
     context "with missing data" do
-      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", post_graduation_email: "" }.to_json) }
+      let(:in_progress_etd) { described_class.new(data: { currentTab: "About Me", creator: "Student", post_graduation_email: "" }) }
 
       it "is not valid" do
         expect(in_progress_etd).not_to be_valid
@@ -216,7 +216,7 @@ RSpec.describe InProgressEtd do
 
   describe '#add_id_to_data_store' do
     let(:in_progress_etd) { described_class.new }
-    let(:parsed_data) { JSON.parse(in_progress_etd.data) }
+    let(:parsed_data) { in_progress_etd.data }
 
     context "a record that has been saved" do
       before do
@@ -230,11 +230,11 @@ RSpec.describe InProgressEtd do
   end
 
   describe '#add_data' do
-    let(:in_progress_etd) { described_class.new(data: old_data.to_json) }
+    let(:in_progress_etd) { described_class.new(data: old_data) }
 
     let(:old_data) { { 'title': 'The Old Title' } }
     let(:new_data) { nil }
-    let(:resulting_data) { JSON.parse(in_progress_etd.data) } # in-memory data
+    let(:resulting_data) { in_progress_etd.data } # in-memory data
     let(:return_value) { in_progress_etd.add_data(new_data) }
 
     before { return_value } # Call the method
@@ -386,7 +386,7 @@ RSpec.describe InProgressEtd do
 
         it 'leaves embargo types unmodified' do
           # Other parts of the codebase now have responsibility for setting embargo_type and booleans
-          # appropriately when leng => open access
+          # appropriately when length => open access
           expect(resulting_data).to include('embargo_length' => described_class::NO_EMBARGO,
                                             'embargo_type' => 'value does not change')
         end
@@ -593,11 +593,11 @@ RSpec.describe InProgressEtd do
   end
 
   describe '#refresh_from_etd!' do
-    let(:refreshed_data) { JSON.parse(ipe.data) }
+    let(:refreshed_data) { ipe.data }
     before { ipe.refresh_from_etd! }
 
     context 'without an associated Etd record' do
-      let(:ipe) { described_class.new(etd_id: nil, data: data.to_json) }
+      let(:ipe) { described_class.new(etd_id: nil, data: data) }
       let(:data) { { 'title' => ['Title from IPE'] } }
 
       it 'keeps the old data' do
@@ -643,7 +643,7 @@ RSpec.describe InProgressEtd do
       end
 
       it 'includes the file info in the JSON datastore' do
-        expect(JSON.parse(refreshed_data['files'])).to eq({
+        expect(refreshed_data['files']).to eq({
           'id' => primary_pdf_fs.id,
           'name' => 'joey_thesis.pdf',
           'size' => primary_pdf_fs.file_size.first,
@@ -651,7 +651,7 @@ RSpec.describe InProgressEtd do
           'deleteType' => 'DELETE'
         })
 
-        expect(JSON.parse(refreshed_data['supplemental_files'])).to contain_exactly(
+        expect(refreshed_data['supplemental_files']).to contain_exactly(
           {
             'id' => supp_1_fs.id,
             'name' => 'nasa.jpeg',
@@ -689,7 +689,7 @@ RSpec.describe InProgressEtd do
       let(:stale_data) {
         {
         title: 'Stale Title from IPE',
-        partnering_agency: ['Stale parter agency'],
+        partnering_agency: ['Stale partner agency'],
         embargo_length: '1000 years',
         department: 'Some',
         other_copyrights: 'true',
@@ -718,7 +718,7 @@ RSpec.describe InProgressEtd do
       end
 
       let(:etd) { Etd.create!(new_data) }
-      let(:ipe) { described_class.new(etd_id: etd.id, data: stale_data.to_json) }
+      let(:ipe) { described_class.new(etd_id: etd.id, data: stale_data) }
 
       it 'replaces the stale data with updated data', :aggregate_failures do
         special_comparisons = ['title', 'degree_awarded', 'department', 'files_embargoed', 'toc_embargoed',
@@ -761,22 +761,22 @@ RSpec.describe InProgressEtd do
     end
 
     it 'is nil when no school or department are set' do
-      ipe = described_class.new(data: {}.to_json)
+      ipe = described_class.new(data: {})
       expect(ipe.admin_set).to be_nil
     end
 
     it 'returns the school admin set if it exists' do
-      ipe = described_class.new(data: { school: 'Henson College' }.to_json)
+      ipe = described_class.new(data: { school: 'Henson College' })
       expect(ipe.admin_set).to eq school_admin_set
     end
 
     it 'returns the department admin set if it exists' do
-      ipe = described_class.new(data: { department: 'Design and Fabrication' }.to_json)
+      ipe = described_class.new(data: { department: 'Design and Fabrication' })
       expect(ipe.admin_set).to eq department_admin_set
     end
 
-    it 'prioritzes school matches' do
-      ipe = described_class.new(data: { school: 'Henson College', department: 'Design and Fabrication' }.to_json)
+    it 'prioritizes school matches' do
+      ipe = described_class.new(data: { school: 'Henson College', department: 'Design and Fabrication' })
       expect(ipe.admin_set).to eq school_admin_set
     end
   end

--- a/spec/validators/about_me_validator_spec.rb
+++ b/spec/validators/about_me_validator_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 describe AboutMeValidator do
-  context "parsed_data method" do
-    subject(:about_me_validator) { described_class.new }
-    let(:record) { InProgressEtd.new }
-    it "returns an empty hash if passed a record without data" do
-      expect(about_me_validator.parsed_data(record)).to eq({})
-    end
+  let(:record) { InProgressEtd.new(data: { 'currentTab': 'About Me', 'creator': '', 'post_graduation_email': 'graduate@somewhere.else' }) }
+  it 'returns an empty hash if passed a record without data' do
+    expect(record.valid?).to be false
+    expect(record.errors.details).to include(school: [{ error: "school is required" }])
   end
 end


### PR DESCRIPTION
**ISSUE**
There were an exceedingly large number of calls to `JSON.parse()` and `#to_json` throughout the InProgressEtd codebase. The only time we really need to cast to a string is to save to the Database, which Rails can handle for us.

**REFACTOR**
Add a serializer to convert the `data` attribute between JSON and String when writing and reading to the database. Then we can simply access `data` as a hash wherever it needs to be read or modified.