### PR TITLE
Fix File replacement bug

### DIFF
--- a/app/models/in_progress_etd.rb
+++ b/app/models/in_progress_etd.rb
@@ -163,7 +163,7 @@ class InProgressEtd < ApplicationRecord
     new_data['committee_chair_attributes'] = etd.committee_chair
 
     primary_file = file_for_refresh(etd.primary_file_fs.first)
-    new_data['files'] = primary_file unless primary_file.blank?
+    new_data['files'] = primary_file.to_json unless primary_file.blank?
 
     unless etd.supplemental_files_fs.blank?
       new_data['supplemental_files'], new_data['supplemental_file_metadata'] = supplemental_files_for_refresh(etd)
@@ -192,7 +192,7 @@ class InProgressEtd < ApplicationRecord
       supp_files_metadata << file_metadata_for_refresh(supp_file)
     end
 
-    [supp_files, supp_files_metadata]
+    [supp_files.to_json, supp_files_metadata]
   end
 
   # Information about the file that the JavaScript needs for display and to render the 'Remove' button.

--- a/spec/models/in_progress_etd_spec.rb
+++ b/spec/models/in_progress_etd_spec.rb
@@ -642,8 +642,8 @@ RSpec.describe InProgressEtd do
         end
       end
 
-      it 'includes the file info in the JSON datastore' do
-        expect(refreshed_data['files']).to eq({
+      it 'includes the file info in the JSON datastore', :aggregate_failures do
+        expect(JSON.parse(refreshed_data['files'])).to eq({
           'id' => primary_pdf_fs.id,
           'name' => 'joey_thesis.pdf',
           'size' => primary_pdf_fs.file_size.first,
@@ -651,7 +651,7 @@ RSpec.describe InProgressEtd do
           'deleteType' => 'DELETE'
         })
 
-        expect(refreshed_data['supplemental_files']).to contain_exactly(
+        expect(JSON.parse(refreshed_data['supplemental_files'])).to contain_exactly(
           {
             'id' => supp_1_fs.id,
             'name' => 'nasa.jpeg',


### PR DESCRIPTION
**ISSUE**
Students and Approvers were unable to replace primary PDFs or supplemental files after recent updated.

**DIAGNOSIS**
There was a double layer of JSON encoding between the Rail and JS apps. On the Rails side, all encoding was removed, on the JS side, the primary and supplemental file decoding remained in place. So, we were trying to decode JSON instead of a string which caused the related code to fail.

This issue only occured when re-submitting changes because the system behaved correctly when there was no initial file content.

See the relevant JS lines
* https://github.com/curationexperts/laevigata/blob/v12.41.8/app/javascript/formStore.js#L502
* https://github.com/curationexperts/laevigata/blob/v12.41.8/app/javascript/formStore.js#L520

**RESOLUTION**
Since there is minimal testing in place (which allowed this bug to occur in the first place), we have chosen to re-add the encoding step on the Rails side (simpler), rather than remove the decoding logic from the JS side (more complex logic). We have tested the fix manually in development environments, but are not adding Jest or RSpec tests because of the complexity of the necessary setup.

**REFERENCE**
See feature documentation video at https://www.youtube.com/watch?v=eChBsM56U4g