### PR TITLE
Fix etd_report bug

### DIFF
--- a/lib/tasks/etd_report.rake
+++ b/lib/tasks/etd_report.rake
@@ -1,7 +1,7 @@
 require 'csv'
 namespace :emory do
   task etd_report: [:environment] do
-    headers = %w[id uid creator title school department degree submitting_type
+    headers = %w[id ppid uid creator title school department degree submitting_type
                  language subfield research_field keyword committee_chair committee_members
                  post_graduation_email degree_awarded graduation_date partnering_agency
                  date_created date_uploaded abstract]
@@ -20,7 +20,7 @@ namespace :emory do
               end
           end
           # handle the fields that aren't stored directly in the ETD record
-          row['uid'] = User.find_by(ppid: etd.depositor).uid
+          row['uid'] = User.find_by(ppid: etd.depositor)&.uid
           csv << row
         end
       end


### PR DESCRIPTION
**ISSUE**
The nightly ETD Report task was silently failing due to a user lookup error. When the user lookup using the PPID fails, the call to fetch the user's UID triggers an exception and causes the task to stop, truncating the report at that point.

**RESOLUTION**
Add code to gracefully handle user lookup failures. We have also added the PPID saved on the ETD in case we want to do additional diagnosis.