### PR TITLE
FIX Default department selection

### DIFF
--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -355,11 +355,7 @@ export const formStore = {
   },
 
   getDepartment () {
-    if (this.selectedDepartment.length > 0) {
-      return this.selectedDepartment
-    } else {
-      return this.savedData['department']
-    }
+    return this.selectedDepartment || this.savedData['department'] || ''
   },
 
   setDepartment (department) {

--- a/app/javascript/test/Department.spec.js
+++ b/app/javascript/test/Department.spec.js
@@ -51,6 +51,7 @@ describe('Department.vue', () => {
     // use findAll instead of find to ensure we only have one disabled option
     const disabled_option = wrapper.findAll('#department option[disabled]').wrappers.map((wrapper) => wrapper.text())
     expect(disabled_option).toEqual(['Select a Department'])
+    expect(wrapper.vm.selected).toEqual('')
   })
 
   it('lists inacive departments in advanced mode', async () =>  {

--- a/app/javascript/test/components/submit/MyProgram.spec.js
+++ b/app/javascript/test/components/submit/MyProgram.spec.js
@@ -9,7 +9,7 @@ import { formStore } from '../../../formStore'
 
 formStore.getSavedOrSelectedSchool = jest.fn((value) => { return 'Rollins School of Public Health' })
 formStore.savedData['partnering_agency'] = ['CDC', 'Does not apply (no collaborating organization)']
-formStore.departments = [{'value':1,'active':true,'label':'Select a Department','disabled':'disabled','selected':'selected'},{'id':'Divinity','label':'Divinity','active':true},{'id':'Ministry','label':'Ministry','active':true},{'id':'Pastoral Counseling','label':'Pastoral Counseling','active':true},{'id':'Theological Studies','label':'Theological Studies','active':true}]
+formStore.departments = [{'id':'','active':true,'label':'Select a Department','disabled':'disabled','selected':'selected'},{'id':'Divinity','label':'Divinity','active':true},{'id':'Ministry','label':'Ministry','active':true},{'id':'Pastoral Counseling','label':'Pastoral Counseling','active':true},{'id':'Theological Studies','label':'Theological Studies','active':true}]
 describe('MyProgram.vue', () => {
   it('has the correct label', () => {
     const wrapper = shallowMount(MyProgram, {

--- a/app/javascript/test/components/submit/MyProgramNoAgencies.spec.js
+++ b/app/javascript/test/components/submit/MyProgramNoAgencies.spec.js
@@ -8,7 +8,7 @@ import { formStore } from '../../../formStore'
 
 formStore.getSavedOrSelectedSchool = jest.fn((value) => { return 'Rollins School of Public Health' })
 formStore.savedData['partnering_agency'] = ['Does not apply (no collaborating organization)']
-formStore.departments = [{'value':1,'active':true,'label':'Select a Department','disabled':'disabled','selected':'selected'},{'id':'Divinity','label':'Divinity','active':true},{'id':'Ministry','label':'Ministry','active':true},{'id':'Pastoral Counseling','label':'Pastoral Counseling','active':true},{'id':'Theological Studies','label':'Theological Studies','active':true}]
+formStore.departments = [{'id':'','active':true,'label':'Select a Department','disabled':'disabled','selected':'selected'},{'id':'Divinity','label':'Divinity','active':true},{'id':'Ministry','label':'Ministry','active':true},{'id':'Pastoral Counseling','label':'Pastoral Counseling','active':true},{'id':'Theological Studies','label':'Theological Studies','active':true}]
 describe('MyProgram.vue with no agencies', () => {
 
   it('has the correct label', () => {


### PR DESCRIPTION
**ISSUE**
The department selection box was not displaying "Select a Department" when it was originally rendered.

**DIAGNOSIS**
The Department component was resetting the selected value using the getDepartment() function on load. The function was returning `undefied` instead of the empty string that other code was expecting.

**FIX**
Ensure getDepartment() returns an empty string instead of `undefined` when no department is set or selected.