### PR TITLE
Fix flakey permission test

### DIFF
--- a/spec/services/permission_checker_spec.rb
+++ b/spec/services/permission_checker_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe PermissionChecker, use_transactional_tests: false do
     # Wrap the entire context in a transaction
     ActiveRecord::Base.connection.begin_transaction
 
+    # Remove any pre-existing AdminSets
+    AdminSet.all.each do |admin_set|
+      admin_set.delete
+      ActiveFedora::Base.eradicate(admin_set.id)
+    end
+
     # Set Up Workflows
     Hyrax::Workflow::WorkflowImporter.path_to_workflow_files = "#{fixture_path}/config/workflows/minimal_one_step_approval.json"
     WorkflowSetup.new("#{fixture_path}/config/emory/superusers_db_only.yml", "#{fixture_path}/config/emory/admin_sets_school_department.yml", "/dev/null").setup


### PR DESCRIPTION
**ISSUE**
Tests are intermittently failing with the error
```
 ActiveRecord::RecordNotFound:
        Couldn't find Hyrax::PermissionTemplate
```

**DIAGNOSIS**
Depending on the test execution order, some AdminSets may have been previously created without corresponding PermissionTemplates. When the WorkflowSetup code attempts to attach roles to all AdminSets, the code fails because other AdminSets aren't set up as expected.

**RESOLUTION**
Remove any pre-existing AdminSets before running the permission test setup.