### PR TITLE
Fix date sorting order on Review Submissions page

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -37,7 +37,7 @@
                         <td>
                           <%= safe_join(document.creator, tag(:br)) %>
                         </td>
-                        <td>
+                        <td data-order="<%= document.date_modified -%>">
                           <%= formatted_date(document.date_modified) %>
                         </td>
                         <td>
@@ -77,7 +77,7 @@
                         <td>
                           <%= safe_join(document.creator, tag(:br)) %>
                         </td>
-                        <td>
+                        <td data-order="<%= document.date_modified -%>">
                           <%= formatted_date(document.date_modified) %>
                         </td>
                         <td>


### PR DESCRIPTION
**ISSUE**
Dates in the table were being sorted lexically instead of in date order.

**FIX**
Provide a `data-order` field that sorts correctly in date order.