### PR TITLE
Change Emory College department name

### DIFF
--- a/config/authorities/emory_programs.yml
+++ b/config/authorities/emory_programs.yml
@@ -126,8 +126,8 @@ terms:
       term: Psychology
     - id: Psychology and Linguistics
       term: Psychology and Linguistics
-    - id: Quantitative Science
-      term: Quantitative Science
+    - id: Quantitative Theory and Methods
+      term: Quantitative Theory and Methods
       active: false
     - id: Religion
       term: Religion


### PR DESCRIPTION
"Quantitative Science" --> "Data and Decision Sciences"

This is a legacy department name which needs to be in the list to support editing published ETDs, but is inactive and can not be selected for new submissions.