### PR TITLE
FIX department selection persistence bugs

### DIFF
--- a/app/javascript/Department.vue
+++ b/app/javascript/Department.vue
@@ -1,58 +1,38 @@
 <template>
     <div>
-      <label for="department"> {{ sharedState.getDepartmentHeading() }} </label>
-        <select id="department" name="etd[department]" class="form-control" aria-required="true" v-model="selected"
-                v-on:change="this.sharedState.getSubfields(), sharedState.setDepartment(selected), sharedState.setValid('My Program', false)">
-            <option v-for="department in departments"
+      <label for="department"> {{ formStore.getDepartmentHeading() }} </label>
+        <select id="department" name="etd[department]" class="form-control" aria-required="true" v-model="selected">
+            <option v-for="department in formStore.departments"
                     v-bind:value="department.id"
                     v-bind:disabled="department.disabled">
-                    {{ labelFor(department.label, department.active) }}
+                    {{ department.label }}
             </option>
         </select>
     </div>
 </template>
 
 <script>
-import axios from "axios"
 import {formStore} from './formStore'
-import {labelFor, showInactive} from './lib/formHelpers'
 
 export default {
-  data() {
-    return {
-      sharedState: formStore,
-      selected: '',
-      departmentsEndpoint: '',
-      departments: {}
+  computed: {
+    formStore() {
+      return formStore
     }
   },
-  created() {
-    this.selected = this.sharedState.getDepartment()
-    this.fetchData()
-    this.sharedState.getSubfields()
+  data() {
+    return {
+      selected: formStore.getDepartment(),
+    }
   },
-  methods: {
-    labelFor,
-    fetchData() {
-      // We need to choose a department list based on the selected school
-      this.departmentsEndpoint = this.sharedState.schools[this.sharedState.getSavedOrSelectedSchool()]
-      axios.get(this.departmentsEndpoint).then(response => {
-        this.departments = this.getSelected(response.data)
-      }).catch(e => {
-        console.log(e)
-      })
-    },
-    getSelected(data){
-      // Add a placeholder option at the top of the options list
-      data.unshift({ "label": `Select a ${this.sharedState.getDepartmentHeading()}`, "disabled":"disabled","active": true, "id": "" })
-
-      // If a previously saved option exists, ensure it's active
-      // If no match is found, we use the placeholder index
-      const selected_index = Math.max(data.findIndex((option) => option.id === this.selected),0)
-      data[selected_index].active = true
-
-      // Filter out inactive options when appropriate
-      return showInactive() ? data : data.filter((option) => option.active)
+  beforeCreate() {
+    formStore.loadDepartments()
+  },
+  watch: {
+    selected(newDepartment) {
+      formStore.setDepartment(newDepartment)
+      formStore.getSubfields()
+      formStore.setValid('My Program', false)
     }
   }
 }

--- a/app/javascript/School.vue
+++ b/app/javascript/School.vue
@@ -38,9 +38,8 @@ export default {
   },
   methods: {
     fetchData() {
-      const selectedSchool = this.sharedState.schools[this.selected]
       this.sharedState.setSelectedSchool(this.selected)
-      this.sharedState.getDepartments(selectedSchool)
+      this.sharedState.loadDepartments()
     }
   },
   mounted: function() {

--- a/app/javascript/Subfield.vue
+++ b/app/javascript/Subfield.vue
@@ -19,6 +19,9 @@ export default {
       sharedState: formStore
     }
   },
+  beforeMount() {
+    this.sharedState.getSubfields()
+  },
   mounted: function(){
     this.$nextTick(function () {
       this.selected = this.sharedState.getSavedOrSelectedSubfield()

--- a/app/javascript/formStore.js
+++ b/app/javascript/formStore.js
@@ -14,6 +14,7 @@ import embargoLengths from './config/embargoLengths.json'
 import schools from './config/schools.json'
 import helpText from './config/helpText.json'
 import PartneringAgency from './lib/PartneringAgency'
+import {labelFor, showInactive} from "./lib/formHelpers";
 
 export const formStore = {
   tabs: {
@@ -362,29 +363,36 @@ export const formStore = {
     this.selectedDepartment = department
   },
 
-  getDepartments (selectedSchool) {
-    if (!this.allowTabSave()) {
-      var savedValue = { "value": this.getDepartment(), "active": true, "label": this.getDepartment(), "selected": "selected" }
-      axios.get(selectedSchool).then(response => {
-        this.departments = response.data
-        if (!this.allowTabSave()) {
-          this.departments.unshift(savedValue)
-        }
-      })
-      return savedValue
-    } else {
-      axios.get(selectedSchool).then(response => {
-        const departmentsFromQA = response.data.filter(function(val) { if (val.active != false) { return val } })
-        const prompt = 'Select a ' + this.getDepartmentHeading()
-        departmentsFromQA.unshift({ "value": prompt, "active": true, "label": prompt, "id": prompt,  "disabled":"disabled", "selected": "selected"})
-        this.departments = departmentsFromQA
-      })
-    }
-  },
   loadDepartments () {
-    var schoolEndpoint = this.schools[this.getSavedOrSelectedSchool()]
-    this.getDepartments(schoolEndpoint)
+    // The deparment list depends on the current school
+    const departmentsEndpoint = this.schools[this.getSavedOrSelectedSchool()]
+    let departmentOptions = []
+    axios.get(departmentsEndpoint).then(response => {
+      this.setupDepartmentOptions(response.data)
+    }).catch(e => {
+      console.log(e)
+    })
   },
+
+  setupDepartmentOptions (authority_data) {
+    // Add a placeholder option at the top of the options list
+    authority_data.unshift({ "id": "", "label": `Select a ${this.getDepartmentHeading()}`,"active": true, "disabled":"disabled" })
+
+    // If a previously saved option exists, ensure it's active
+    // If no match is found, use the placeholder option (i.e. set index to 0)
+    this.selectedDepartment = this.getDepartment()
+    const selected_index = Math.max(authority_data.findIndex((option) => option.id === this.selectedDepartment),0)
+    authority_data[selected_index].active = true
+
+    // Flag inactive department labels
+    authority_data.forEach((dept_option) => {
+      dept_option.label = labelFor(dept_option.label, dept_option.active)
+    })
+
+    // Filter out inactive options when appropriate
+    this.departments = showInactive() ? authority_data : authority_data.filter((option) => option.active)
+  },
+
   getDepartmentLabelFromId (id) {
     if(this.departments.length > 0){
       return this.departments.filter((department) => { return department.id === id })[0].label

--- a/app/javascript/lib/formHelpers.js
+++ b/app/javascript/lib/formHelpers.js
@@ -6,6 +6,6 @@ export function labelFor(label, active) {
     if (active === true) {
         return label
     } else {
-        return `⚠️ ${label}`
+        return `⚠️ ${label} (inactive)`
     }
 }

--- a/app/javascript/test/App.spec.js
+++ b/app/javascript/test/App.spec.js
@@ -3,9 +3,6 @@
 /* global expect */
 import { shallowMount } from '@vue/test-utils'
 import App from 'App'
-import { quillEditor } from 'vue-quill-editor'
-import axios from 'axios'
-jest.mock('axios')
 
 describe('App.vue', () => {
   it('renders a form', () => {
@@ -90,8 +87,7 @@ describe('App.vue', () => {
       expect(wrapper.find('h1').text()).toBe('Submit Your Thesis or Dissertation')
     })
     it("displays all of the user's data on the submit tab", () => {
-      const wrapper = shallowMount(App, {
-      })
+
     })
     it('lets the user submit their data for publication as an ETD', () => {
 
@@ -137,7 +133,7 @@ describe('App.vue', () => {
       wrapper.vm.$data.sharedState.tabs.my_files.complete = false
       wrapper.vm.$data.sharedState.tabs.embargo.complete = false
 
-      wrapper.vm.$data.sharedState.hasError = jest.fn((value) => { return true })
+      wrapper.vm.$data.sharedState.hasError = jest.fn(() => { return true })
 
       expect(wrapper.html()).toContain('Table of Contents is required')
       expect(wrapper.html()).toContain('Abstract is required')      
@@ -146,12 +142,13 @@ describe('App.vue', () => {
 
   describe('Edit form:', () => {
     it('contains hidden flag needed on back end', () => {
-      const wrapper = shallowMount(App, { })
-      expect(wrapper.contains('input[name=request_from_form][value=true]')).toBe(true)
+      const wrapper = shallowMount(App)
+      const hiddenFlag = wrapper.find('input[name="request_from_form"][value="true"]')
+      expect(hiddenFlag.exists()).toBe(true)
     })
 
     it('with an associated ETD record, renders the form without tabs', () => {
-      const wrapper = shallowMount(App, { })
+      const wrapper = shallowMount(App)
       wrapper.vm.$data.sharedState.setEtdId('123')
       expect(wrapper.html()).toContain('Submit Your Thesis')
       expect(wrapper.findAll('ul.navtabs').length).toEqual(0)

--- a/app/javascript/test/Department.spec.js
+++ b/app/javascript/test/Department.spec.js
@@ -2,15 +2,15 @@
 /* global it */
 /* global expect */
 /* global jest */
-import { shallowMount, flushPromises } from '@vue/test-utils'
+import {shallowMount} from '@vue/test-utils'
 import Department from 'Department'
+import * as formHelpers from "../lib/formHelpers"
 import axios from 'axios'
-import * as formHelpers from "../lib/formHelpers";
 jest.mock('axios')
 
 describe('Department.vue', () => {
   beforeEach(() => {
-    // mock an response from the candler_rograms endpoint
+    // mock a response from the candler_programs endpoint
     const mockResponse =  {data:
         [ {"id":"Divinity",             "label":"Divinity",             "active":true},
           {"id":"Ministry",             "label":"Ministry",             "active":true},
@@ -25,16 +25,13 @@ describe('Department.vue', () => {
   })
 
   it('lists active departments', async () =>  {
-    const wrapper = shallowMount(Department, {
-      data() {
-        // set Candler as the previously saved school
-        return {sharedState: {savedData: {school: 'Candler School of Theology'}}}
-      }
-    })
+    const wrapper = shallowMount(Department)
 
-    await flushPromises
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$forceUpdate()
 
     const enabled_options = wrapper.findAll('option:not([disabled])').wrappers.map((wrapper) => wrapper.text())
+
     expect(enabled_options).toEqual(['Divinity', 'Ministry'])
   })
 
@@ -46,7 +43,8 @@ describe('Department.vue', () => {
       }
     })
 
-    await flushPromises
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$forceUpdate()
 
     // use findAll instead of find to ensure we only have one disabled option
     const disabled_option = wrapper.findAll('#department option[disabled]').wrappers.map((wrapper) => wrapper.text())
@@ -54,46 +52,38 @@ describe('Department.vue', () => {
     expect(wrapper.vm.selected).toEqual('')
   })
 
-  it('lists inacive departments in advanced mode', async () =>  {
+  it('lists inactive departments in advanced mode', async () =>  {
     // render the form using the admin view option
     jest.spyOn(formHelpers, "showInactive").mockReturnValue(true);
 
-    const wrapper = shallowMount(Department, {
-      data() {
-        // set Candler as the previously saved school
-        return {sharedState: {savedData: {school: 'Candler School of Theology'}}}
-      }
-    })
-
-    await flushPromises
+    const wrapper = shallowMount(Department)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$forceUpdate()
 
     const enabled_options = wrapper.findAll('option:not([disabled])').wrappers.map((wrapper) => wrapper.text())
-    expect(enabled_options).toEqual(['Divinity', 'Ministry', '⚠️ Pastoral Counseling', '⚠️ Theological Studies'])
+    expect(enabled_options).toEqual(['Divinity', 'Ministry', '⚠️ Pastoral Counseling (inactive)', '⚠️ Theological Studies (inactive)'])
   })
 
-  it('lists includes inactive departments if they were preiously saved', async () =>  {
-    const wrapper = shallowMount(Department, {
-      data() {
-        // set Candler as the previously saved school
-        return {sharedState: {savedData: {school: 'Candler School of Theology', department: 'Theological Studies'}}}
-      }
-    })
+  it('lists includes inactive departments if they were previously saved', async () =>  {
+    const wrapper = shallowMount(Department)
 
-    await flushPromises
+    wrapper.vm.formStore.savedData['department'] = 'Theological Studies'
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$forceUpdate()
 
     const enabled_options = wrapper.findAll('option:not([disabled])').wrappers.map((wrapper) => wrapper.text())
     expect(enabled_options).toEqual(['Divinity', 'Ministry', 'Theological Studies'])
   })
 
   it('Uses "Specialty" instead of "Department" for School of Nursing ', async () =>  {
-    const wrapper = shallowMount(Department, {
-      data() {
-        // set Candler as the previously saved school
-        return {sharedState: {savedData: {school: 'Nell Hodgson Woodruff School of Nursing'}}}
-      }
-    })
+    const wrapper = shallowMount(Department)
 
-    await flushPromises
+    wrapper.vm.formStore.savedData['school'] = 'Nell Hodgson Woodruff School of Nursing'
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$forceUpdate()
+
+    // Check the input label
+    expect(wrapper.find('label[for="department"').text()).toEqual('Specialty')
 
     // Check the text of the first option
     expect(wrapper.find('#department option').text()).toEqual('Select a Specialty')

--- a/app/javascript/test/LegacyGraduation.spec.js
+++ b/app/javascript/test/LegacyGraduation.spec.js
@@ -65,6 +65,6 @@ describe('GraduationDate.vue with an inactive legacy term', () => {
     await flushPromises
 
     const option_labels = wrapper.findAll('#graduation-date option').wrappers.map((option) => option.text())
-    expect(option_labels).toEqual(['Select a Graduation Date', 'Fall 2017', '⚠️ 2013'])
+    expect(option_labels).toEqual(['Select a Graduation Date', 'Fall 2017', '⚠️ 2013 (inactive)'])
   })
 })

--- a/app/javascript/test/Subfield.spec.js
+++ b/app/javascript/test/Subfield.spec.js
@@ -4,37 +4,30 @@
 import { shallowMount } from '@vue/test-utils'
 import Subfield from 'Subfield'
 
-describe('Subfield.vue', () => {
-  beforeEach(() => {
-    const wrapper = shallowMount(Subfield, {
-    })
-    wrapper.vm.$data.sharedState.subfields = [{ id: 'MPH', label: 'MPH' }]
-  })
 
+describe('Subfield.vue', () => {
   it('renders a select element', () => {
     const wrapper = shallowMount(Subfield, {
     })
+    wrapper.vm.$data.sharedState.subfields = [{ id: 'MPH', label: 'MPH' }]
     expect(wrapper.findAll('select')).toHaveLength(1)
   })
 
   it('has a label that contains Subfield', () => {
     const wrapper = shallowMount(Subfield, {
     })
+    wrapper.vm.$data.sharedState.subfields = [{ id: 'MPH', label: 'MPH' }]
     expect(wrapper.findAll('label')).toHaveLength(1)
   })
 
   it('has the correct html', () => {
     const wrapper = shallowMount(Subfield, {
     })
+    wrapper.vm.$data.sharedState.subfields = [{ id: 'MPH', label: 'MPH' }]
     expect(wrapper.html()).toEqual(`<div><label for=\"subfield\">Subfield</label> <select id=\"subfield\" name=\"etd[subfield]\" class=\"form-control\"><option value=\"MPH\">MPH</option></select></div>`)
   })
 
   describe('Subfield.vue without Subfield data', () => {
-    beforeEach(() => {
-      const wrapper = shallowMount(Subfield, {
-      })
-      wrapper.vm.$data.sharedState.subfields = []
-    })
     it('does not render a select element', () => {
       const wrapper = shallowMount(Subfield, {
       })

--- a/app/javascript/test/formStore.spec.js
+++ b/app/javascript/test/formStore.spec.js
@@ -27,14 +27,6 @@ describe('formStore', () => {
     expect(formStore.tabs.submit.label).toEqual('Submit')
   })
 
-  it('loads the saved department as the first choice', () => {
-
-    formStore.allowTabSave = jest.fn(() => { return false })
-    formStore.getDepartment = jest.fn(() => { return 'African Studies' })
-    formStore.getDepartments()
-    expect(formStore.getDepartments()).toEqual({'active': true, 'label': 'African Studies', 'selected': 'selected', 'value': 'African Studies'})
-  })
-
   it('returns the correct embargo length based on the selected school', () => {
     formStore.setSelectedSchool('Emory College')
     expect(formStore.getEmbargoLengths()).toEqual([{ value: 'None - open access immediately', selected: 'selected' },


### PR DESCRIPTION
**ISSUE**
The selected department was not consistently being restored depending on how you loaded and naviaged the tabs.

**DIAGNOSIS**
Unclear reactivity relations caused the selection setting to occur before the dynamic options list was populated.

**SOLUTION**
Refactor the code to minimize the number of objects that are managed reactively (i.e. only the selection, not the entire formStore)