### PR TITLE
Fix flaky test and correct typos

### DIFF
--- a/spec/lib/runtime_info_spec.rb
+++ b/spec/lib/runtime_info_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe RuntimeInfo do
   # We're seeing intermittent failures in other tests that expect the Rails
-  # environment to be set to test, so ensure it's propoerly reset here.
+  # environment to be set to test, so ensure it's properly reset here.
   after(:all) do
     Rails.env = 'test'.inquiry unless Rails.env.test?
   end

--- a/spec/views/masthead.html.erb_spec.rb
+++ b/spec/views/masthead.html.erb_spec.rb
@@ -5,9 +5,12 @@ RSpec.describe "_masthead", type: :view do
     allow(view).to receive(:render).and_call_original
     allow(view).to receive(:render).with('/logo').and_return('logo')
     allow(view).to receive(:render).with('/user_util_links').and_return('util_links')
+
+    # Clear any memoized runtime badge from other tests
+    RuntimeInfo.instance_variable_set(:@badge, nil)
   end
 
-  it "dsiplays the current environment (Test)" do
+  it "displays the current environment (Test)" do
     render
     expect(rendered).to have_selector('div', id: 'environment_badge', text: 'test')
   end


### PR DESCRIPTION
**ISSUE**
The environment badge gets memoized and can contain unexpected values depending on the randomized test sequence, causing the mastead test to intermittently fail.

**RESOLUION**
Reset the badge before the test to ensure it is regenerated using test environment defaults before running the masthead spec.