### PR TITLE
Update link to GA Tech Theses & Dissertations

### DIFF
--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,38 +1,52 @@
 <div class="col-xs-12 col-sm-6">
   <h2>Emory Theses and Dissertations</h2>
-  <p>The Emory Theses and Dissertations (ETD) Repository holds capstone scholarly works from the Laney Graduate School, the Rollins School of Public Health, the Candler School of Theology, and the Nell Hodgson Woodruff School of Nursing, as well as undergraduate honors papers from the Emory College of Arts and Sciences.</p>
-  <p>Emory University theses and dissertations submitted before the launch of the ETD repository can be found by searching the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>. The theses and dissertations of the Wallace H. Coulter Department of Biomedical Engineering, a joint degree program by Emory University and Georgia Tech, are available in <a href="https://smartech.gatech.edu/">SMARTech</a>, Georgia Tech’s repository, and in the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>.</p>
+  <p>The Emory Theses and Dissertations (ETD) Repository holds capstone scholarly works from the Laney Graduate School,
+    the Rollins School of Public Health, the Candler School of Theology, and the Nell Hodgson Woodruff School of
+    Nursing, as well as undergraduate honors papers from the Emory College of Arts and Sciences.</p>
+  <p>Emory University theses and dissertations submitted before the launch of the ETD repository can be found by
+    searching the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>. The theses and dissertations
+    of the Wallace H. Coulter Department of Biomedical Engineering, a joint degree program by Emory University and
+    Georgia Tech, are available in <a href="https://hdl.handle.net/1853/67552">SMARTech</a>, Georgia Tech’s repository, and
+    in the <a href="https://search.libraries.emory.edu/">Emory Library Catalog</a>.</p>
   <div class="submit-buttons">
     <%= render 'submit_my_etd' %>
   </div>
   <hr>
   <div class="news-and-announcements">
-  <h2>News & Announcements</h2>
-  <h3>ETD Copyright Workshops</h3>
-  <p>Visit the Emory Libraries' Scholarly Communications <a href="https://libraries.emory.edu/services/scholarly-communications/workshops">workshop page</a> for upcoming and recorded ETD copyright workshops for your thesis or dissertation.</p>
-  <h3>Submission Forms For All Participants</h3>
-  <p>All students depositing their thesis or dissertation must complete the ETD Submission form:</p>
-  <ul class="submission-forms">
-    <li>
-      <a target:"_blank" href="https://libraries.emory.edu/media/11036">College Honors Program submission form</a>
-    </li>
-    <li>
-      <a target:"_blank" href="https://libraries.emory.edu/media/11041">Candler School of Theology submission form</a>
-    </li>
-    <li>
-      <a target:"_blank" href="https://libraries.emory.edu/media/11046">Rollins School of Public Health submission form</a>
-    </li>
-    <li>
-      <a target:"_blank" href="https://libraries.emory.edu/media/11051">Nell Hodgson Woodruff School of Nursing submission form</a>
-    </li>
-  </ul>
-  <p>This form WHICH REQUIRES THE SIGNATURE OF YOUR ADVISOR gives the library permission to publish your thesis or dissertation on the web; confirms access restrictions -- if any; and certifies that you have secured rights to all content that you will be publishing.</p>
+    <h2>News & Announcements</h2>
+    <h3>ETD Copyright Workshops</h3>
+    <p>Visit the Emory Libraries' Scholarly Communications
+      <a href="https://libraries.emory.edu/services/scholarly-communications/workshops">workshop page</a> for upcoming
+      and recorded ETD copyright workshops for your thesis or dissertation.</p>
+    <h3>Submission Forms For All Participants</h3>
+    <p>All students depositing their thesis or dissertation must complete the ETD Submission form:</p>
+    <ul class="submission-forms">
+      <li>
+        <a target:"_blank" href="https://libraries.emory.edu/media/11036">College Honors Program submission form</a>
+      </li>
+      <li>
+        <a target:"_blank" href="https://libraries.emory.edu/media/11041">Candler School of Theology submission form</a>
+      </li>
+      <li>
+        <a target:"_blank" href="https://libraries.emory.edu/media/11046">Rollins School of Public Health submission
+        form</a>
+      </li>
+      <li>
+        <a target:"_blank" href="https://libraries.emory.edu/media/11051">Nell Hodgson Woodruff School of Nursing
+        submission form</a>
+      </li>
+    </ul>
+    <p>This form WHICH REQUIRES THE SIGNATURE OF YOUR ADVISOR gives the library permission to publish your thesis or
+      dissertation on the web; confirms access restrictions -- if any; and certifies that you have secured rights to all
+      content that you will be publishing.</p>
   </div>
 </div><!-- /.col-xs-6 -->
 
 <div class="col-xs-12 col-sm-6">
-   <ul id="homeTabs" class="nav nav-tabs">
-    <li class="active"><a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a></li>
+  <ul id="homeTabs" class="nav nav-tabs">
+    <li class="active">
+      <a href="#recently_uploaded" data-toggle="tab" role="tab" id="recentTab"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></a>
+    </li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane fade in active" id="recently_uploaded" role="tabpanel" aria-labelledby="recentTab">


### PR DESCRIPTION
* Change the GA Tech link from https://smartech.gatech.edu/  to https://hdl.handle.net/1853/67552
* Reformat for better indentation and wrapping