### PR TITLE
Simplify AWS tag management

### DIFF
--- a/app/lib/runtime_info.rb
+++ b/app/lib/runtime_info.rb
@@ -5,21 +5,19 @@ require 'aws-sdk-core/ec2_metadata'
 include ActionView::Helpers::TagHelper
 
 class RuntimeInfo
-  TAG_MAPPER = { 'prod' => 'production', 'stage' => 'staging', 'qa' => 'qa testing' }.freeze
-
   class << self
     def badge
-      @badge ||= tag.div(environment.titleize, id: 'environment_badge', class: display_class)
+      @badge ||= tag.div(environment, id: 'environment_badge', class: display_class)
     end
 
     def environment
-      TAG_MAPPER[environment_tag] || environment_tag || Rails.env
+      environment_tag || Rails.env
     end
 
     private
 
     def display_class
-      'hidden' if environment_tag == 'prod'
+      'hidden' if environment == 'Production'
     end
 
     def environment_tag

--- a/config/deploy/ssm.rb
+++ b/config/deploy/ssm.rb
@@ -12,7 +12,7 @@
 
 require 'net/ssh/proxy/command'
 set :rails_env, 'production'
-set :host_env, -> { ENV['HOST_ENV'] || 'stage' }
+set :host_env, -> { ENV['HOST_ENV'] || 'Staging' }
 set :instance_id, lambda {
                     ENV['HOST_ID'] ||
                       `aws ec2 describe-instances --region us-east-2  --profile emory-etd \

--- a/spec/lib/runtime_info_spec.rb
+++ b/spec/lib/runtime_info_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe RuntimeInfo do
+  # We're seeing intermittent failures in other tests that expect the Rails
+  # environment to be set to test, so ensure it's propoerly reset here.
+  after(:all) do
+    Rails.env = 'test'.inquiry unless Rails.env.test?
+  end
+
   describe '.environment' do
     describe 'in AWS environments' do
       let(:response) { nil }
@@ -18,31 +24,17 @@ RSpec.describe RuntimeInfo do
         allow(metadata_service).to receive(:get).and_return(response)
       end
 
-      context 'with tag:Environment=prod' do
-        let(:response) { 'prod' }
-        it 'returns "Production"' do
-          expect(described_class.environment).to eq('production')
+      context 'with tag:Environment=QA' do
+        let(:response) { 'QA' }
+        it 'keeps capitalization' do
+          expect(described_class.environment).to eq('QA')
         end
       end
 
-      context 'with tag:Environment=stage' do
-        let(:response) { 'stage' }
-        it 'returns "Staging"' do
-          expect(described_class.environment).to eq('staging')
-        end
-      end
-
-      context 'with tag:Environment=qa' do
-        let(:response) { 'qa' }
-        it 'returns "quality assurance"' do
-          expect(described_class.environment).to eq('qa testing')
-        end
-      end
-
-      context 'with tag:Environment=any other string' do
-        let(:response) { 'any_other_string' }
+      context 'with tag:Environment=any_string' do
+        let(:response) { 'any_string' }
         it 'returns the tag' do
-          expect(described_class.environment).to eq('any_other_string')
+          expect(described_class.environment).to eq('any_string')
         end
       end
 
@@ -56,7 +48,7 @@ RSpec.describe RuntimeInfo do
           allow(metadata_service).to receive(:get).and_raise(Aws::EC2Metadata::MetadataNotFoundError)
         end
 
-        it 'returns the Rails environment' do
+        it 'returns the a tag missing message' do
           expect(described_class.environment).to match('missing')
         end
       end
@@ -64,7 +56,7 @@ RSpec.describe RuntimeInfo do
 
     describe 'in local environments' do
       before do
-        allow(Rails).to receive(:env).and_return('test')
+        allow(Rails).to receive(:env).and_return('test'.inquiry)
 
         # stub an EC2Metadata object
         metadata_service = instance_double(Aws::EC2Metadata)
@@ -82,7 +74,7 @@ RSpec.describe RuntimeInfo do
 
       context 'in development' do
         before do
-          allow(Rails).to receive(:env).and_return('development')
+          allow(Rails).to receive(:env).and_return('development'.inquiry)
         end
 
         it 'returns the Rails environment' do
@@ -99,7 +91,7 @@ RSpec.describe RuntimeInfo do
       context 'in EC2 production environments' do
         before do
           allow(described_class).to receive(:ec2?).and_return(true)
-          allow(described_class).to receive(:environment_tag).and_return('prod')
+          allow(described_class).to receive(:environment_tag).and_return('Production')
         end
 
         it 'returns a hidden div' do
@@ -109,7 +101,7 @@ RSpec.describe RuntimeInfo do
 
       context 'in non-EC2 environments' do
         it 'returns the rails environment' do
-          expect(described_class.badge).to match(/>Test</)
+          expect(described_class.badge).to match(/>test</)
         end
 
         it 'is not hidden' do
@@ -119,7 +111,7 @@ RSpec.describe RuntimeInfo do
 
       context 'in other environments' do
         before do
-          allow(described_class).to receive(:environment_tag).and_return('testing qa3')
+          allow(described_class).to receive(:environment_tag).and_return('testing QA3')
           allow(described_class).to receive(:ec2?).and_return(true)
         end
 
@@ -127,8 +119,8 @@ RSpec.describe RuntimeInfo do
           expect(described_class.badge).to match('<div id="environment_badge"')
         end
 
-        it 'capitalizes the envioronment name' do
-          expect(described_class.badge).to match('Testing Qa3')
+        it 'does not modify the tag' do
+          expect(described_class.badge).to match('testing QA3')
         end
       end
     end

--- a/spec/views/masthead.html.erb_spec.rb
+++ b/spec/views/masthead.html.erb_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe "_masthead", type: :view do
 
   it "dsiplays the current environment (Test)" do
     render
-    expect(rendered).to have_selector('div', id: 'environment_badge', text: 'Test')
+    expect(rendered).to have_selector('div', id: 'environment_badge', text: 'test')
   end
 end


### PR DESCRIPTION
**ISSUE**
Previously, we mapped AWS tags for banners and deployment. This required some level of contextual awareness about what tag form was appropriate in what context. It also added code to handle the mapping in deployment and display contexts.

**RESOLUTION**
Use the same labels in AWS we want to see and use
throughout the application.

**EXAMPLES**
OLD TAGS
* prod
* stage
* qa

NEW TAGS
* Production
* Staging
* QA