### PR TITLE
Add formatted 404 Not Found page for bad Collection and Adminset IDs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,10 +37,6 @@ class ApplicationController < ActionController::Base
     root_path
   end
 
-  rescue_from ActionController::RoutingError do |exception|
-    render plain: '404 Not found', status: 404
-  end
-
   private
 
   def append_info_to_payload(payload)

--- a/config/exception_middleware.rb
+++ b/config/exception_middleware.rb
@@ -7,8 +7,8 @@ class ExceptionMiddleware
 
   def call(env)
     @app.call(env)
-  rescue Blacklight::Exceptions::RecordNotFound
+  rescue Blacklight::Exceptions::RecordNotFound, ActiveFedora::ObjectNotFoundError
     # Redirect to non-existant location, which goes to the 404 page
-    [301, { 'Location' => '/not-found', 'Content-Type' => 'text/html' }, ['Moved Permanently']]
+    [301, { 'Location' => '/error_404', 'Content-Type' => 'text/html' }, ['Moved Permanently']]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get 'error_404', to: 'pages#error_404'
+  get 'error_404', to: 'pages#error_404', as: :page_not_found
   # If you go somewhere without a route, show a 404 page
   match '*path', via: :all, to: 'pages#error_404'
 end

--- a/spec/requests/collection_spec.rb
+++ b/spec/requests/collection_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe '/collection ', type: :request do
+  it "returns 404 for a non-existent collections", :aggregate_failures do
+    get hyrax.collection_path('invalid-id')
+    expect(response).to redirect_to page_not_found_path(locale: nil)
+    follow_redirect!
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include "The page you were looking for does not exist"
+  end
+end

--- a/spec/requests/etd_spec.rb
+++ b/spec/requests/etd_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'concerns/etds', type: :request do
+  it "renders the show page" do
+    etd = FactoryBot.create(:etd)
+    get hyrax_etd_path(etd)
+    expect(response).to have_http_status(:success)
+  end
+
+  it "returns 404 for a non-existent record", :aggregate_failures do
+    get hyrax_etd_path('invalid-id')
+    expect(response).to redirect_to page_not_found_path(locale: nil)
+    follow_redirect!
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include "The page you were looking for does not exist"
+  end
+end


### PR DESCRIPTION
**ISSUE**
Invalid AdminSet or Collection IDs in URLs triggered an ActiveFedora::ObjectNotFoundError exception which was not being handled explicity by the application, so we were getting the default Rails 404 page.

**RESOLUTION**
Add the ActiveFedora execption to the existing exception handling for similar Blacklight (Solr) not-found errors.

This change also adds tests for the relevant error handling.