### PR TITLE
Update school links in page footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,10 +9,10 @@
       <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/copyright-patents">Copyright & Patents</a></li>
       <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/policies-procedures">Policies & Procedures</a></li>
       <li class="navbar-text"><a href="https://libraries.emory.edu/research/open-access-publishing/emory-repositories-policy/etd/access-restrictions">Access Restrictions</a></li>
-      <li class="navbar-text"><a href="http://www.graduateschool.emory.edu/">Laney Graduate School</a></li>
-      <li class="navbar-text"><a href="https://www.sph.emory.edu/">Rollins School of Public Health</a></li>
-      <li class="navbar-text"><a href="http://candler.emory.edu/index.html">Candler School of Theology</a></li>
-      <li class="navbar-text"><a href="http://college.emory.edu/main/index.html">Emory College</a></li>
+      <li class="navbar-text"><a href="https://graduateschool.emory.edu/">Laney Graduate School</a></li>
+      <li class="navbar-text"><a href="https://sph.emory.edu/">Rollins School of Public Health</a></li>
+      <li class="navbar-text"><a href="https://candler.emory.edu/">Candler School of Theology</a></li>
+      <li class="navbar-text"><a href="https://college.emory.edu/">Emory College</a></li>
       <li class="navbar-text"><a href="https://libraries.emory.edu/">Emory Libraries</a></li>
       <li class="navbar-text">© <%=Time.now.year%> Emory University. Version <span title="<%= GitShaPresenter.sha %>"><%= GitShaPresenter.branch %> updated <%= GitShaPresenter.last_deployed %></span>.</li>
       </ul>


### PR DESCRIPTION
**ISSUE**
A number of the links in the footer were pointing at URLs that return a permanent redirect.

**RESOLUTION**
Update the links to point at the canonical URL for the school sites.

This change also ensures consistent use of HTTPS for links.