### PR TITLE
Update Laney and Rollins programs

### DIFF
--- a/config/authorities/laney_programs.yml
+++ b/config/authorities/laney_programs.yml
@@ -29,6 +29,7 @@ terms:
       term: Economics
     - id: Educational Studies
       term: Educational Studies
+      active: false
     - id: English
       term: English
     - id: Environmental Health
@@ -39,10 +40,12 @@ terms:
       term: Epidemiology
     - id: Film and Media Studies
       term: Film and Media Studies
+      active: false
     - id: French
       term: French
     - id: Graduate Institute of the Liberal Arts
       term: Graduate Institute of the Liberal Arts
+      active: false
     - id: Health Services and Research Health Policy
       term: Health Services and Research Health Policy
     - id: Hispanic Studies
@@ -53,6 +56,7 @@ terms:
       term: Islamic Civilizations Studies
     - id: Jewish Studies
       term: Jewish Studies
+      active: false
     - id: Mathematics
       term: Mathematics
     - id: Music
@@ -75,5 +79,6 @@ terms:
       term: Sociology
     - id: Spanish
       term: Spanish
+      active: false
     - id: Women's, Gender, and Sexuality Studies
       term: Women's, Gender, and Sexuality Studies

--- a/config/authorities/rollins_programs.yml
+++ b/config/authorities/rollins_programs.yml
@@ -4,6 +4,12 @@
 # `config/emory/admin_sets.yml`, both in this code base and on every server
 # where this code is deployed.
 terms:
+    - id: Applied Epidemiology
+      term: Applied Epidemiology
+      active: false
+    - id: Applied Public Health Informatics
+      term: Applied Public Health Informatics
+      active: false
     - id: Behavioral Sciences and Health Education
       term: Behavioral, Social, and Health Education Sciences
     - id: Biostatistics
@@ -19,11 +25,11 @@ terms:
     - id: Hubert Department of Global Health
       term: Hubert Department of Global Health - MPH
     - id: Biostatistics and Bioinformatics
-      term: Biostatistics and Bioinformatics
+      term: "[migrated] Biostatistics and Bioinformatics"
       active: false
     - id: Career Masters of Public Health
-      term: Career Masters of Public Health
+      term: "[migrated] Career Masters of Public Health"
       active: false
     - id: Executive Masters of Public Health
-      term: Executive Masters of Public Health
+      term: "[migrated] Executive Masters of Public Health"
       active: false


### PR DESCRIPTION
**ISSUE**
In order to edit ETDs submitted with various legacy department names, those departments need to be in the present in the vocabulary. If the department name is not present, the ETD may not be editable or may cause an exception when trying to save it.

**RESOLUTION**
Ensure legacy department names are in the program lists for relevant schools.

NOTE: This P.R. also deactivates Laney schools per Freshdesk Ticket [#251](https://curationexperts.freshdesk.com/a/tickets/251)