### PR TITLE
Fix webpacker compliation issues during deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,6 +14,10 @@ set :bundle_env_variables, nokogiri_use_system_libraries: 1
 set :keep_releases, 5
 set :assets_prefix, "#{shared_path}/public/assets"
 
+set :default_env, {
+  'NODE_OPTIONS' => '--openssl-legacy-provider'
+}
+
 SSHKit.config.command_map[:rake] = 'bundle exec rake'
 
 # Default branch is :main


### PR DESCRIPTION
**ISSUE**
Capistrano was failing on the `rake assets:precompile` step due to a silent webpacker compile failure.

**RESOLUTION**
Allow the webpacker compiler to run with legacy SSL config.

see also:
https://codingbeautydev.com/blog/node-err-ossl-evp-unsupported/